### PR TITLE
first set of handles allocated returns an uninitialized handle

### DIFF
--- a/src/cute_handle_table.cpp
+++ b/src/cute_handle_table.cpp
@@ -83,7 +83,7 @@ CF_Handle cf_handle_allocator_alloc(CF_HandleTable* table, uint32_t index, uint1
 		int first_index = table->m_handles.capacity();
 		if (!first_index) first_index = 1;
 		table->m_handles.ensure_count(first_index * 2);
-		int last_index = table->m_handles.capacity() - 1;
+		int last_index = table->m_handles.count() - 1;
 		s_add_elements_to_freelist(table, first_index, last_index);
 		freelist_index = table->m_freelist;
 	}


### PR DESCRIPTION
When you start to create handles the `first_index` being 1 will cause you to go from `m_count 0 => 2` and `m_capacity 0 => 8`,
`last_index` will get an bad handle on the very first set of handles, all handles afterwards seems to be fine.

second and later allocation times this grows it'll be `m_count 2 => 16` and `m_capacity 8 => 16` and won't cause any invalid handles