### PR TITLE
Mark enums as closed

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -49,7 +49,7 @@ typedef enum CF_DisplayOrientation
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_DISPLAY_ORIENTATION_DEFS
 	#undef CF_ENUM
-} CF_DisplayOrientation;
+} CF_CLOSED_ENUM CF_DisplayOrientation;
 
 typedef uint32_t CF_DisplayID;
 
@@ -211,7 +211,7 @@ typedef enum CF_AppOptionFlagBits
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_APP_OPTION_DEFS
 	#undef CF_ENUM
-} CF_AppOptionFlagBits;
+} CF_CLOSED_ENUM CF_AppOptionFlagBits;
 
 /**
  * @function cf_make_app
@@ -751,7 +751,7 @@ typedef enum CF_PowerState
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_POWER_STATE_DEFS
 	#undef CF_ENUM
-} CF_PowerState;
+} CF_CLOSED_ENUM CF_PowerState;
 
 /**
  * @function cf_power_state_to_string

--- a/include/cute_coroutine.h
+++ b/include/cute_coroutine.h
@@ -90,7 +90,7 @@ typedef enum CF_CoroutineState
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_COROUTINE_STATE_DEFS
 	#undef CF_ENUM
-} CF_CoroutineState;
+} CF_CLOSED_ENUM CF_CoroutineState;
 
 /**
  * @function cf_coroutine_state_to_string

--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -98,6 +98,22 @@
 #	define CF_CALL
 #endif
 
+#ifndef CF_HAS_ATTR
+#	ifdef __has_attribute
+#		define CF_HAS_ATTR(attr) __has_attribute(attr)
+#	else
+#		define CF_HAS_ATTR(attr) 0
+#	endif
+#endif
+
+#if defined(__clang__) || CF_HAS_ATTR(enum_extensibility)
+#	define CF_OPEN_ENUM __attribute__((enum_extensibility(open)))
+#	define CF_CLOSED_ENUM __attribute__((enum_extensibility(closed)))
+#else
+#	define CF_OPEN_ENUM
+#	define CF_CLOSED_ENUM
+#endif
+
 #define CF_UNUSED(x) (void)x
 #define CF_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #ifdef __cplusplus

--- a/include/cute_file_system.h
+++ b/include/cute_file_system.h
@@ -278,7 +278,7 @@ typedef enum CF_FileType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_FILE_TYPE_DEFS
 	#undef CF_ENUM
-} CF_FileType;
+} CF_CLOSED_ENUM CF_FileType;
 
 /**
  * @function cf_file_type_to_string

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -152,7 +152,7 @@ typedef enum CF_BackendType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_BACKEND_TYPE_DEFS
 	#undef CF_ENUM
-} CF_BackendType;
+} CF_CLOSED_ENUM CF_BackendType;
 
 /**
  * @function cf_backend_type_to_string
@@ -307,7 +307,7 @@ typedef enum CF_PixelFormat
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_PIXEL_FORMAT_DEFS
 	#undef CF_ENUM
-} CF_PixelFormat;
+} CF_CLOSED_ENUM CF_PixelFormat;
 
 /**
  * @function cf_pixel_format_to_string
@@ -352,7 +352,7 @@ typedef enum CF_PixelFormatOp
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_PIXELFORMAT_OP_DEFS
 	#undef CF_ENUM
-} CF_PixelFormatOp;
+} CF_CLOSED_ENUM CF_PixelFormatOp;
 
 /**
  * @function cf_pixel_format_op_to_string
@@ -402,7 +402,7 @@ typedef enum CF_TextureUsageBits
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_TEXTURE_USAGE_DEFS
 	#undef CF_ENUM
-} CF_TextureUsageBits;
+} CF_CLOSED_ENUM CF_TextureUsageBits;
 
 /**
  * @enum     CF_Filter
@@ -422,7 +422,7 @@ typedef enum CF_Filter
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_FILTER_DEFS
 	#undef CF_ENUM
-} CF_Filter;
+} CF_CLOSED_ENUM CF_Filter;
 
 /**
  * @function cf_filter_to_string
@@ -459,7 +459,7 @@ typedef enum CF_WrapMode
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_WRAP_MODE_DEFS
 	#undef CF_ENUM
-} CF_WrapMode;
+} CF_CLOSED_ENUM CF_WrapMode;
 
 /**
  * @function cf_wrap_mode_string
@@ -581,7 +581,7 @@ typedef enum CF_ShaderStage
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_SHADER_STAGE_DEFS
 	#undef CF_ENUM
-} CF_ShaderStage;
+} CF_CLOSED_ENUM CF_ShaderStage;
 
 /**
  * @function cf_shader_directory
@@ -867,7 +867,7 @@ typedef enum CF_VertexFormat
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_VERTEX_FORMAT_DEFS
 	#undef CF_ENUM
-} CF_VertexFormat;
+} CF_CLOSED_ENUM CF_VertexFormat;
 
 /**
  * @function cf_vertex_format_string
@@ -1011,7 +1011,7 @@ typedef enum CF_CullMode
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_CULL_MODE_DEFS
 	#undef CF_ENUM
-} CF_CullMode;
+} CF_CLOSED_ENUM CF_CullMode;
 
 /**
  * @function cf_cull_mode_string
@@ -1058,7 +1058,7 @@ typedef enum CF_CompareFunction
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_COMPARE_FUNCTION_DEFS
 	#undef CF_ENUM
-} CF_CompareFunction;
+} CF_CLOSED_ENUM CF_CompareFunction;
 
 /**
  * @function cf_compare_function_string
@@ -1105,7 +1105,7 @@ typedef enum CF_StencilOp
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_STENCIL_OP_DEFS
 	#undef CF_ENUM
-} CF_StencilOp;
+} CF_CLOSED_ENUM CF_StencilOp;
 
 /**
  * @function cf_stencil_op_string
@@ -1147,7 +1147,7 @@ typedef enum CF_BlendOp
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_BLEND_OP_DEFS
 	#undef CF_ENUM
-} CF_BlendOp;
+} CF_CLOSED_ENUM CF_BlendOp;
 
 /**
  * @function cf_blend_op_string
@@ -1205,7 +1205,7 @@ typedef enum CF_BlendFactor
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_BLENDFACTOR_DEFS
 	#undef CF_ENUM
-} CF_BlendFactor;
+} CF_CLOSED_ENUM CF_BlendFactor;
 
 /**
  * @function cf_blend_factor_string
@@ -1444,7 +1444,7 @@ typedef enum CF_UniformType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_UNIFORM_TYPE_DEFS
 	#undef CF_ENUM
-} CF_UniformType;
+} CF_CLOSED_ENUM CF_UniformType;
 
 /**
  * @function cf_uniform_type_string

--- a/include/cute_haptics.h
+++ b/include/cute_haptics.h
@@ -105,7 +105,7 @@ typedef enum CF_HapticType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_HAPTIC_TYPE_DEFS
 	#undef CF_ENUM
-} CF_HapticType;
+} CF_CLOSED_ENUM CF_HapticType;
 
 /**
  * @function cf_haptic_type_to_string
@@ -163,7 +163,7 @@ typedef enum CF_HapticWaveType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_HAPTIC_WAVE_TYPE_DEFS
 	#undef CF_ENUM
-} CF_HapticWaveType;
+} CF_CLOSED_ENUM CF_HapticWaveType;
 
 /**
  * @function cf_haptic_wave_type_to_string

--- a/include/cute_https.h
+++ b/include/cute_https.h
@@ -176,7 +176,7 @@ typedef enum CF_HttpsResult
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_HTTPS_RESULT_DEFS
 	#undef CF_ENUM
-} CF_HttpsResult;
+} CF_CLOSED_ENUM CF_HttpsResult;
 
 /**
  * @function cf_https_result_to_string

--- a/include/cute_input.h
+++ b/include/cute_input.h
@@ -37,7 +37,7 @@ typedef enum CF_MouseButton
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_MOUSE_BUTTON_DEFS
 	#undef CF_ENUM
-} CF_MouseButton;
+} CF_CLOSED_ENUM CF_MouseButton;
 
 /**
  * @function cf_mouse_button_to_string
@@ -544,7 +544,7 @@ typedef enum CF_KeyButton
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_KEY_BUTTON_DEFS
 	#undef CF_ENUM
-} CF_KeyButton;
+} CF_CLOSED_ENUM CF_KeyButton;
 
 /**
  * @function cf_key_button_to_string

--- a/include/cute_joypad.h
+++ b/include/cute_joypad.h
@@ -48,7 +48,7 @@ typedef enum CF_JoypadPowerLevel
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_JOYPAD_POWER_LEVEL_DEFS
 	#undef CF_ENUM
-} CF_JoypadPowerLevel;
+} CF_CLOSED_ENUM CF_JoypadPowerLevel;
 
 /**
  * @function cf_joypad_power_level_to_string
@@ -115,7 +115,7 @@ typedef enum CF_JoypadButton
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_JOYPAD_BUTTON_DEFS
 	#undef CF_ENUM
-} CF_JoypadButton;
+} CF_CLOSED_ENUM CF_JoypadButton;
 
 /**
  * @function cf_joypad_button_to_string
@@ -164,7 +164,7 @@ typedef enum CF_JoypadAxis
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_JOYPAD_AXIS_DEFS
 	#undef CF_ENUM
-} CF_JoypadAxis;
+} CF_CLOSED_ENUM CF_JoypadAxis;
 
 /**
  * @function cf_joypad_axis_to_string
@@ -227,7 +227,7 @@ typedef enum CF_JoypadType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_JOYPAD_TYPE_DEFS
 	#undef CF_ENUM
-} CF_JoypadType;
+} CF_CLOSED_ENUM CF_JoypadType;
 
 /**
  * @function cf_joypad_type_to_string

--- a/include/cute_json.h
+++ b/include/cute_json.h
@@ -67,7 +67,7 @@ typedef enum CF_JType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_JTYPE_DEFS
 	#undef CF_ENUM
-} CF_JType;
+} CF_CLOSED_ENUM CF_JType;
 
 /**
  * @function cf_json_type_to_string

--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -2091,7 +2091,7 @@ typedef enum CF_ShapeType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_SHAPE_TYPE_DEFS
 	#undef CF_ENUM
-} CF_ShapeType;
+} CF_CLOSED_ENUM CF_ShapeType;
 
 /**
  * @function cf_shape_type_to_string

--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -342,7 +342,7 @@ typedef enum CF_ClientState
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_CLIENT_STATE_DEFS
 	#undef CF_ENUM
-} CF_ClientState;
+} CF_CLOSED_ENUM CF_ClientState;
 
 /**
  * @function cf_client_state_to_string
@@ -492,7 +492,7 @@ typedef enum CF_ServerEventType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_SERVER_EVENT_TYPE_DEFS
 	#undef CF_ENUM
-} CF_ServerEventType;
+} CF_CLOSED_ENUM CF_ServerEventType;
 
 /**
  * @function cf_server_event_type_to_string

--- a/include/cute_result.h
+++ b/include/cute_result.h
@@ -91,7 +91,7 @@ typedef enum CF_MessageBoxType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_MESSAGE_BOX_TYPE_DEFS
 	#undef CF_ENUM
-} CF_MessageBoxType;
+} CF_CLOSED_ENUM CF_MessageBoxType;
 
 /**
  * @function cf_message_box_type_to_string

--- a/include/cute_shader_bytecode.h
+++ b/include/cute_shader_bytecode.h
@@ -59,7 +59,7 @@ typedef enum CF_ShaderInfoDataType
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_SHADER_INFO_DATA_TYPE_DEFS
 	#undef CF_ENUM
-} CF_ShaderInfoDataType;
+} CF_CLOSED_ENUM CF_ShaderInfoDataType;
 
 /**
  * @struct   CF_ShaderUniformMemberInfo

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -62,7 +62,7 @@ typedef enum CF_PlayDirection
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_PLAY_DIRECTION_DEFS
 	#undef CF_ENUM
-} CF_PlayDirection;
+} CF_CLOSED_ENUM CF_PlayDirection;
 
 /**
  * @function cf_play_direction_to_string


### PR DESCRIPTION
Marking these as either open or closed allows to import these enums as actual enums in Swift, rather than structs. This will make for better type checking and does not impact actual C/C++ code.

https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md