### PR TITLE
Use scalar mode on ARM Linux

### DIFF
--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -22,6 +22,9 @@
 #	define CF_WINDOWS 1
 #elif defined(__linux__) || defined(__unix__) && !defined(__APPLE__) && !defined(__EMSCRIPTEN__)
 #	define CF_LINUX 1
+#       if !defined(__SSE__)
+#               define CUTE_SOUND_SCALAR_MODE
+#       endif
 #elif defined(__APPLE__)
 #	define CF_APPLE 1
 #	include <TargetConditionals.h>


### PR DESCRIPTION
When the current architecture lacks SSE instructions, force the sound module's mode to scalar.

This allows for a successful build on eg. ARM64 Ubuntu 22.04.

Fixes #167