### PR TITLE
Add cf_easy_sprite_unload

### DIFF
--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -199,7 +199,7 @@ CF_INLINE CF_Sprite cf_sprite_defaults()
  *           as it's only a single-frame made from a png file.
  * @remarks  The preferred way to make a sprite is `cf_make_sprite`, but this function provides a very simple way to get started
  *           by merely loading a single .png image, or for games that don't require animations. See [Virtual File System](https://randygaul.github.io/cute_framework/#/topics/virtual_file_system).
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
+ * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
  */
 CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_png(const char* png_path, CF_Result* result_out);
 
@@ -207,7 +207,7 @@ CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_png(const char* png_path, CF_R
  * @function cf_make_easy_sprite_from_pixels
  * @category sprite
  * @brief    TODO
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
+ * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
  */
 CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_pixels(const CF_Pixel* pixels, int w, int h);
 
@@ -215,7 +215,7 @@ CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_pixels(const CF_Pixel* pixels,
  * @function cf_easy_sprite_update_pixels
  * @category sprite
  * @brief    TODO
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
+ * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
  */
 CF_API void CF_CALL cf_easy_sprite_update_pixels(CF_Sprite* sprite, const CF_Pixel* pixels);
 
@@ -265,6 +265,15 @@ CF_API CF_Sprite CF_CALL cf_make_demo_sprite();
  * @related  CF_Sprite cf_make_sprite cf_sprite_unload
  */
 CF_API void CF_CALL cf_sprite_unload(const char* aseprite_path);
+
+/**
+ * @function cf_easy_sprite_unload
+ * @category sprite
+ * @brief    Unloads an easy sprite's image resources.
+ * @param    sprite The `CF_Sprite` to unload. This `CF_Sprite` should have been created by a `cf_make_easy_sprite_*` function.
+ * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
+ */
+CF_API void CF_CALL cf_easy_sprite_unload(CF_Sprite *sprite);
 
 //--------------------------------------------------------------------------------------------------
 // In-line implementation of `CF_Sprite` functions.

--- a/src/cute_sprite.cpp
+++ b/src/cute_sprite.cpp
@@ -107,3 +107,12 @@ void cf_sprite_unload(const char* aseprite_path)
 {
 	cf_aseprite_cache_unload(aseprite_path);
 }
+
+void cf_easy_sprite_unload(CF_Sprite *sprite)
+{
+	CF_Image* img = app->easy_sprites.try_find(sprite->easy_sprite_id);
+	if (img) {
+		app->easy_sprites.remove(sprite->easy_sprite_id);
+		cf_image_free(img);
+	}
+}

--- a/test/test_sprite.cpp
+++ b/test/test_sprite.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "test_harness.h"
+#include "internal/cute_app_internal.h"
 
 #include <cute.h>
 using namespace Cute;
@@ -36,7 +37,30 @@ TEST_CASE(test_make_sprite)
 	return true;
 }
 
+TEST_CASE(test_easy_sprite_unload)
+{
+	CHECK(cf_is_error(cf_make_app(NULL, 0, 0, 0, 0, APP_OPTIONS_HIDDEN | APP_OPTIONS_NO_AUDIO | APP_OPTIONS_NO_GFX, NULL)));
+
+	CF_Pixel r, g, b;
+	r.val = 0xFF0000FF;
+	g.val = 0x00FF00FF;
+	b.val = 0x0000FFFF;
+
+	CF_Pixel pixels[3] = { r, g, b };
+
+	CF_Sprite s = cf_make_easy_sprite_from_pixels(pixels, 3, 1);
+	REQUIRE(s.easy_sprite_id);
+	REQUIRE(app->easy_sprites.count() == 1);
+
+	cf_easy_sprite_unload(&s);
+	REQUIRE(app->easy_sprites.count() == 0);
+
+	cf_destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_sprite)
 {
 	RUN_TEST_CASE(test_make_sprite);
+	RUN_TEST_CASE(test_easy_sprite_unload);
 }


### PR DESCRIPTION
I'm loading sprites from a png while trying to integrate with cute_tiled, and wanted to be able to easily unload the sprites when I switch levels.