### PR TITLE
Disable buffer cycling in SDL_UploadToGPUBuffer/SDL_UploadToGPUTexture

### DIFF
--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -229,7 +229,7 @@ void cf_texture_update(CF_Texture texture_handle, void* data, int size)
 	src.pixels_per_row = tex->w;
 	src.rows_per_layer = tex->h;
 	SDL_GPUTextureRegion dst = SDL_GPUTextureRegionDefaults(tex, tex->w, tex->h);
-	SDL_UploadToGPUTexture(pass, &src, &dst, true);
+	SDL_UploadToGPUTexture(pass, &src, &dst, false);
 	SDL_EndGPUCopyPass(pass);
 	if (!tex->buf) SDL_ReleaseGPUTransferBuffer(app->device, buf);
 	if (!app->cmd) SDL_SubmitGPUCommandBuffer(cmd);
@@ -853,7 +853,7 @@ static void s_update_buffer(CF_Buffer* buffer, int element_count, void* data, in
 	region.buffer = buffer->buffer;
 	region.offset = 0;
 	region.size = size;
-	SDL_UploadToGPUBuffer(pass, &location, &region, true);
+	SDL_UploadToGPUBuffer(pass, &location, &region, false);
 	SDL_EndGPUCopyPass(pass);
 	if (!app->cmd) SDL_SubmitGPUCommandBuffer(cmd);
 }

--- a/src/cute_imgui.cpp
+++ b/src/cute_imgui.cpp
@@ -293,7 +293,7 @@ void cf_imgui_draw(SDL_GPUTexture* swapchain_texture)
 		region.buffer = app->imgui_vbuf;
 		region.offset = 0;
 		region.size = (uint32_t)(draw_data->TotalVtxCount * sizeof(ImDrawVert));
-		SDL_UploadToGPUBuffer(copy_pass, &src, &region, true);
+		SDL_UploadToGPUBuffer(copy_pass, &src, &region, false);
 
 		src.transfer_buffer = app->imgui_itbuf;
 		region.buffer = app->imgui_ibuf;


### PR DESCRIPTION
This leads to a significant reduction in VRAM usage.

According to https://moonside.games/posts/sdl-gpu-concepts-cycling/:

* `SDL_MapGPUTransferBuffer(cycle=true)` ensures that cycling happen if there is any in flight **upload** command. This is to ensure that uploaded data is not corrupted. This is why turning this off and without vsync creates visual corruption.
* `SDL_UploadToGPUBuffer/Texture(cycle=true)` however, ensures that cycling happens if the resource is bound to an earlier **render** command in the command buffer.
  This ensures that render data is not corrupted due to an in-flight upload.
* But because commands are ordered on the GPU due to barriers and the way CF uploads before rendering, I think cycling on upload is not needed.
  Cycling is only needed on mapping because it happens concurrently on both CPU and GPU.

I have personally tested between master (`37767848969574ba4d003d1504030c003e8edd67`) and this branch.
On master, the output of `nvidia-smi` for some samples are:

```
0   N/A  N/A           52465    C+G   ./textdrawing                          1389MiB
```

On this branch:

```
0   N/A  N/A           52998    C+G   ./textdrawing                           109MiB
```

There is no visual corruption in various samples after switching to this branch.