### PR TITLE
Ignore buffer cycling until the first frame is rendered

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -554,6 +554,7 @@ int cf_app_draw_onto_screen(bool clear)
 
 	SDL_SubmitGPUCommandBuffer(app->cmd);
 	app->cmd = NULL;
+	app->rendered_first_frame = true;
 
 	// Clear all pushed draw parameters.
 	draw->alpha_discards.set_count(1);

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -838,7 +838,7 @@ static void s_update_buffer(CF_Buffer* buffer, int element_count, void* data, in
 
 	// Copy vertices over to the driver.
 	CF_ASSERT(size <= buffer->size);
-	void* p = SDL_MapGPUTransferBuffer(app->device, buffer->transfer_buffer, true);
+	void* p = SDL_MapGPUTransferBuffer(app->device, buffer->transfer_buffer, app->rendered_first_frame);
 	CF_MEMCPY(p, data, size);
 	SDL_UnmapGPUTransferBuffer(app->device, buffer->transfer_buffer);
 	buffer->element_count = element_count;

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -101,6 +101,7 @@ struct CF_App
 	CF_WindowState window_state;
 	CF_WindowState window_state_prev;
 	SDL_GPUCommandBuffer* cmd = NULL;
+	bool rendered_first_frame = false;
 	bool use_depth_stencil = false;
 	uint64_t default_image_id = CF_PNG_ID_RANGE_LO;
 	bool vsync = false;


### PR DESCRIPTION
I have no idea why this works but it works.

The sprite batcher submits a flurry of `s_update_buffer` in the first frame and due to SDL's cycling it creates a huge number of spare buffers.
But after the first frame, there is only one update per frame.
This is why frame rate has zero effect on resource usage because everything is decided on the first frame.
SDL's buffer cycling indeed works: It keeps reusing the gazillions of buffers created on the first frame.

The workaround is to ignore cycling on the very first frame.
There is nothing inflight so there is no chance of corruption.

Resource usage even on the RAM side is tiny now.

I think there should be a better fix if the sprite batcher is better understood.