### PR TITLE
Init video subsystem

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -45,6 +45,7 @@ static void s_init_video()
 
 CF_DisplayID cf_default_display()
 {
+	s_init_video();
 	return { SDL_GetPrimaryDisplay() };
 }
 

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -72,7 +72,6 @@ void cf_free_display_list(CF_DisplayID* display_list)
 
 int cf_display_x(CF_DisplayID display_id)
 {
-	SDL_GetPrimaryDisplay();
 	s_init_video();
 	SDL_Rect rect;
 	SDL_GetDisplayBounds(display_id, &rect);

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -39,8 +39,7 @@ static void s_init_video()
 {
 	static bool init = false;
 	if (init) return;
-	init = true;
-	SDL_Init(SDL_INIT_VIDEO);
+	init = SDL_Init(SDL_INIT_VIDEO);
 }
 
 CF_DisplayID cf_default_display()


### PR DESCRIPTION
In order to use `cf_default_display` we need to first initalize the video subsystem.

I've also added https://github.com/RandyGaul/cute_framework/commit/9ae12223e8f73337b027f59c4e3b7a1b6acd8972, but I'm happy to remove it if that's not something we want to do.