### PR TITLE
Set high density window property

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -286,6 +286,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, x_offset+x);
 		SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, y_offset+y);
 	}
+	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, options & SDL_WINDOW_HIGH_PIXEL_DENSITY);
 	window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
 	CF_App* app = (CF_App*)CF_ALLOC(sizeof(CF_App));

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -231,9 +231,6 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		SDL_Init(SDL_INIT_AUDIO);
 	}
 
-	// Turn on high DPI support for all platforms.
-	options |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-	
 	if (!SDL_Init(sdl_options)) {
 		return cf_result_error("SDL_Init failed");
 	}
@@ -265,6 +262,8 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	}
 
 	Uint32 flags = 0;
+	// Turn on high DPI support for all platforms.
+	flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
 	if (use_metal) flags |= SDL_WINDOW_METAL;
 	if (options & CF_APP_OPTIONS_FULLSCREEN_BIT) flags |= SDL_WINDOW_FULLSCREEN;
 	if (options & CF_APP_OPTIONS_RESIZABLE_BIT) flags |= SDL_WINDOW_RESIZABLE;
@@ -286,7 +285,6 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_X_NUMBER, x_offset+x);
 		SDL_SetNumberProperty(props, SDL_PROP_WINDOW_CREATE_Y_NUMBER, y_offset+y);
 	}
-	SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, options & SDL_WINDOW_HIGH_PIXEL_DENSITY);
 	window = SDL_CreateWindowWithProperties(props);
 	SDL_DestroyProperties(props);
 	CF_App* app = (CF_App*)CF_ALLOC(sizeof(CF_App));


### PR DESCRIPTION
This fixes the HighDPI mode rendering on macOS.

https://wiki.libsdl.org/SDL3/SDL_CreateWindowWithProperties