### PR TITLE
Do a non-shallow clone of SDL3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ else()
 		GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
 		GIT_TAG 88a01fbc964fbea1203071ea3ca2c6f799d4f571
 		CMAKE_ARGS -DSDL_SHARED=OFF -DSDL_STATIC=ON -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF -DSDL_EXAMPLES=OFF
-		GIT_SHALLOW TRUE
+		GIT_SHALLOW FALSE  # Cannot be shallow until SDL has tag
 		GIT_PROGRESS TRUE
 	)
 	FetchContent_MakeAvailable(SDL3)


### PR DESCRIPTION
This fixes the current failed build in CI.

However, CI time significantly increases due to non-shallow clone.

The alternative is that you can fork SDL3 and only update it with upstream when needed.