### PR TITLE
Fix cf_destroy_shader

### DIFF
--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -1228,8 +1228,8 @@ void cf_destroy_shader(CF_Shader shader_handle)
 	// if it exists. See `cf_make_draw_shader`.
 	CF_Shader* blit = (CF_Shader*)draw->draw_shd_to_blit_shd.try_get(shader_handle.id);
 	if (blit) {
-		draw->draw_shd_to_blit_shd.remove(shader_handle.id);
 		cf_destroy_shader(*blit);
+		draw->draw_shd_to_blit_shd.remove(shader_handle.id);
 	}
 
 	CF_ShaderInternal* shd = (CF_ShaderInternal*)shader_handle.id;


### PR DESCRIPTION
The hashmap removal would invalidate the earlier pointer and a different blit shader would be destroyed.

A blit shader is not mapped to anything so I think it safe to remove the mapping later.