### PR TITLE
Bump SDL to 3.2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,7 @@ else()
 	set(SDL_EXAMPLES OFF CACHE BOOL "Do not build SDL examples")
 	FetchContent_Declare(
 		SDL3
-		URL https://github.com/libsdl-org/SDL/archive/da80b9bce50b12c2731f85691fd6f9aec2eb4c2f.zip
+		URL https://github.com/libsdl-org/SDL/releases/download/release-3.2.6/SDL3-3.2.6.zip
 		DOWNLOAD_EXTRACT_TIMESTAMP ON
 		CMAKE_ARGS -DSDL_SHARED=$<NOT:${CF_FRAMEWORK_STATIC}> -DSDL_STATIC=${CF_FRAMEWORK_STATIC} -DSDL_TEST_LIBRARY=OFF -DSDL_TESTS=OFF -DSDL_EXAMPLES=OFF
 	)

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -402,8 +402,8 @@ void cf_destroy_app()
 	if (app->device) SDL_ReleaseWindowFromGPUDevice(app->device, app->window);
 	SDL_DestroyWindow(app->window);
 	if (app->device) SDL_DestroyGPUDevice(app->device);
-	SDL_Quit();
 	destroy_threadpool(app->threadpool);
+	SDL_Quit();
 	cs_shutdown();
 	CF_Image* easy_sprites = app->easy_sprites.items();
 	for (int i = 0; i < app->easy_sprites.count(); ++i) {


### PR DESCRIPTION
This PR upgrades SDL to version 3.2.6.

Rearranged the threadpool destroy before the `SDL_Quit` as I was getting:

```
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181b20)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181c00)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181ce0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181dc0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181ea0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181f80)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000182060)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181ab0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181b90)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181c70)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181d50)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181e30)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181f10)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x600000181ff0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] Leaked thread (0x6000001820d0)
2025-03-03 06:38:29.661 easysprite[92289:5369682] WARNING:

Assertion failure at SDL_SetObjectsInvalid (/Users/piotr/Work/GitHub/cute_framework/build/_deps/sdl3-src/src/SDL_utils.c:241), triggered 1 time:
  'SDL_HashTableEmpty(SDL_objects)'
```