### PR TITLE
uninitialized duplicates

### DIFF
--- a/libraries/cute/cute_sound.h
+++ b/libraries/cute/cute_sound.h
@@ -1784,7 +1784,9 @@ cs_error_t cs_init(void* os_handle, unsigned play_frequency_in_Hz, int buffered_
 	s_ctx->mutex = SDL_CreateMutex();
 
 #endif
-
+	s_ctx->duplicate_capacity = 0;
+	s_ctx->duplicate_count = 0;
+	s_ctx->duplicates = NULL;
 	return CUTE_SOUND_ERROR_NONE;
 }
 


### PR DESCRIPTION
uninitialized duplicates won't allocate an array when playing first sound and can cause a crash. 
not sure if this should have allocation for duplicates be done in cs_init() or on first playing first sound since there's an option to disable cull_duplicates.