### PR TITLE
Fix some annoying compile warnings

### DIFF
--- a/samples/platformer.cpp
+++ b/samples/platformer.cpp
@@ -858,7 +858,7 @@ void update_stars(Game *game)
             {
                 int last_index = cf_array_count(game->stars) - 1;
                 CF_MEMCPY(game->stars + index, game->stars + last_index, sizeof(stars[0]));
-                cf_array_pop(game->stars);
+                CF_UNUSED(cf_array_pop(game->stars));
                 continue;
             }
             
@@ -1264,7 +1264,7 @@ void update_players(Game *game)
             {
                 int last_index = cf_array_count(game->players) - 1;
                 CF_MEMCPY(players + index, players + last_index, sizeof(players[0]));
-                cf_array_pop(game->players);
+                CF_UNUSED(cf_array_pop(game->players));
                 continue;
             }
             
@@ -1322,7 +1322,7 @@ void update_star_particles(Game *game)
             {
                 int last_index = cf_array_count(particles) - 1;
                 CF_MEMCPY(particles + index, particles + last_index, sizeof(particles[0]));
-                cf_array_pop(particles);
+                CF_UNUSED(cf_array_pop(particles));
                 continue;
             }
             

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -46,7 +46,7 @@ static void s_init_video()
 CF_DisplayID cf_default_display()
 {
 	s_init_video();
-	return { SDL_GetPrimaryDisplay() };
+	return SDL_GetPrimaryDisplay();
 }
 
 int cf_display_count()

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -23,7 +23,7 @@ TEST_CASE(test_array_macros_simple)
 	REQUIRE(vec[2] == 3);
 	REQUIRE(apop(vec) == 3);
 	REQUIRE(alen(vec) == 2);
-	apop(vec);
+	CF_UNUSED(apop(vec));
 	REQUIRE(apop(vec) == 1);
 	REQUIRE(alen(vec) == 0);
 	for (int i = 0; i < 32; ++i) {


### PR DESCRIPTION
Removes the `unused return value` warning and `braces around scalar initializer`