### PR TITLE
moving spritebatch_defrag() to cleanup phase

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -418,7 +418,6 @@ int cf_app_draw_onto_screen(bool clear)
 	// This does atlas management internally.
 	// All references to backend texture id's are now invalid (fetch_image or canvas_get_backend_target_handle).
 	spritebatch_tick(&draw->sb);
-	spritebatch_defrag(&draw->sb);
 
 	// Render any remaining geometry in the draw API.
 	cf_render_to(app->offscreen_canvas, clear);
@@ -446,6 +445,8 @@ int cf_app_draw_onto_screen(bool clear)
 	if (app->options & APP_OPTIONS_OPENGL_CONTEXT) {
 		SDL_GL_SwapWindow(app->window);
 	}
+
+	spritebatch_defrag(&draw->sb);
 
 	// Clear all pushed draw parameters.
 	draw->colors.set_count(1);


### PR DESCRIPTION
when using CF_TemporaryImage with cf_fetch_image(), spritebatch_defrag() will thrash the atlas texture before imgui gets to use it causing sokol to give you a bunch of errors