### PR TITLE
Allow dots in normalized paths

### DIFF
--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -202,9 +202,9 @@ char* cf_path_normalize(const char* path)
 			}
 			prev_was_dot = true;
 		} else {
-            if (prev_was_dot) {
-                spush(result, '.');
-            }
+			if (prev_was_dot) {
+				spush(result, '.');
+			}
 			spush(result, c);
 			prev_was_dot = false;
 			prev_was_dotdot = false;

--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -202,6 +202,9 @@ char* cf_path_normalize(const char* path)
 			}
 			prev_was_dot = true;
 		} else {
+            if (prev_was_dot) {
+                spush(result, '.');
+            }
 			spush(result, c);
 			prev_was_dot = false;
 			prev_was_dotdot = false;

--- a/test/test_path.cpp
+++ b/test/test_path.cpp
@@ -199,6 +199,10 @@ TEST_CASE(test_path_c)
 	REQUIRE(sequ(s, "/"));
 	sfree(s);
 
+    s = spnorm("/first.last/.hidden");
+    REQUIRE(sequ(s, "/first.last/.hidden"));
+    sfree(s);
+
 	return true;
 }
 

--- a/test/test_path.cpp
+++ b/test/test_path.cpp
@@ -199,9 +199,9 @@ TEST_CASE(test_path_c)
 	REQUIRE(sequ(s, "/"));
 	sfree(s);
 
-    s = spnorm("/first.last/.hidden");
-    REQUIRE(sequ(s, "/first.last/.hidden"));
-    sfree(s);
+	s = spnorm("/first.last/.hidden");
+	REQUIRE(sequ(s, "/first.last/.hidden"));
+	sfree(s);
 
 	return true;
 }


### PR DESCRIPTION
I just did the bare minimum to support the use-case. Sorry about the extra commit... CLion didn't realize the file was tabs for some reason.