### PR TITLE
Allow configuring whether to build an Apple framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir -p ./dist
           cp -v ./include/*.h ./dist
-          cp -R -v ./build_folder/cute.framework ./dist
+          cp -R -v ./build_folder/libcute.a ./dist
           tar -czvf ${{ matrix.platform.artifact }}.tar.gz -C dist .
         if: runner.os == 'macOS'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(CF_FRAMEWORK_STATIC "Build static library for Cute Framework." ON)
 option(CF_GLSLANG "Build CF with online shader compilation support." ON)
 option(CF_GLSLANG_OPTIMIZER "Build CF with online shader compilation + optmization support (requires python 3.x installation)." ON)
+option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
 
 # Platform detection.
 if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
@@ -414,17 +415,19 @@ elseif(WINDOWS)
 elseif(LINUX)
 	target_compile_options(cute PRIVATE -msse4.1)
 elseif(APPLE)
-	set_target_properties(cute PROPERTIES FRAMEWORK TRUE)
-	if (CF_FRAMEWORK_STATIC)
-	set_target_properties(cute PROPERTIES
-		FRAMEWORK_VERSION "1.0.0"
-		MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.static"
-	)
-	else()
-	set_target_properties(cute PROPERTIES
-		FRAMEWORK_VERSION "1.0.0"
-		MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.shared"
-	)
+	if(CF_FRAMEWORK_APPLE_FRAMEWORK)
+		set_target_properties(cute PROPERTIES FRAMEWORK TRUE)
+		if (CF_FRAMEWORK_STATIC)
+		set_target_properties(cute PROPERTIES
+			FRAMEWORK_VERSION "1.0.0"
+			MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.static"
+		)
+		else()
+		set_target_properties(cute PROPERTIES
+			FRAMEWORK_VERSION "1.0.0"
+			MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.shared"
+		)
+		endif()
 	endif()
 endif()
 


### PR DESCRIPTION
This PR allows the user to specify `CF_FRAMEWORK_APPLE_FRAMEWORK=ON` to force generation of an `cute.framework` Apple framework.

Closes https://github.com/RandyGaul/cute_framework/issues/203