### PR TITLE
Fix undefined behaviour in the shader definition

### DIFF
--- a/samples/recolor.cpp
+++ b/samples/recolor.cpp
@@ -4,8 +4,8 @@ using namespace Cute;
 #include <imgui.h>
 
 #define STR(X) #X
-const char* s_recolor = STR(
-	#include "blend.shd"\n
+#define BLEND_SHD "#include \"blend.shd\"\n"
+const char* s_recolor = BLEND_SHD STR(
 	vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
 	{
 		vec3 a = rgb_to_hsv(color.rgb);


### PR DESCRIPTION
Original code was throwing this error:

```
error: embedding a #include directive within macro arguments is not supported
    8 |         #include "blend.shd"\n
```

This change uses literal concatenation to merge the header include directive as a string with the rest of the shader code.