### PR TITLE
Build in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build CF
 # This workflow will work for pushes, pull requests, or a manual trigger (workflow_dispatch).
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 6
+
 jobs:
   build:
     # Matrix feature for cross-platform coverage. Names the build "Build X"


### PR DESCRIPTION
GitHub Actions are run on machines with 4 cores. This change sets the parallel level to number of cores + 2. It cut down the time for the Linux build from 17 minutes to 7 minutes.

This can also be configured as an argument to `cmake` using `--parallel 6`.