### PR TITLE
fix: implied return and NULL cast to uint64_t

### DIFF
--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -1620,8 +1620,8 @@ typedef bool (text_markup_info_fn)(const char* text, MarkupInfo info, const Text
 
 CF_INLINE void text_get_markup_info(text_markup_info_fn* fn, const char* text, v2 position, int num_chars_to_draw = -1) { cf_text_get_markup_info((cf_text_markup_info_fn*)fn, text, position, num_chars_to_draw); }
 CF_INLINE void push_text_effect_active(bool effects_on) { cf_push_text_effect_active(effects_on); }
-CF_INLINE bool pop_text_effect_active() { cf_pop_text_effect_active(); }
-CF_INLINE bool peek_text_effect_active() { cf_peek_text_effect_active(); }
+CF_INLINE bool pop_text_effect_active() { return cf_pop_text_effect_active(); }
+CF_INLINE bool peek_text_effect_active() { return cf_peek_text_effect_active(); }
 
 CF_INLINE void render_settings_filter(Filter filter) { cf_render_settings_filter(filter); }
 CF_INLINE void render_settings_push_viewport(Rect viewport) { cf_render_settings_push_viewport(viewport); }

--- a/src/cute_audio.cpp
+++ b/src/cute_audio.cpp
@@ -33,9 +33,8 @@ CF_Audio cf_audio_load_ogg(const char* path)
 		CF_Audio src = cf_audio_load_ogg_from_memory(data, (int)size);
 		CF_FREE(data);
 		return src;
-	} else {
-		return { NULL };
 	}
+	return { 0 };
 }
 
 CF_Audio cf_audio_load_wav(const char* path)
@@ -46,9 +45,8 @@ CF_Audio cf_audio_load_wav(const char* path)
 		auto src = cf_audio_load_wav_from_memory(data, (int)size);
 		CF_FREE(data);
 		return (CF_Audio)src;
-	} else {
-		return { NULL };
 	}
+	return { 0 };
 }
 
 CF_Audio cf_audio_load_ogg_from_memory(void* memory, int byte_count)


### PR DESCRIPTION
- The wrapper functions in `cute_draw.h` are meant to return bool type, however the return values of internal `cf_*` functions which are called aren't stored or returned, thus making these functions return nothing. Easily fixed by calling the internal functions within the wrapper and returning the returned values.

- In `cute_audio.cpp`, a NULL was returned previously. Due to `CF_Audio` having just one field in the struct for the data, that would mean the NULL would be cast to uint64_t. This means that comparing the return value from `cf_audio_load_*` functions to NULL would not yield any actual results in some scenarios, as the value would be cast to `uint64_t`, resulting in undefined behavior. Solution is simple, just return an empty `CF_Audio` struct. Then, if needed, the return value can simply be compared to 0, which would imply that either the `CF_Audio` wasn't yet populated, OR there was an error trying to load audio. (NOTE: Asserts can also be used here to indicate what is PRECISELY the case.)