### PR TITLE
Use correct directory when copying sample data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ set(CF_SRCS
 	src/internal/yyjson.c
 
 	libraries/cimgui/imgui/backends/imgui_impl_sdl.cpp
-	
+
 	libraries/cimgui/imgui/imgui.cpp
 	libraries/cimgui/imgui/imgui_demo.cpp
 	libraries/cimgui/imgui/imgui_draw.cpp
@@ -452,9 +452,9 @@ if (CF_FRAMEWORK_BUILD_SAMPLES)
 	endforeach()
 
 	# Copy over some folders for certain samples.
-	add_custom_command(TARGET spaceshooter PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/samples/spaceshooter_data $<TARGET_FILE_DIR:spaceshooter>/spaceshooter_data)
-	add_custom_command(TARGET waves PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/samples/waves_data $<TARGET_FILE_DIR:waves>/waves_data)
-	add_custom_command(TARGET shallow_water PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/samples/shallow_water_data $<TARGET_FILE_DIR:shallow_water>/shallow_water_data)
+	add_custom_command(TARGET spaceshooter PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/samples/spaceshooter_data $<TARGET_FILE_DIR:spaceshooter>/spaceshooter_data)
+	add_custom_command(TARGET waves PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/samples/waves_data $<TARGET_FILE_DIR:waves>/waves_data)
+	add_custom_command(TARGET shallow_water PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/samples/shallow_water_data $<TARGET_FILE_DIR:shallow_water>/shallow_water_data)
 endif()
 
 # Propogate public headers to other cmake scripts including this subdirectory.


### PR DESCRIPTION
This commit updates the CMakeLists.txt file to use the correct directory when copying over the sample data when building from source directory.

Previously, the sample data was copied from the top-level CMake working dir, which wouldn't work when the samples were being built from a project including CF.

With this change, the sample data should be copied over from the CF working directory, which should work in all cases.