### PR TITLE
Explicitly cast returned pointer in cute_symbol to void*

### DIFF
--- a/src/cute_symbol.cpp
+++ b/src/cute_symbol.cpp
@@ -21,5 +21,5 @@ void cf_unload_shared_library(CF_SharedLibrary* library)
 
 void* cf_load_function(CF_SharedLibrary* library, const char* function_name)
 {
-	return SDL_LoadFunction(library, function_name);
+	return (void*)SDL_LoadFunction(library, function_name);
 }


### PR DESCRIPTION
This fixes a compile error on gcc without `-fpermissive`.