### PR TITLE
Bump shadercross

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -254,7 +254,10 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		} else if (use_vulkan) {
 			device_name = "vulkan";
 		}
-		device = SDL_CreateGPUDevice(SDL_ShaderCross_GetShaderFormats(), options & APP_OPTIONS_GFX_DEBUG_BIT, device_name);
+		if(!SDL_ShaderCross_Init()) {
+			return cf_result_error("Failed to initialize SDL_ShaderCross.");
+		}
+		device = SDL_CreateGPUDevice(SDL_ShaderCross_GetSPIRVShaderFormats(), options & APP_OPTIONS_GFX_DEBUG_BIT, device_name);
 		if (!device) {
 			return cf_result_error("Failed to create GPU Device.");
 		}


### PR DESCRIPTION
This PR updates the shadercross dependency to incorporate all the newest changes.

What I'm not sure about, is after https://github.com/flibitijibibo/SDL_gpu_shadercross/commit/c776f225aca7add078874516694b898ec96146ac#diff-85d451ecdc5be12bf18bd38506d3f9ea7746cd7b8ea990b9faccf05e854746e1R22, do we need to use the `SDL_ShaderCross_GetHLSLShaderFormats()`?