### PR TITLE
Return the same camera dimensions that were passed in

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2328,7 +2328,7 @@ CF_V2 cf_camera_peek_position()
 
 CF_V2 cf_camera_peek_dimensions()
 {
-	return draw->cam_dimensions;
+	return draw->cam_dimensions * 2.0f;
 }
 
 float cf_camera_peek_rotation()


### PR DESCRIPTION
`cf_camera_dimensions` appears to divide the passed in width and height by 2. This PR just makes it so that when we peek at the dimensions, we get the same thing we passed in.

```c++
cf_camera_dimensions(320, 180);
v2 dim = cf_camera_peek_dimensions();
ImGui::Text("%f, %f", dim.x, dim.y); // displays 160, 90
```