### PR TITLE
Fix CF_Pixel conversion functions

### DIFF
--- a/include/cute_color.h
+++ b/include/cute_color.h
@@ -574,7 +574,7 @@ CF_INLINE CF_Pixel cf_pixel_premultiply(CF_Pixel c) { c.colors.r = cf_mul_un8(c.
  * @return   Returns a `CF_Color` (0.0f-1.0f) converted from pixel form (0-255).
  * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
  */
-CF_INLINE CF_Color cf_pixel_to_color(CF_Pixel p) { return cf_make_color_hex2((int)p.val & 0xFFFFFF, ((int)p.val & 0xFF000000) >> 24); }
+CF_INLINE CF_Color cf_pixel_to_color(CF_Pixel p) { return cf_make_color_rgba(p.colors.r, p.colors.g, p.colors.b, p.colors.a); }
 
 /**
  * @function cf_pixel_to_int_rgb
@@ -585,7 +585,7 @@ CF_INLINE CF_Color cf_pixel_to_color(CF_Pixel p) { return cf_make_color_hex2((in
  *           the green component, the third byte is the blue component, the fourth byte is 0xFF or full-alpha.
  * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
  */
-CF_INLINE uint32_t cf_pixel_to_int_rgb(CF_Pixel p) { return p.val | 0x000000FF; }
+CF_INLINE uint32_t cf_pixel_to_int_rgb(CF_Pixel p) { return p.val | 0xFF000000; }
 
 /**
  * @function cf_pixel_to_int_rgba
@@ -626,7 +626,7 @@ CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c) { CF_Pixel p; p.colors.r = (int
  *           the green component, the third byte is the blue component, the fourth byte is 0xFF or full-alpha.
  * @related  cf_color_to_pixel cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
  */
-CF_INLINE uint32_t cf_color_to_int_rgb(CF_Color c) { return cf_color_to_pixel(c).val | 0x000000FF; }
+CF_INLINE uint32_t cf_color_to_int_rgb(CF_Color c) { return cf_color_to_pixel(c).val | 0xFF000000; }
 
 /**
  * @function cf_color_to_int_rgba
@@ -918,13 +918,13 @@ CF_INLINE bool operator!=(Pixel a, Pixel b) { return a.val != b.val; }
 CF_INLINE Pixel lerp(Pixel a, Pixel b, uint8_t s) { return cf_pixel_lerp(a, b, s); }
 CF_INLINE Pixel premultiply(Pixel p) { return cf_pixel_premultiply(p); }
 
-CF_INLINE Color to_color(Pixel p) { return cf_make_color_hex((int)p.val); }
+CF_INLINE Color to_color(Pixel p) { return cf_make_color_rgba(p.colors.r, p.colors.g, p.colors.b, p.colors.a); }
 CF_INLINE uint32_t to_int_rgba(Pixel p) { return p.val; }
-CF_INLINE uint32_t to_int_rgb(Pixel p) { return p.val | 0x000000FF; }
+CF_INLINE uint32_t to_int_rgb(Pixel p) { return p.val | 0xFF000000; }
 CF_INLINE String to_string(Pixel p) { char* s = NULL; return shex(s, p.val); }
 
 CF_INLINE Pixel to_pixel(Color c) { return cf_color_to_pixel(c); }
-CF_INLINE uint32_t to_int_rgb(Color c) { return cf_color_to_pixel(c).val | 0x000000FF; }
+CF_INLINE uint32_t to_int_rgb(Color c) { return cf_color_to_pixel(c).val | 0xFF000000; }
 CF_INLINE uint32_t to_int_rgba(Color c) { return cf_color_to_pixel(c).val; }
 CF_INLINE String to_string(Color c) { char* s = NULL; return shex(s, cf_color_to_pixel(c).val); }
 


### PR DESCRIPTION
CF_Pixel conversion functions that used bitwise operations were assuming an `rgba` byte order, but the correct byte order is `abgr`