### PR TITLE
Fix looping behaviour for pingpong animation

### DIFF
--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -543,11 +543,7 @@ CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
 				sprite->frame_index++;
 				if (sprite->frame_index == frame_count) {
 					sprite->loop_count++;
-					if (sprite->loop) {
-						sprite->frame_index--;
-					} else {
-						sprite->frame_index = frame_count - 1;
-					}
+					sprite->frame_index--;
 				}
 			}
 		}

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -536,17 +536,17 @@ CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
 						sprite->loop_count++;
 						sprite->frame_index++;
 					} else  {
-						sprite->frame_index = frame_count - 1;
+						sprite->frame_index = 0;
 					}
 				}
 			} else {
 				sprite->frame_index++;
 				if (sprite->frame_index == frame_count) {
+					sprite->loop_count++;
 					if (sprite->loop) {
-						sprite->loop_count++;
 						sprite->frame_index--;
 					} else {
-						sprite->frame_index = 0;
+						sprite->frame_index = frame_count - 1;
 					}
 				}
 			}

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -534,9 +534,9 @@ CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
 				if (sprite->frame_index < 0) {
 					if (sprite->loop) {
 						sprite->loop_count++;
-						sprite->frame_index = frame_count - 1;
-					} else  {
 						sprite->frame_index++;
+					} else  {
+						sprite->frame_index = frame_count - 1;
 					}
 				}
 			} else {
@@ -544,9 +544,9 @@ CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
 				if (sprite->frame_index == frame_count) {
 					if (sprite->loop) {
 						sprite->loop_count++;
-						sprite->frame_index = 0;
-					} else {
 						sprite->frame_index--;
+					} else {
+						sprite->frame_index = 0;
 					}
 				}
 			}


### PR DESCRIPTION
The sprite would loop properly in ping pong mode.

If loop is set to false, it will bounce back once and stop.
