### PR TITLE
Fix scissor and viewport application order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 		add_executable(stencil_pie_chart samples/stencil_pie_chart.c)
 		add_executable(platformer samples/platformer.cpp)
 		add_executable(polygon samples/polygon.cpp)
+		add_executable(scissor samples/scissor.c)
 		set(SAMPLE_EXECUTABLES
 			easysprite
 			basicserialization
@@ -513,6 +514,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			stencil_pie_chart
 			platformer
 			polygon
+			scissor
 		)
 
 		foreach(CURRENT_TARGET ${SAMPLE_EXECUTABLES})

--- a/samples/scissor.c
+++ b/samples/scissor.c
@@ -1,0 +1,26 @@
+#include <cute.h>
+
+int main(int argc, char* argv[])
+{
+	int w = 640;
+	int h = 480;
+	cf_make_app("Scissor", 0, 0, 0, w, h, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
+
+	while (cf_app_is_running()) {
+		cf_app_update(NULL);
+		cf_render_settings_push_scissor((CF_Rect){
+			.x = 0,
+			.y = 0,
+			.w = 320,
+			.h = 240
+		});
+
+		cf_draw_circle((CF_Circle){ .p = { 0, 0 }, .r = 100.0f}, 10.0f);
+
+		cf_app_draw_onto_screen(true);
+	}
+
+	cf_destroy_app();
+
+	return 0;
+}

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -378,18 +378,6 @@ static void s_draw_report(spritebatch_sprite_t* sprites, int count, int texture_
 		draw->vertex_fn(verts, vert_count);
 	}
 
-	// Apply viewport.
-	Rect viewport = draw->viewports.last();
-	if (viewport.w >= 0 && viewport.h >= 0) {
-		cf_apply_viewport(viewport.x, viewport.y, viewport.w, viewport.h);
-	}
-
-	// Apply scissor.
-	Rect scissor = draw->scissors.last();
-	if (scissor.w >= 0 && scissor.h >= 0) {
-		cf_apply_scissor(scissor.x, scissor.y, scissor.w, scissor.h);
-	}
-
 	// Map the vertex buffer with sprite vertex data.
 	cf_mesh_update_vertex_data(draw->mesh, verts, vert_count);
 	cf_apply_mesh(draw->mesh);
@@ -408,8 +396,22 @@ static void s_draw_report(spritebatch_sprite_t* sprites, int count, int texture_
 	// Apply render state.
 	cf_material_set_render_state(draw->material, draw->render_states.last());
 
-	// Kick off a draw call.
+	// Apply shader.
 	cf_apply_shader(draw->shaders.last(), draw->material);
+
+	// Apply viewport.
+	Rect viewport = draw->viewports.last();
+	if (viewport.w >= 0 && viewport.h >= 0) {
+		cf_apply_viewport(viewport.x, viewport.y, viewport.w, viewport.h);
+	}
+
+	// Apply scissor.
+	Rect scissor = draw->scissors.last();
+	if (scissor.w >= 0 && scissor.h >= 0) {
+		cf_apply_scissor(scissor.x, scissor.y, scissor.w, scissor.h);
+	}
+
+	// Kick off a draw call.
 	cf_draw_elements();
 	cf_commit();
 


### PR DESCRIPTION
`cf_apply_shader` creates a `SDL_GPURenderPass` so viewport and scissor state have to be applied after that.