### PR TITLE
Improve IME and text input support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 		add_executable(platformer samples/platformer.cpp)
 		add_executable(polygon samples/polygon.cpp)
 		add_executable(scissor samples/scissor.c)
+		add_executable(ime samples/ime.c)
 		set(SAMPLE_EXECUTABLES
 			easysprite
 			basicserialization
@@ -521,6 +522,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			platformer
 			polygon
 			scissor
+			ime
 		)
 
 		foreach(CURRENT_TARGET ${SAMPLE_EXECUTABLES})

--- a/include/cute_input.h
+++ b/include/cute_input.h
@@ -745,6 +745,22 @@ CF_API bool CF_CALL cf_mouse_hidden();
 CF_API void CF_CALL cf_mouse_lock_inside_window(bool true_to_lock);
 
 /**
+ * @struct   CF_InputTextBuffer
+ * @category input
+ * @brief    Represents the application's input text buffer.
+ * @related  cf_input_enable_ime cf_input_disable_ime cf_input_text_get_buffer cf_input_text_clear
+ */
+typedef struct CF_InputTextBuffer
+{
+	/* @member The length of the buffer. */
+	int len;
+
+	/* @member The buffer's data which is a sequence of utf32 codepoints. */
+	const int* codepoints;
+} CF_InputTextBuffer;
+// @end
+
+/**
  * @function cf_input_text_add_utf8
  * @category input
  * @brief    Adds a utf8 codepoint to the input buffer of the application.
@@ -773,6 +789,17 @@ CF_API int CF_CALL cf_input_text_pop_utf32();
  * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
  */
 CF_API bool CF_CALL cf_input_text_has_data();
+
+/**
+ * @function cf_input_text_get_buffer
+ * @category input
+ * @brief    Returns the content of the text input buffer.
+ * @return   Returns true if the input buffer of the application has any text within.
+ * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
+ *           multiple keystrokes, especially when dealing with non-Latin based inputs.
+ * @related  cf_input_enable_ime cf_input_disable_ime cf_input_text_clear
+ */
+CF_API bool CF_CALL cf_input_text_get_buffer(CF_InputTextBuffer* buffer);
 
 /**
  * @function cf_input_text_clear
@@ -970,6 +997,7 @@ CF_INLINE const char* to_string(MouseButton button)
 }
 
 using ImeComposition = CF_ImeComposition;
+using InputTextBuffer = CF_InputTextBuffer;
 using Touch = CF_Touch;
 
 CF_INLINE bool key_down(KeyButton key) { return cf_key_down(key); }
@@ -999,6 +1027,7 @@ CF_INLINE void mouse_lock_inside_window(bool true_to_lock) { cf_mouse_lock_insid
 CF_INLINE void input_text_add_utf8(const char* text) { cf_input_text_add_utf8(text); }
 CF_INLINE int input_text_pop_utf32() { return cf_input_text_pop_utf32(); }
 CF_INLINE bool input_text_has_data() { return cf_input_text_has_data(); }
+CF_INLINE bool input_text_get_buffer(CF_InputTextBuffer* buffer) { return cf_input_text_get_buffer(buffer); }
 CF_INLINE void input_text_clear() {  cf_input_text_clear(); }
 	 
 CF_INLINE void input_enable_ime() { cf_input_enable_ime(); }

--- a/samples/ime.c
+++ b/samples/ime.c
@@ -1,0 +1,154 @@
+#include <cute.h>
+#include <SDL3/SDL_hints.h>
+
+// A structure with 2 text representations
+typedef struct TextBoxData {
+	// utf32 codepoint array for editting.
+	dyna int* utf32;
+	// null-terminated utf8 string for rendering.
+	// TODO: This gets decoded back into utf32 anyway which is inefficient.
+	char* utf8;
+} TextBoxData;
+
+static inline int utf8_bytes_required(int codepoint) {
+	if (codepoint <= 0x7F) {
+		return 1;
+	} else if (codepoint <= 0x7FF) {
+		return 2;
+	} else if (codepoint <= 0xFFFF) {
+		return 3;
+	} else if (codepoint <= 0x10FFFF) {
+		return 4;
+	} else {
+		return 0;
+	}
+}
+
+void text_append_input(TextBoxData* data, CF_InputTextBuffer buffer) {
+	for (int i = 0; i < buffer.len; ++i) {
+		int codepoint = buffer.codepoints[i];
+		sappend_UTF8(data->utf8, codepoint);
+		apush(data->utf32, codepoint);
+	}
+}
+
+void text_pop(TextBoxData* data) {
+	if (data->utf32 && alen(data->utf32) > 0) {
+		int codepoint = apop(data->utf32);
+		spopn(data->utf8, utf8_bytes_required(codepoint));
+	}
+}
+
+void text_clear(TextBoxData* data) {
+	sclear(data->utf8);
+	aclear(data->utf32);
+}
+
+void text_free(TextBoxData* data) {
+	sfree(data->utf8);
+	afree(data->utf32);
+	data->utf8 = NULL;
+	data->utf32 = NULL;
+}
+
+void update_ime_rect(CF_V2 text_pos, TextBoxData* textbox) {
+	// Position IME rect below the baseline.
+	// TODO: This fails on multiline text.
+	CF_V2 text_size = textbox->utf8 ? cf_text_size(textbox->utf8, -1) : cf_text_size("", -1);
+	CF_V2 box_pos = cf_world_to_screen((CF_V2){ text_pos.x + text_size.x, text_pos.y - text_size.y });
+	// TODO: what should width and height be?
+	// Unikey (Vietnamese IME) always ignores size.
+	// Maybe setting size to 0 will tell the IME to do whatever.
+	cf_input_set_ime_rect((int)box_pos.x, (int)box_pos.y, 0, 0);
+}
+
+int main(int argc, char* argv[])
+{
+	int w = 640;
+	int h = 480;
+	cf_make_app("IME", 0, 0, 0, w, h, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
+
+	TextBoxData text = { 0 };
+	bool render_composition = false;
+	float t = 0;
+
+	float half_width = (float)w * 0.5f;
+	float half_height = (float)h * 0.5f;
+
+	while (cf_app_is_running()) {
+		cf_app_update(NULL);
+		t += CF_DELTA_TIME;
+
+		cf_draw_translate(-half_width, half_height);
+		cf_push_font("Calibri");
+		cf_push_font_size(20);
+
+		bool text_input_enabled = cf_input_is_ime_enabled();
+		const char* instruction = !text_input_enabled
+			? "Press Enter to start text input"
+			: "Press Enter to stop text input";
+		cf_draw_text(instruction, (CF_V2){ 0, 0 }, -1);
+
+		// Draw input box slightly below
+		cf_draw_translate(0.f, -cf_text_size(instruction, -1).y * 1.5);
+
+		// Append the text from the buffer
+		CF_InputTextBuffer buffer;
+		bool received_text = cf_input_text_get_buffer(&buffer);
+		if (received_text) {
+			text_append_input(&text, buffer);
+			update_ime_rect((CF_V2){ 0 }, &text);
+
+			cf_input_text_clear();
+		}
+
+		// Draw the text input
+		if (text.utf8) {
+			cf_draw_text(text.utf8, (CF_V2){ 0.f, 0.f }, -1);
+		}
+
+		// Draw cursor
+		if (text_input_enabled) {
+			CF_V2 text_size = text.utf8 ? cf_text_size(text.utf8, -1) : cf_text_size("", -1);
+
+			CF_Color color = cf_draw_peek_color();
+			color.a = sinf(t * 8.f) * 0.5f + 0.5f;
+			cf_draw_push_color(color);
+			cf_draw_line(
+				(CF_V2){ text_size.x, 0.f },
+				(CF_V2){ text_size.x, -text_size.y },
+				0.f
+			);
+			cf_draw_pop_color();
+		}
+
+		// Some IME uses Enter to submit composition so we only toggle if no
+		// text was received
+		if (!received_text && cf_key_just_pressed(CF_KEY_RETURN)) {
+			if (text_input_enabled) {
+				cf_input_disable_ime();
+			} else {
+				cf_input_enable_ime();
+				cf_input_text_clear();
+				text_clear(&text);
+				update_ime_rect((CF_V2){ 0 }, &text);
+			}
+		}
+
+		// Backspace to delete
+		if (
+			text_input_enabled
+			&& (
+				cf_key_repeating(CF_KEY_BACKSPACE)
+				|| cf_key_just_pressed(CF_KEY_BACKSPACE)
+			)
+		) {
+			text_pop(&text);
+			update_ime_rect((CF_V2){ 0 }, &text);
+		}
+
+		cf_app_draw_onto_screen(true);
+	}
+
+	text_free(&text);
+}

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -561,6 +561,7 @@ void cf_pump_input_msgs()
 			app->ime_composition.clear();
 			const char* text = event.edit.text;
 			while (*text) app->ime_composition.add(*text++);
+			app->ime_composition.add(0);
 			app->ime_composition_cursor = event.edit.start;
 			app->ime_composition_selection_len = event.edit.length;
 		}	break;

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -358,6 +358,13 @@ bool cf_input_text_has_data()
 	return app->input_text.count() > 0 ? true : false;
 }
 
+bool cf_input_text_get_buffer(CF_InputTextBuffer* buffer)
+{
+	buffer->len = app->input_text.count();
+	buffer->codepoints = app->input_text.data();
+	return app->input_text.count() > 0;
+}
+
 void cf_input_text_clear()
 {
 	app->input_text.clear();

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -551,6 +551,7 @@ void cf_pump_input_msgs()
 
 		case SDL_EVENT_TEXT_EDITING:
 		{
+			app->ime_composition.clear();
 			const char* text = event.edit.text;
 			while (*text) app->ime_composition.add(*text++);
 			app->ime_composition_cursor = event.edit.start;


### PR DESCRIPTION
* Allow grabbing the entire text input buffer.
  At least it is useful for my IME which sends an entire composed word.
* Replace rather than append composition.
  It is what the IME is "cooking".
  At least on Linux, the IME handles text replacement and the application just have to render.
* Add an IME example.
  Only tested with https://en.wikipedia.org/wiki/UniKey_(software) on Linux but SDL **should** be portable.

There are a few things that may need further thoughts:

Should `cf_draw_text` accepts `NULL` as input and treat it as an empty string?
CF allows initializing a string as `NULL` and manipulate it.
So `NULL` is equivalent to an empty string.

Do we need a way to render text from utf32?
The current example keeps 2 concurrent representations: utf8 and utf32.
utf32 is for editing since each codepoint is a glyph.
utf8 is for rendering since CF expects it but upon rendering, it is decoded into utf32 anyway.
That said, I'm not sure how text editors do this.
I only need short textboxes so it doesn't really matter that much.

What should `cf_text_size` return?
Previously, I changed it to be inclusive of the entire text box.
But to render a cursor on a multilline string, that is not enough.
For example:

```
First line is long
Second | <- cursor is here.
```

Maybe a `CF_TextInfo cf_text_info(const char* text, int num_chars)` where `CF_TextInfo` can accommodate different types of info.

Supporting IME composition candidates (think auto complete for IME): https://wiki.libsdl.org/SDL3/SDL_HINT_IME_IMPLEMENTED_UI#remarks.
It is apparently a thing but I have no knowledge of this nor do I need it soon.