### PR TITLE
Fix memory error when unloading easy sprite

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -85,11 +85,19 @@ void cf_get_pixels(SPRITEBATCH_U64 image_id, void* buffer, int bytes_to_fill, vo
 	} else if (image_id >= CF_PNG_ID_RANGE_LO && image_id <= CF_PNG_ID_RANGE_HI) {
 		cf_png_cache_get_pixels(image_id, buffer, bytes_to_fill);
 	} else if (image_id >= CF_FONT_ID_RANGE_LO && image_id <= CF_FONT_ID_RANGE_HI) {
-		CF_Pixel* pixels = app->font_pixels.get(image_id);
-		CF_MEMCPY(buffer, pixels, bytes_to_fill);
+		CF_Pixel** pixels = app->font_pixels.try_get(image_id);
+		if (pixels) {
+			CF_MEMCPY(buffer, *pixels, bytes_to_fill);
+		} else {
+			CF_MEMSET(buffer, 0, bytes_to_fill);
+		}
 	} else if (image_id >= CF_EASY_ID_RANGE_LO && image_id <= CF_EASY_ID_RANGE_HI) {
-		CF_Pixel* pixels = app->easy_sprites.get(image_id).pix;
-		CF_MEMCPY(buffer, pixels, bytes_to_fill);
+		CF_Image* img = app->easy_sprites.try_get(image_id);
+		if (img) {
+			CF_MEMCPY(buffer, img->pix, bytes_to_fill);
+		} else {
+			CF_MEMSET(buffer, 0, bytes_to_fill);
+		}
 	} else if (image_id >= CF_PREMADE_ID_RANGE_LO && image_id <= CF_PREMADE_ID_RANGE_HI) {
 		// These are handled externally by the user, so spritebatch should never ask for pixels.
 		// It's assumed premade atlases are generated properly externally.

--- a/src/cute_sprite.cpp
+++ b/src/cute_sprite.cpp
@@ -105,7 +105,7 @@ void cf_easy_sprite_unload(CF_Sprite *sprite)
 {
 	CF_Image* img = app->easy_sprites.try_find(sprite->easy_sprite_id);
 	if (img) {
-		app->easy_sprites.remove(sprite->easy_sprite_id);
 		cf_image_free(img);
+		app->easy_sprites.remove(sprite->easy_sprite_id);
 	}
 }


### PR DESCRIPTION
* cf_easy_sprite_unload: This should free the image before removing the sprite entry. Otherwise, the image pointer would be invalidated.
* cf_get_pixels: Guard against invalid id when handling font and easy sprite. This is because after a resource is unloaded, its id still lingers in the batcher for a while.