### PR TITLE
Ensure that font is always pushed in scratch example

### DIFF
--- a/samples/scratch.cpp
+++ b/samples/scratch.cpp
@@ -36,6 +36,7 @@ int main(int argc, char* argv[])
 
 	while (app_is_running()) {
 		app_update();
+		push_font("Calibri");
 
 		if (fps == 0) {
 			fps = 1.0f / CF_DELTA_TIME;


### PR DESCRIPTION
Since the stacks of states always get reset every frame, the scratch example will crash if it only push the font once.