### PR TITLE
Defrag the sprite batcher before every flush

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2819,6 +2819,7 @@ static void s_process_command(CF_Canvas canvas, CF_Command* cmd, CF_Command* nex
 		// Process the collated drawable items. Might get split up into multiple draw calls depending on
 		// the atlas compiler.
 		draw->need_flush = false;
+		spritebatch_defrag(&draw->sb);
 		spritebatch_flush(&draw->sb);
 	}
 }
@@ -2853,6 +2854,7 @@ void cf_render_layers_to(CF_Canvas canvas, int layer_lo, int layer_hi, bool clea
 	}
 	if (draw->need_flush) {
 		draw->need_flush = false;
+		spritebatch_defrag(&draw->sb);
 		spritebatch_flush(&draw->sb);
 	}
 	draw->has_drawn_something = false;


### PR DESCRIPTION
This ensures that the atlas is defragged before every flush.
Both RAM and VRAM usage are reduced significantly.
No change to the cycling flag is needed.

However, I have no idea how this affects performance since there is another per-frame defrag.