### PR TITLE
Add text_length to cf_draw_text

### DIFF
--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -641,9 +641,10 @@ CF_API float CF_CALL cf_text_height(const char* text);
  * @brief    Draws text.
  * @param    text      The text to draw.
  * @param    position  The top-left corner of the text.
+ * @param    text_length The length of the text to draw. Use -1 to draw until a null terminator.
  * @related  cf_make_font cf_draw_text cf_text_effect_register cf_draw_to cf_app_draw_onto_screen
  */
-CF_API void CF_CALL cf_draw_text(const char* text, CF_V2 position);
+CF_API void CF_CALL cf_draw_text(const char* text, CF_V2 position, int text_length /*= -1*/);
 
 /**
  * @struct   CF_TextEffect
@@ -1174,7 +1175,7 @@ CF_INLINE CF_Aabb pop_text_clip_box() { return cf_pop_text_clip_box(); }
 CF_INLINE CF_Aabb peek_text_clip_box() { return cf_peek_text_clip_box(); }
 CF_INLINE float text_width(const char* text) { return cf_text_width(text); }
 CF_INLINE float text_height(const char* text) { return cf_text_height(text); }
-CF_INLINE void draw_text(const char* text, CF_V2 position) { cf_draw_text(text, position); }
+CF_INLINE void draw_text(const char* text, CF_V2 position, int text_length = -1) { cf_draw_text(text, position, text_length); }
 
 struct TextEffect : public CF_TextEffect
 {

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1856,7 +1856,7 @@ static void s_parse_codes(CF_TextEffectState* effect, const char* text)
 	effect->sanitized = s->sanitized;
 }
 
-void cf_draw_text(const char* text, CF_V2 position)
+void cf_draw_text(const char* text, CF_V2 position, int text_length)
 {
 	CF_Font* font = cf_font_get(draw->fonts.last());
 	CF_ASSERT(font);
@@ -1962,7 +1962,12 @@ void cf_draw_text(const char* text, CF_V2 position)
 			y -= line_height;
 		}
 	};
-
+	
+	if(text_length < 0)
+	{
+		text_length = INT_MAX;	
+	}
+	
 	// Render the string glyph-by-glyph.
 	while (*text) {
 		cp_prev = cp;
@@ -2058,8 +2063,9 @@ void cf_draw_text(const char* text, CF_V2 position)
 			}
 		}
 
-		// Actually render the sprite.
-		if (visible) {
+		// Actually render the sprite. 
+		// Test text_length using <= because index is already incremented at the beginning of the function
+		if (visible && index <= text_length) {
 			s.geom.u.sprite.p0 = mul(draw->cam, V2(q0.x, q1.y));
 			s.geom.u.sprite.p1 = mul(draw->cam, V2(q1.x, q1.y));
 			s.geom.u.sprite.p2 = mul(draw->cam, V2(q1.x, q0.y));


### PR DESCRIPTION
Support drawing partial strings with cf_draw_text while not requiring the user to create temporary strings.