### PR TITLE
Fix string manipulation functions

### DIFF
--- a/src/cute_string.cpp
+++ b/src/cute_string.cpp
@@ -346,7 +346,7 @@ char* cf_sreplace(char* s, const char* replace_me, const char* with_me)
 	while ((find = sfind(search, replace_me))) {
 		int find_offset = (int)(find - s);
 		if (replace_len > with_len) {
-			int remaining = scount(s) - find_offset - (int)with_len;
+			int remaining = scount(s) - find_offset - (int)replace_len;
 			int diff = (int)(replace_len - with_len);
 			CF_MEMCPY(find, with_me, with_len);
 			CF_MEMMOVE(find + with_len, find + replace_len, remaining);
@@ -404,7 +404,7 @@ char* cf_serase(char* s, int index, int count)
 		s[index] = 0;
 		return s;
 	} else {
-		int remaining = scount(s) - (count + index) + 1;
+		int remaining = scount(s) - (count + index);
 		CF_MEMMOVE(s + index, s + count + index, remaining);
 		alen(s) -= count;
 	}


### PR DESCRIPTION
I was running my program through AddressSanitizer and these show up:

* cf_serase: `scount` already includes the null terminator so +1 is redundant.
* cf_sreplace: `remaining` is wrongly calculated based on `with_len` instead of `replace_len`. We want to overwrite the replaced substring with what follows after it so `replace_len` should be used in all cases.

The current code works in most cases since a new page is zero filled and accessing out of bound will just return 0.
But it will break if the string lies near the border of a page or the allocator recycle some memory chunks.