### PR TITLE
cf_path_get_filename - support path string arguments with no "/" seperators

### DIFF
--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -34,8 +34,9 @@
 
 char* cf_path_get_filename(const char* path)
 {
+	if (!path || path[0] == '\0') { return NULL; }
+
 	int at = slast_index_of(path, '/');
-	if (at == -1) return NULL;
 	return smake(path + at + 1);
 }
 

--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -37,19 +37,35 @@ char* cf_path_get_filename(const char* path)
 	if (!path || path[0] == '\0') { return NULL; }
 
 	int at = slast_index_of(path, '/');
-	return smake(path + at + 1);
+
+	const char *f = path + at + 1;
+	if (f[0] != '\0') {
+		return smake(f);
+	}
+
+	// The last character was "/" so there was no filename
+	return NULL;
 }
 
 char* cf_path_get_filename_no_ext(const char* path)
 {
-	int at = slast_index_of(path, '.');
-	if (at == -1) return NULL;
-	char* s = (char*)cf_path_get_filename(path);
-	at = slast_index_of(s, '.');
-	if (at == -1 || at == 0) {
+	char* s = cf_path_get_filename(path);
+	
+	if (!s) { return NULL; }
+
+	int at = slast_index_of(s, '.');
+	if (at == 0) {
+		// The filename only has an extension
 		sfree(s);
 		return NULL;
 	}
+
+	if (at == -1) {
+		// The filename has no extension
+		return s;
+	}
+
+	// Remove the extension from the filename
 	serase(s, at, slen(s) - at);
 	return s;
 }

--- a/test/test_path.cpp
+++ b/test/test_path.cpp
@@ -36,10 +36,18 @@ TEST_CASE(test_path_c)
 	sfree(s);
 
 	s = spfname("file.txt");
+	REQUIRE(sequ(s, "file.txt"));
+	sfree(s);
+
+	s = spfname("/.txt");
+	REQUIRE(sequ(s, ".txt"));
+	sfree(s);
+
+	s = spfname("/root/");
 	REQUIRE(sequ(s, NULL));
 	sfree(s);
 
-	s = spfname(".txt");
+	s = spfname("/.root/");
 	REQUIRE(sequ(s, NULL));
 	sfree(s);
 
@@ -60,10 +68,18 @@ TEST_CASE(test_path_c)
 	sfree(s);
 
 	s = spfname_no_ext("file.txt");
-	REQUIRE(sequ(s, NULL));
+	REQUIRE(sequ(s, "file"));
 	sfree(s);
 
 	s = spfname_no_ext("/file");
+	REQUIRE(sequ(s, "file"));
+	sfree(s);
+
+	s = spfname_no_ext("/root/");
+	REQUIRE(sequ(s, NULL));
+	sfree(s);
+
+	s = spfname_no_ext("/.root/");
 	REQUIRE(sequ(s, NULL));
 	sfree(s);
 

--- a/test/test_path.cpp
+++ b/test/test_path.cpp
@@ -39,6 +39,10 @@ TEST_CASE(test_path_c)
 	REQUIRE(sequ(s, "file.txt"));
 	sfree(s);
 
+	s = spfname("file");
+	REQUIRE(sequ(s, "file"));
+	sfree(s);
+
 	s = spfname("/.txt");
 	REQUIRE(sequ(s, ".txt"));
 	sfree(s);


### PR DESCRIPTION
If a user passes in a path string to `cf_path_get_filename` that contains no "/" separators, assume that string is the filename. Return a copy of that string instead of `NULL`