### PR TITLE
Remove extra tokens

### DIFF
--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -1061,7 +1061,7 @@ void cf_unload_shader_compiler()
 {
 #ifdef CF_RUNTIME_SHADER_COMPIILATION
 	glslang::FinalizeProcess();
-#endif CF_RUNTIME_SHADER_COMPIILATION
+#endif
 }
 
 // Create a user shader by injecting their `shader` function into CF's draw shader.


### PR DESCRIPTION
Resolves this warning:

```
build/_deps/cute-src/src/cute_graphics.cpp:1064:8: warning: extra tokens at end of #endif directive [-Wextra-tokens]
#endif CF_RUNTIME_SHADER_COMPIILATION
```