### PR TITLE
Fix the hget_ptr macro returning the wrong value

### DIFF
--- a/src/cute_hashtable.cpp
+++ b/src/cute_hashtable.cpp
@@ -287,8 +287,8 @@ int cf_hashtable_find_impl2(const CF_Hhdr* table, const void* key)
 		CF_MEMSET(table->hidden_item, 0, table->item_size);
 		return -1;
 	}
-	int index = table->slots[slot].item_index;
-	return index;
+	((CF_Hhdr*)table)->return_index = table->slots[slot].item_index;
+	return table->return_index;
 }
 
 int cf_hashtable_find_impl(const CF_Hhdr* table, uint64_t key)

--- a/src/cute_hashtable.cpp
+++ b/src/cute_hashtable.cpp
@@ -285,6 +285,8 @@ int cf_hashtable_find_impl2(const CF_Hhdr* table, const void* key)
 		// We will be "returning" a zero'd out item through `hget` with this
 		// hidden item.
 		CF_MEMSET(table->hidden_item, 0, table->item_size);
+
+		((CF_Hhdr *)table)->return_index = -1;
 		return -1;
 	}
 	((CF_Hhdr*)table)->return_index = table->slots[slot].item_index;

--- a/test/test_hashtable.cpp
+++ b/test/test_hashtable.cpp
@@ -58,6 +58,28 @@ TEST_CASE(test_hashtable_macros)
 	}
 	{
 		v2* h = NULL;
+		hset(h, 0, V2(1, 2));
+		hset(h, 1, V2(4, 10));
+		hset(h, 2, V2(-12, 13));
+		v2 *a = hget_ptr(h, 0);
+		v2 *b = hget_ptr(h, 1);
+		v2 *c = hget_ptr(h, 2);
+		REQUIRE(a->x == 1 && a->y == 2);
+		REQUIRE(b->x == 4 && b->y == 10);
+		REQUIRE(c->x == -12 && c->y == 13);
+		hdel(h, 0);
+		hdel(h, 1);
+		hdel(h, 2);
+		a = hget_ptr(h, 0);
+		b = hget_ptr(h, 1);
+		c = hget_ptr(h, 2);
+		REQUIRE(a == NULL);
+		REQUIRE(b == NULL);
+		REQUIRE(c == NULL);
+		hfree(h);
+	}
+	{
+		v2* h = NULL;
 		int iters = 100;
 		for (int i = 0; i < iters; ++i) {
 			v2 v = V2((float)i, (float)i);


### PR DESCRIPTION
Write the found index from `cf_hashtable_find_impl2` to `hhdr->return_index` so the `hget_ptr` macro can use it