### PR TITLE
sprite shatter and slicing examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,9 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 		add_executable(scissor samples/scissor.c)
 		add_executable(ime samples/ime.c)
 		add_executable(pivot samples/pivot.cpp)
+		add_executable(sprite_slice samples/sprite_slice.cpp)
+		add_executable(sprite_shatter samples/sprite_shatter.cpp)
+		add_executable(screen_shatter samples/screen_shatter.cpp)
 		set(SAMPLE_EXECUTABLES
 			easysprite
 			basicserialization
@@ -553,6 +556,9 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			scissor
 			ime
 			pivot
+			sprite_slice
+			sprite_shatter
+			screen_shatter
 		)
 
 		foreach(CURRENT_TARGET ${SAMPLE_EXECUTABLES})

--- a/samples/screen_shatter.cpp
+++ b/samples/screen_shatter.cpp
@@ -20,7 +20,7 @@ struct
     CF_Vertex* verts;
 } draw;
 
-CF_Rnd random;
+CF_Rnd rnd;
 
 struct ScreenChunk
 {
@@ -80,7 +80,7 @@ void init(int w, int h)
     
     cf_array_free(attrs);
     
-    random = cf_rnd_seed(0);
+    rnd = cf_rnd_seed(0);
 }
 
 void screen_chunk(CF_V2 screen_dims, ScreenChunk* chunks)
@@ -101,7 +101,7 @@ void screen_chunk(CF_V2 screen_dims, ScreenChunk* chunks)
     while (cf_array_count(aabbs) > 0)
     {
         int count = cf_array_count(aabbs);
-        int index = cf_rnd_range_int(&random, 0, count - 1);
+        int index = cf_rnd_range_int(&rnd, 0, count - 1);
         
         CF_Aabb aabb = aabbs[index];
         aabbs[index] = aabbs[count - 1];
@@ -177,11 +177,11 @@ void screen_chunk(CF_V2 screen_dims, ScreenChunk* chunks)
             CF_V2 new_extents = extents;
             if (ds.x > min_size.x)
             {
-                new_extents.x = cf_rnd_range_float(&random, min_size.x, extents.x);
+                new_extents.x = cf_rnd_range_float(&rnd, min_size.x, extents.x);
             }
             if (ds.y > min_size.y)
             {
-                new_extents.y = cf_rnd_range_float(&random, min_size.y, extents.y);
+                new_extents.y = cf_rnd_range_float(&rnd, min_size.y, extents.y);
             }
             
             // p0----p1--------p2

--- a/samples/screen_shatter.cpp
+++ b/samples/screen_shatter.cpp
@@ -1,0 +1,361 @@
+#include <cute.h>
+#include "proggy.h"
+
+#define STR(X) #X
+
+const char* shader_str = STR(
+    vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
+{
+    return texture(u_image, smooth_uv(v_uv, u_texture_size));
+}
+);
+
+struct
+{
+    CF_Shader shader;
+    CF_Material material;
+    CF_Canvas copy_canvas;
+    CF_Mesh mesh;
+    CF_M3x2 projection;
+    CF_Vertex* verts;
+} draw;
+
+CF_Rnd random;
+
+struct ScreenChunk
+{
+    CF_V2 verts[3];
+    CF_V2 uvs[3];
+    CF_V2 velocity;
+};
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset);
+void init(int w, int h);
+void shattered_screen(CF_V2 screen_dims, ScreenChunk* chunks);
+void update_screen_chunk(ScreenChunk* chunks);
+void draw_screen_chunk(ScreenChunk* chunks);
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset)
+{
+    CF_VertexAttribute vert = {};
+    vert.name = name;
+    vert.format = format;
+    vert.offset = offset;
+    
+    cf_array_push(attrs, vert);
+}
+
+void init(int w, int h)
+{
+    draw.shader = cf_make_draw_shader_from_source(shader_str);
+    draw.material = cf_make_material();
+    
+	CF_VertexAttribute* attrs = NULL;
+    cf_array_fit(attrs, 32);
+    
+    add_vertex_attribute(attrs, "in_pos", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, p));
+    add_vertex_attribute(attrs, "in_posH", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, posH));
+    add_vertex_attribute(attrs, "in_n", CF_VERTEX_FORMAT_INT, CF_OFFSET_OF(CF_Vertex, n));
+    add_vertex_attribute(attrs, "in_ab", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[0]));
+    add_vertex_attribute(attrs, "in_cd", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[2]));
+    add_vertex_attribute(attrs, "in_ef", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[4]));
+    add_vertex_attribute(attrs, "in_gh", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[6]));
+    add_vertex_attribute(attrs, "in_uv", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, uv));
+	add_vertex_attribute(attrs, "in_col", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, color));
+	add_vertex_attribute(attrs, "in_radius", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, radius));
+	add_vertex_attribute(attrs, "in_stroke", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, stroke));
+	add_vertex_attribute(attrs, "in_aa", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, aa));
+    add_vertex_attribute(attrs, "in_params", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, type));
+    add_vertex_attribute(attrs, "in_user_params", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, attributes));
+    draw.mesh = cf_make_mesh(CF_MB * 5, attrs, cf_array_count(attrs), sizeof(CF_Vertex));
+    
+    draw.verts = NULL;
+    cf_array_fit(draw.verts, 1024);
+    
+    CF_CanvasParams params = cf_canvas_defaults(w, h);
+    draw.copy_canvas = cf_make_canvas(params);
+    
+    draw.projection = cf_ortho_2d(0, 0, (float)w, (float)h);
+    cf_draw_projection(draw.projection);
+    
+    cf_array_free(attrs);
+    
+    random = cf_rnd_seed(0);
+}
+
+void screen_chunk(CF_V2 screen_dims, ScreenChunk* chunks)
+{
+    CF_V2 center = cf_v2(0, 0);
+    float push_strength = 10.0f;
+    
+    CF_V2 screen_min = cf_neg_v2(cf_mul_v2_f(screen_dims, 0.5f));
+    CF_V2 screen_max = cf_mul_v2_f(screen_dims, 0.5f);
+    CF_Aabb screen_aabb = cf_make_aabb(screen_min, screen_max);
+    CF_V2 screen_top_left = cf_top_left(screen_aabb);
+    
+    CF_Aabb* aabbs = NULL;
+    cf_array_fit(aabbs, 128);
+    cf_array_push(aabbs, screen_aabb);
+    CF_V2 min_size = cf_v2(96, 96);
+    
+    while (cf_array_count(aabbs) > 0)
+    {
+        int count = cf_array_count(aabbs);
+        int index = cf_rnd_range_int(&random, 0, count - 1);
+        
+        CF_Aabb aabb = aabbs[index];
+        aabbs[index] = aabbs[count - 1];
+        cf_array_pop(aabbs);
+        
+        CF_V2 extents = cf_extents(aabb);
+        CF_V2 ds = cf_sub_v2(extents, min_size);
+        bool discard = ds.x <= min_size.x && ds.y <= min_size.y;
+        
+        if (discard)
+        {
+            CF_V2 p0 = cf_top_left(aabb);
+            CF_V2 p1 = cf_bottom_left(aabb);
+            CF_V2 p2 = cf_top_right(aabb);
+            CF_V2 p3 = cf_bottom_right(aabb);
+            
+            CF_V2 uv0 = cf_sub_v2(screen_top_left, p0);
+            CF_V2 uv1 = cf_sub_v2(screen_top_left, p1);
+            CF_V2 uv2 = cf_sub_v2(screen_top_left, p2);
+            CF_V2 uv3 = cf_sub_v2(screen_top_left, p3);
+            
+            uv0.x = cf_abs(uv0.x / screen_dims.x);
+            uv0.y = cf_abs(uv0.y / screen_dims.y);
+            uv1.x = cf_abs(uv1.x / screen_dims.x);
+            uv1.y = cf_abs(uv1.y / screen_dims.y);
+            uv2.x = cf_abs(uv2.x / screen_dims.x);
+            uv2.y = cf_abs(uv2.y / screen_dims.y);
+            uv3.x = cf_abs(uv3.x / screen_dims.x);
+            uv3.y = cf_abs(uv3.y / screen_dims.y);
+            
+            CF_V2 centroid;
+            
+            // left tri
+            {
+                ScreenChunk chunk = {};
+                chunk.verts[0] = p0;
+                chunk.verts[1] = p1;
+                chunk.verts[2] = p2;
+                
+                chunk.uvs[0] = uv0;
+                chunk.uvs[1] = uv1;
+                chunk.uvs[2] = uv2;
+                
+                centroid = cf_centroid(chunk.verts, CF_ARRAY_SIZE(chunk.verts));
+                chunk.velocity = cf_sub_v2(centroid, center);
+                chunk.velocity = cf_norm(chunk.velocity);
+                chunk.velocity = cf_mul_v2_f(chunk.velocity, push_strength);
+                
+                cf_array_push(chunks, chunk);
+            }
+            
+            // right tri
+            {
+                ScreenChunk chunk = {};
+                chunk.verts[0] = p2;
+                chunk.verts[1] = p1;
+                chunk.verts[2] = p3;
+                
+                chunk.uvs[0] = uv2;
+                chunk.uvs[1] = uv1;
+                chunk.uvs[2] = uv3;
+                
+                centroid = cf_centroid(chunk.verts, CF_ARRAY_SIZE(chunk.verts));
+                chunk.velocity = cf_sub_v2(centroid, center);
+                chunk.velocity = cf_norm(chunk.velocity);
+                chunk.velocity = cf_mul_v2_f(chunk.velocity, push_strength);
+                
+                cf_array_push(chunks, chunk);
+            }
+        }
+        else
+        {
+            CF_V2 new_extents = extents;
+            if (ds.x > min_size.x)
+            {
+                new_extents.x = cf_rnd_range_float(&random, min_size.x, extents.x);
+            }
+            if (ds.y > min_size.y)
+            {
+                new_extents.y = cf_rnd_range_float(&random, min_size.y, extents.y);
+            }
+            
+            // p0----p1--------p2
+            // | q0  | q1      |
+            // |     |         |
+            // p3----p4--------p5
+            // | q2  | q3      |
+            // p6----p7--------p8
+            
+            CF_V2 p0 = cf_top_left(aabb);
+            CF_V2 p1 = cf_v2(p0.x + new_extents.x, p0.y);
+            CF_V2 p2 = cf_top_right(aabb);
+            CF_V2 p3 = cf_v2(p0.x, p0.y - new_extents.y);
+            CF_V2 p4 = cf_v2(p1.x, p1.y - new_extents.y);
+            CF_V2 p5 = cf_v2(p2.x, p3.y);
+            CF_V2 p6 = cf_bottom_left(aabb);
+            CF_V2 p7 = cf_v2(p1.x, p0.y - extents.y);
+            CF_V2 p8 = cf_bottom_right(aabb);
+            
+            CF_Aabb q0 = cf_make_aabb(p3, p1);
+            CF_Aabb q1 = cf_make_aabb(p4, p2);
+            CF_Aabb q2 = cf_make_aabb(p6, p4);
+            CF_Aabb q3 = cf_make_aabb(p7, p5);
+            
+            cf_array_push(aabbs, q0);
+            cf_array_push(aabbs, q1);
+            cf_array_push(aabbs, q2);
+            cf_array_push(aabbs, q3);
+        }
+    }
+    
+    cf_array_free(aabbs);
+}
+
+void update_screen_chunk(ScreenChunk* chunks)
+{
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        ScreenChunk* chunk = chunks + index;
+        CF_V2 dp = cf_mul_v2_f(chunk->velocity, CF_DELTA_TIME);
+        chunk->verts[0] = cf_add_v2(chunk->verts[0], dp);
+        chunk->verts[1] = cf_add_v2(chunk->verts[1], dp);
+        chunk->verts[2] = cf_add_v2(chunk->verts[2], dp);
+    }
+}
+
+void draw_screen_chunk(ScreenChunk* chunks)
+{
+    CF_M3x2 mvp = cf_draw_peek();
+    mvp = cf_mul_m32(draw.projection, mvp);
+    
+    CF_Vertex verts[3] = {};
+    
+    verts[0].aa = false;
+    verts[1].aa = false;
+    verts[2].aa = false;
+    verts[0].alpha = 255;
+    verts[1].alpha = 255;
+    verts[2].alpha = 255;
+    
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        ScreenChunk* chunk = chunks + index;
+        
+        verts[0].p = chunk->verts[0];
+        verts[1].p = chunk->verts[1];
+        verts[2].p = chunk->verts[2];
+        
+        verts[0].posH = cf_mul_m32_v2(mvp, chunk->verts[0]);
+        verts[1].posH = cf_mul_m32_v2(mvp, chunk->verts[1]);
+        verts[2].posH = cf_mul_m32_v2(mvp, chunk->verts[2]);
+        
+        verts[0].uv = chunk->uvs[0];
+        verts[1].uv = chunk->uvs[1];
+        verts[2].uv = chunk->uvs[2];
+        
+        cf_array_push(draw.verts, verts[0]);
+        cf_array_push(draw.verts, verts[1]);
+        cf_array_push(draw.verts, verts[2]);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int w = 640;
+    int h = 480;
+    
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
+	CF_Result result = cf_make_app("Screen Shatter", 0, 0, 0, w, h, options, argv[0]);
+	if (cf_is_error(result)) return -1;
+    
+    // need to know the atlas size otherwise without smooth_uv() the sprites will look blurry
+    CF_V2 canvas_dims = cf_v2((float)w, (float)h);
+    
+    cf_make_font_from_memory(proggy_data, proggy_sz, "ProggyClean");
+    init(w, h);
+    
+    CF_Sprite demo_sprite = cf_make_demo_sprite();
+    cf_sprite_play(&demo_sprite, "spin");
+    int frame_count = cf_array_count(demo_sprite.animation->frames);
+    demo_sprite.scale = cf_v2(12, 12);
+    
+    CF_Canvas app_canvas = cf_app_get_canvas();
+    
+    dyna ScreenChunk* chunks = NULL;
+    cf_array_fit(chunks, 1024);
+    
+	while (cf_app_is_running())
+	{
+		cf_app_update(NULL);
+        
+        cf_array_clear(draw.verts);
+        
+        if (cf_key_just_pressed(CF_KEY_R))
+        {
+            cf_sprite_reset(&demo_sprite);
+            cf_array_clear(chunks);
+        }
+        if (cf_key_just_pressed(CF_KEY_SPACE))
+        {
+            cf_sprite_pause(&demo_sprite);
+            cf_array_clear(chunks);
+            
+            // copy last drawn screen
+            cf_draw_canvas(app_canvas, cf_v2(0, 0), canvas_dims);
+            cf_render_to(draw.copy_canvas, true);
+            screen_chunk(canvas_dims, chunks);
+        }
+        
+        cf_sprite_update(&demo_sprite);
+        update_screen_chunk(chunks);
+        
+        if (cf_array_count(chunks))
+        {
+            draw_screen_chunk(chunks);
+            
+            cf_apply_canvas(app_canvas, true);
+            cf_draw_push_shader(draw.shader);
+            
+            cf_material_set_texture_fs(draw.material, "u_image", cf_canvas_get_target(draw.copy_canvas));
+            cf_material_set_uniform_fs(draw.material, "u_texture_size", &canvas_dims, CF_UNIFORM_TYPE_FLOAT2, 1);
+            
+            cf_mesh_update_vertex_data(draw.mesh, draw.verts, cf_array_count(draw.verts));
+            cf_apply_mesh(draw.mesh);
+            
+            cf_apply_shader(draw.shader, draw.material);
+            cf_draw_elements();
+            
+            cf_draw_pop_shader();
+        }
+        else
+        {
+            cf_draw_push_color(cf_color_grey());
+            CF_Aabb background_aabb = cf_make_aabb(cf_neg_v2(canvas_dims), canvas_dims);
+            cf_draw_box_fill(background_aabb, 0.0f);
+            cf_draw_pop_color();
+            
+            cf_draw_sprite(&demo_sprite);
+            
+            const char* text = "Press SPACE to shatter screen\nR to reset";
+            
+            cf_push_font("ProggyClean");
+            cf_push_font_size(26.0f);
+            CF_V2 text_size = cf_text_size(text, -1);
+            cf_draw_text(text, cf_v2(-text_size.x * 0.5f, h * -0.35f), -1);
+            cf_pop_font_size();
+            cf_pop_font();
+            
+            cf_render_to(app_canvas, true);
+        }
+        
+        cf_app_draw_onto_screen(false);
+    }
+    
+    cf_destroy_app();
+    return 0;
+}

--- a/samples/screen_shatter.cpp
+++ b/samples/screen_shatter.cpp
@@ -4,7 +4,7 @@
 #define STR(X) #X
 
 const char* shader_str = STR(
-    vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
+vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
 {
     return texture(u_image, smooth_uv(v_uv, u_texture_size));
 }

--- a/samples/sprite_shatter.cpp
+++ b/samples/sprite_shatter.cpp
@@ -1,0 +1,353 @@
+#include <cute.h>
+#include "proggy.h"
+
+#define STR(X) #X
+
+const char* shader_str = STR(
+vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
+{
+    return texture(u_image, smooth_uv(v_uv, u_texture_size));
+}
+);
+
+struct
+{
+    CF_Shader shader;
+    CF_Material material;
+    CF_Mesh mesh;
+    CF_M3x2 projection;
+    CF_Vertex* verts;
+} draw;
+
+struct SpriteChunk
+{
+    CF_V2 verts[4];
+    CF_V2 uvs[4];
+    CF_V2 velocity;
+    uint8_t opacity;
+    CF_Pixel color;
+};
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset);
+void init(int w, int h);
+void shatter_sprite(CF_Sprite* sprite, int steps, SpriteChunk* chunks);
+void update_sprite_chunks(SpriteChunk* chunks);
+void draw_sprite_chunks(SpriteChunk* chunks);
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset)
+{
+    CF_VertexAttribute vert = {};
+    vert.name = name;
+    vert.format = format;
+    vert.offset = offset;
+    
+    cf_array_push(attrs, vert);
+}
+
+void init(int w, int h)
+{
+    draw.shader = cf_make_draw_shader_from_source(shader_str);
+    draw.material = cf_make_material();
+    
+	CF_VertexAttribute* attrs = NULL;
+    cf_array_fit(attrs, 32);
+    
+    add_vertex_attribute(attrs, "in_pos", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, p));
+    add_vertex_attribute(attrs, "in_posH", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, posH));
+    add_vertex_attribute(attrs, "in_n", CF_VERTEX_FORMAT_INT, CF_OFFSET_OF(CF_Vertex, n));
+    add_vertex_attribute(attrs, "in_ab", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[0]));
+    add_vertex_attribute(attrs, "in_cd", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[2]));
+    add_vertex_attribute(attrs, "in_ef", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[4]));
+    add_vertex_attribute(attrs, "in_gh", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[6]));
+    add_vertex_attribute(attrs, "in_uv", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, uv));
+	add_vertex_attribute(attrs, "in_col", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, color));
+	add_vertex_attribute(attrs, "in_radius", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, radius));
+	add_vertex_attribute(attrs, "in_stroke", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, stroke));
+	add_vertex_attribute(attrs, "in_aa", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, aa));
+    add_vertex_attribute(attrs, "in_params", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, type));
+    add_vertex_attribute(attrs, "in_user_params", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, attributes));
+    draw.mesh = cf_make_mesh(CF_MB * 5, attrs, cf_array_count(attrs), sizeof(CF_Vertex));
+    
+    draw.verts = NULL;
+    cf_array_fit(draw.verts, 1024);
+    
+    draw.projection = cf_ortho_2d(0, 0, (float)w, (float)h);
+    cf_draw_projection(draw.projection);
+    
+    cf_array_free(attrs);
+}
+
+void shatter_sprite(CF_Sprite* sprite, int steps, SpriteChunk* chunks)
+{
+    float split_step = (float)steps;
+    
+    CF_Pixel color = cf_color_to_pixel(cf_draw_peek_color());
+    uint8_t opacity = (uint8_t)(sprite->opacity * 255.0f);
+    
+    CF_V2 sprite_min = sprite->transform.p;
+    CF_V2 sprite_max = sprite_min;
+    float w = sprite->w * sprite->scale.x;
+    float h = sprite->h * sprite->scale.y;
+    
+    sprite_min.x -= w / 2;
+    sprite_min.y -= h / 2;
+    sprite_max.x += w / 2;
+    sprite_max.y += h / 2;
+    
+    CF_Aabb aabb = cf_make_aabb(sprite_min, sprite_max);
+    CF_V2 step = cf_sub_v2(sprite_max, sprite_min);
+    step = cf_div_v2_f(step, split_step);
+    
+    CF_M3x2 mvp = cf_draw_peek();
+    mvp = cf_mul_m32(draw.projection, mvp);
+    
+    CF_Vertex verts[6] = {};
+    CF_TemporaryImage temporary_image = cf_fetch_image(sprite);
+    CF_V2 u = cf_min_v2(temporary_image.v, temporary_image.u);
+    CF_V2 v = cf_max_v2(temporary_image.v, temporary_image.u);
+    CF_V2 duv = cf_sub_v2(v, u);
+    CF_V2 uv_step = cf_div_v2_f(duv, split_step);
+    
+    CF_V2 center = cf_center(aabb);
+    float push_strength = 10.0f;
+    
+    // y is down
+    for (int y = 0; y < split_step; ++y)
+    {
+        for (int x = 0; x < split_step; ++x)
+        {
+            SpriteChunk chunk = {};
+            
+            CF_V2 chunk_top_left = cf_top_left(aabb);
+            chunk_top_left.x += step.x * x;
+            chunk_top_left.y -= step.y * y;
+            
+            CF_V2 chunk_center = chunk_top_left;
+            chunk_center.x += step.x * 0.5f;
+            chunk_center.y -= step.y * 0.5f;
+            
+            // uniform force push to each chunk from the center
+            CF_V2 velocity = cf_sub_v2(chunk_center, center);
+            velocity = cf_norm(velocity);
+            velocity = cf_mul_v2_f(velocity, push_strength);
+            
+            CF_Aabb chunk_aabb = cf_make_aabb_from_top_left(chunk_top_left, step.x, step.y);
+            
+            CF_V2 chunk_u = u;
+            chunk_u.x += uv_step.x * x;
+            chunk_u.y += uv_step.y * y;
+            
+            CF_V2 uv0 = chunk_u;
+            CF_V2 uv1 = uv0;
+            CF_V2 uv2 = uv0;
+            CF_V2 uv3 = uv0;
+            
+            uv1.y += uv_step.y;
+            
+            uv2.x += uv_step.x;
+            
+            uv3.x += uv_step.x;
+            uv3.y += uv_step.y;
+            
+            chunk.verts[0] = cf_top_left(chunk_aabb);
+            chunk.verts[1] = cf_bottom_left(chunk_aabb);
+            chunk.verts[2] = cf_top_right(chunk_aabb);
+            chunk.verts[3] = cf_bottom_right(chunk_aabb);
+            
+            chunk.uvs[0] = uv0;
+            chunk.uvs[1] = uv1;
+            chunk.uvs[2] = uv2;
+            chunk.uvs[3] = uv3;
+            
+            chunk.opacity = opacity;
+            chunk.color = color;
+            
+            chunk.velocity = velocity;
+            
+            cf_array_push(chunks, chunk);
+        }
+    }
+}
+
+void update_sprite_chunks(SpriteChunk* chunks)
+{
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        SpriteChunk* chunk = chunks + index;
+        
+        CF_V2 dp = cf_mul_v2_f(chunk->velocity, CF_DELTA_TIME);
+        
+        chunk->verts[0] = cf_add_v2(chunk->verts[0], dp);
+        chunk->verts[1] = cf_add_v2(chunk->verts[1], dp);
+        chunk->verts[2] = cf_add_v2(chunk->verts[2], dp);
+        chunk->verts[3] = cf_add_v2(chunk->verts[3], dp);
+    }
+}
+
+void draw_sprite_chunks(SpriteChunk* chunks)
+{
+    CF_M3x2 mvp = cf_draw_peek();
+    mvp = cf_mul_m32(draw.projection, mvp);
+    
+    CF_Vertex verts[6] = {};
+    
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        SpriteChunk* chunk = chunks + index;
+        
+        verts[0].p = chunk->verts[0];
+        verts[1].p = chunk->verts[1];
+        verts[2].p = chunk->verts[2];
+        verts[3].p = chunk->verts[2];
+        verts[4].p = chunk->verts[1];
+        verts[5].p = chunk->verts[3];
+        
+        verts[0].posH = cf_mul_m32_v2(mvp, chunk->verts[0]);
+        verts[1].posH = cf_mul_m32_v2(mvp, chunk->verts[1]);
+        verts[2].posH = cf_mul_m32_v2(mvp, chunk->verts[2]);
+        verts[3].posH = cf_mul_m32_v2(mvp, chunk->verts[2]);
+        verts[4].posH = cf_mul_m32_v2(mvp, chunk->verts[1]);
+        verts[5].posH = cf_mul_m32_v2(mvp, chunk->verts[3]);
+        
+        verts[0].uv = chunk->uvs[0];
+        verts[1].uv = chunk->uvs[1];
+        verts[2].uv = chunk->uvs[2];
+        verts[3].uv = chunk->uvs[2];
+        verts[4].uv = chunk->uvs[1];
+        verts[5].uv = chunk->uvs[3];
+        
+        verts[0].aa = false;
+        verts[1].aa = false;
+        verts[2].aa = false;
+        verts[3].aa = false;
+        verts[4].aa = false;
+        verts[5].aa = false;
+        
+        verts[0].alpha = chunk->opacity;
+        verts[1].alpha = chunk->opacity;
+        verts[2].alpha = chunk->opacity;
+        verts[3].alpha = chunk->opacity;
+        verts[4].alpha = chunk->opacity;
+        verts[5].alpha = chunk->opacity;
+        
+        verts[0].color = chunk->color;
+        verts[1].color = chunk->color;
+        verts[2].color = chunk->color;
+        verts[3].color = chunk->color;
+        verts[4].color = chunk->color;
+        verts[5].color = chunk->color;
+        
+        cf_array_push(draw.verts, verts[0]);
+        cf_array_push(draw.verts, verts[1]);
+        cf_array_push(draw.verts, verts[2]);
+        cf_array_push(draw.verts, verts[3]);
+        cf_array_push(draw.verts, verts[4]);
+        cf_array_push(draw.verts, verts[5]);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int w = 640;
+    int h = 480;
+    
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
+	CF_Result result = cf_make_app("Sprite Shatter", 0, 0, 0, w, h, options, argv[0]);
+	if (cf_is_error(result)) return -1;
+    
+    // need to know the atlas size otherwise without smooth_uv() the sprites will look blurry
+    int atlas_w = 2048;
+    int atlas_h = 2048;
+    CF_V2 atlas_dims = cf_v2((float)atlas_w, (float)atlas_h);
+    cf_draw_set_atlas_dimensions(atlas_w, atlas_h);
+    
+    cf_make_font_from_memory(proggy_data, proggy_sz, "ProggyClean");
+    init(w, h);
+    
+    CF_V2 normal_position = cf_v2(-100, 0);
+    CF_V2 shatter_position = cf_v2(100, 0);
+    
+    CF_Sprite demo_sprite = cf_make_demo_sprite();
+    cf_sprite_play(&demo_sprite, "spin");
+    int frame_count = cf_array_count(demo_sprite.animation->frames);
+    demo_sprite.scale = cf_v2(4, 4);
+    
+    CF_Canvas app_canvas = cf_app_get_canvas();
+    
+    dyna SpriteChunk* chunks = NULL;
+    cf_array_fit(chunks, 32);
+    
+	while (cf_app_is_running())
+	{
+		cf_app_update(NULL);
+        
+        cf_array_clear(draw.verts);
+        
+        if (cf_key_just_pressed(CF_KEY_R))
+        {
+            cf_sprite_reset(&demo_sprite);
+        }
+        if (cf_key_just_pressed(CF_KEY_SPACE))
+        {
+            cf_sprite_pause(&demo_sprite);
+            cf_array_clear(chunks);
+            shatter_sprite(&demo_sprite, 4, chunks);
+        }
+        
+        cf_sprite_update(&demo_sprite);
+        update_sprite_chunks(chunks);
+        
+        // normal
+        {
+            demo_sprite.transform.p = normal_position;
+            cf_draw_sprite(&demo_sprite);
+        }
+        
+        // shattered
+        {
+            if (demo_sprite.paused)
+            {
+                draw_sprite_chunks(chunks);
+                
+                CF_TemporaryImage image = cf_fetch_image(&demo_sprite);
+                
+                cf_apply_canvas(app_canvas, true);
+                cf_draw_push_shader(draw.shader);
+                
+                // still relying on base shader so need to setup `u_image` and `u_texture_size`
+                // TODO: you might have more than 1 texture so this would cause
+                //       you to get bad sampling if you have a lot of sprites
+                cf_material_set_texture_fs(draw.material, "u_image", image.tex);
+                cf_material_set_uniform_fs(draw.material, "u_texture_size", &atlas_dims, CF_UNIFORM_TYPE_FLOAT2, 1);
+                
+                cf_mesh_update_vertex_data(draw.mesh, draw.verts, cf_array_count(draw.verts));
+                cf_apply_mesh(draw.mesh);
+                
+                cf_apply_shader(draw.shader, draw.material);
+                cf_draw_elements();
+                
+                cf_draw_pop_shader();
+            }
+            else
+            {
+                demo_sprite.transform.p = shatter_position;
+                cf_draw_sprite(&demo_sprite);
+                cf_render_to(app_canvas, true);
+            }
+        }
+        
+        const char* text = "Press SPACE to shatter Sprite\nR to reset";
+        
+        cf_push_font("ProggyClean");
+        cf_push_font_size(26.0f);
+        CF_V2 text_size = cf_text_size(text, -1);
+        cf_draw_text(text, cf_v2(-text_size.x * 0.5f, h * -0.25f), -1);
+        cf_pop_font_size();
+        cf_pop_font();
+        
+        cf_app_draw_onto_screen(false);
+    }
+    
+    cf_destroy_app();
+    return 0;
+}

--- a/samples/sprite_slice.cpp
+++ b/samples/sprite_slice.cpp
@@ -4,7 +4,7 @@
 #define STR(X) #X
 
 const char* shader_str = STR(
-    vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
+vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
 {
     return texture(u_image, smooth_uv(v_uv, u_texture_size));
 }

--- a/samples/sprite_slice.cpp
+++ b/samples/sprite_slice.cpp
@@ -130,7 +130,7 @@ void slice_sprite(CF_Sprite* sprite, CF_V2 start, CF_V2 end, SpriteChunk* chunks
     CF_Ray ray;
     ray.p = start;
     ray.d = cf_sub_v2(end, start);
-    ray.d = cf_norm(ray.d);
+    ray.d = cf_safe_norm(ray.d);
     ray.t = cf_distance(end, start);
     
     CF_Raycast hit_result = cf_ray_to_aabb(ray, aabb);

--- a/samples/sprite_slice.cpp
+++ b/samples/sprite_slice.cpp
@@ -133,37 +133,40 @@ void slice_sprite(CF_Sprite* sprite, CF_V2 start, CF_V2 end, SpriteChunk* chunks
     ray.d = cf_safe_norm(ray.d);
     ray.t = cf_distance(end, start);
     
-    CF_Raycast hit_result = cf_ray_to_aabb(ray, aabb);
-    if (hit_result.hit)
+    if (ray.t > 0)
     {
-        cf_array_clear(chunks);
+        CF_Raycast hit_result = cf_ray_to_aabb(ray, aabb);
+        if (hit_result.hit)
+        {
+            cf_array_clear(chunks);
         
-        CF_V2 hit_point = cf_mul_v2_f(ray.d, hit_result.t);
-        hit_point = cf_add_v2(start, hit_point);
+            CF_V2 hit_point = cf_mul_v2_f(ray.d, hit_result.t);
+            hit_point = cf_add_v2(start, hit_point);
         
-        CF_Poly sprite_poly;
-        sprite_poly.verts[0] = sprite_min;
-        sprite_poly.verts[1] = cf_v2(sprite_min.x, sprite_max.y);
-        sprite_poly.verts[2] = cf_v2(sprite_max.x, sprite_min.y);
-        sprite_poly.verts[3] = sprite_max;
-        sprite_poly.count = 4;
-        cf_make_poly(&sprite_poly);
+            CF_Poly sprite_poly;
+            sprite_poly.verts[0] = sprite_min;
+            sprite_poly.verts[1] = cf_v2(sprite_min.x, sprite_max.y);
+            sprite_poly.verts[2] = cf_v2(sprite_max.x, sprite_min.y);
+            sprite_poly.verts[3] = sprite_max;
+            sprite_poly.count = 4;
+            cf_make_poly(&sprite_poly);
         
-        const float epsilon = (float)1e-4;
-        CF_V2 n = cf_perp(ray.d);
+            const float epsilon = (float)1e-4;
+            CF_V2 n = cf_perp(ray.d);
         
-        CF_Halfspace slice_plane = cf_plane2(n, hit_point);
-        CF_SliceOutput output = cf_slice(slice_plane, sprite_poly, epsilon);
+            CF_Halfspace slice_plane = cf_plane2(n, hit_point);
+            CF_SliceOutput output = cf_slice(slice_plane, sprite_poly, epsilon);
         
-        SpriteChunk chunk = {};
-        chunk.opacity = (uint8_t)(sprite->opacity * 255.0f);
-        chunk.color = color;
+            SpriteChunk chunk = {};
+            chunk.opacity = (uint8_t)(sprite->opacity * 255.0f);
+            chunk.color = color;
         
-        set_sprite_chunk(&chunk, &output.front, sprite, push_strength);
-        cf_array_push(chunks, chunk);
+            set_sprite_chunk(&chunk, &output.front, sprite, push_strength);
+            cf_array_push(chunks, chunk);
         
-        set_sprite_chunk(&chunk, &output.back, sprite, push_strength);
-        cf_array_push(chunks, chunk);
+            set_sprite_chunk(&chunk, &output.back, sprite, push_strength);
+            cf_array_push(chunks, chunk);
+        }
     }
 }
 

--- a/samples/sprite_slice.cpp
+++ b/samples/sprite_slice.cpp
@@ -1,0 +1,346 @@
+#include <cute.h>
+#include "proggy.h"
+
+#define STR(X) #X
+
+const char* shader_str = STR(
+    vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
+{
+    return texture(u_image, smooth_uv(v_uv, u_texture_size));
+}
+);
+
+struct
+{
+    CF_Shader shader;
+    CF_Material material;
+    CF_Mesh mesh;
+    CF_M3x2 projection;
+    CF_Vertex* verts;
+} draw;
+
+struct SpriteChunk
+{
+    CF_Poly poly;
+    CF_V2 uvs[8];
+    CF_V2 velocity;
+    uint8_t opacity;
+    CF_Pixel color;
+};
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset);
+void init(int w, int h);
+void set_sprite_chunk(SpriteChunk* chunk, CF_Poly* poly, CF_Sprite* sprite, float push_strength);
+void slice_sprite(CF_Sprite* sprite, CF_V2 start, CF_V2 end, SpriteChunk* chunks);
+void update_sprite_chunks(SpriteChunk* chunks);
+void draw_sprite_chunks(SpriteChunk* chunks);
+
+void add_vertex_attribute(CF_VertexAttribute* attrs, const char* name, CF_VertexFormat format, int offset)
+{
+    CF_VertexAttribute vert = {};
+    vert.name = name;
+    vert.format = format;
+    vert.offset = offset;
+    
+    cf_array_push(attrs, vert);
+}
+
+void init(int w, int h)
+{
+    draw.shader = cf_make_draw_shader_from_source(shader_str);
+    draw.material = cf_make_material();
+    
+	CF_VertexAttribute* attrs = NULL;
+    cf_array_fit(attrs, 32);
+    
+    add_vertex_attribute(attrs, "in_pos", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, p));
+    add_vertex_attribute(attrs, "in_posH", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, posH));
+    add_vertex_attribute(attrs, "in_n", CF_VERTEX_FORMAT_INT, CF_OFFSET_OF(CF_Vertex, n));
+    add_vertex_attribute(attrs, "in_ab", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[0]));
+    add_vertex_attribute(attrs, "in_cd", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[2]));
+    add_vertex_attribute(attrs, "in_ef", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[4]));
+    add_vertex_attribute(attrs, "in_gh", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, shape[6]));
+    add_vertex_attribute(attrs, "in_uv", CF_VERTEX_FORMAT_FLOAT2, CF_OFFSET_OF(CF_Vertex, uv));
+	add_vertex_attribute(attrs, "in_col", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, color));
+	add_vertex_attribute(attrs, "in_radius", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, radius));
+	add_vertex_attribute(attrs, "in_stroke", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, stroke));
+	add_vertex_attribute(attrs, "in_aa", CF_VERTEX_FORMAT_FLOAT, CF_OFFSET_OF(CF_Vertex, aa));
+    add_vertex_attribute(attrs, "in_params", CF_VERTEX_FORMAT_UBYTE4_NORM, CF_OFFSET_OF(CF_Vertex, type));
+    add_vertex_attribute(attrs, "in_user_params", CF_VERTEX_FORMAT_FLOAT4, CF_OFFSET_OF(CF_Vertex, attributes));
+    draw.mesh = cf_make_mesh(CF_MB * 5, attrs, cf_array_count(attrs), sizeof(CF_Vertex));
+    
+    draw.verts = NULL;
+    cf_array_fit(draw.verts, 1024);
+    
+    draw.projection = cf_ortho_2d(0, 0, (float)w, (float)h);
+    cf_draw_projection(draw.projection);
+    
+    cf_array_free(attrs);
+}
+
+void set_sprite_chunk(SpriteChunk* chunk, CF_Poly* poly, CF_Sprite* sprite, float push_strength)
+{
+    CF_V2 sprite_top_left = sprite->transform.p;
+    float w = sprite->w * sprite->scale.x;
+    float h = sprite->h * sprite->scale.y;
+    sprite_top_left.x -= w * 0.5f;
+    sprite_top_left.y += h * 0.5f;
+    
+    CF_TemporaryImage temporary_image = cf_fetch_image(sprite);
+    CF_V2 u = cf_min_v2(temporary_image.v, temporary_image.u);
+    CF_V2 v = cf_max_v2(temporary_image.v, temporary_image.u);
+    CF_V2 duv = cf_sub_v2(v, u);
+    
+    chunk->poly = *poly;
+    for (int index = 0; index < chunk->poly.count; ++index)
+    {
+        CF_V2 uv = cf_sub_v2(sprite_top_left, chunk->poly.verts[index]);
+        uv.x = cf_abs(uv.x / w);
+        uv.y = cf_abs(uv.y / h);
+        uv = cf_mul_v2(uv, duv);
+        uv = cf_add_v2(u, uv);
+        
+        chunk->uvs[index] = uv;
+    }
+    
+    chunk->velocity = cf_center_of_mass(chunk->poly);
+    chunk->velocity = cf_sub_v2(chunk->velocity, sprite->transform.p);
+    chunk->velocity = cf_norm(chunk->velocity);
+    chunk->velocity = cf_mul_v2_f(chunk->velocity, push_strength);
+}
+
+void slice_sprite(CF_Sprite* sprite, CF_V2 start, CF_V2 end, SpriteChunk* chunks)
+{
+    CF_Pixel color = cf_color_to_pixel(cf_draw_peek_color());
+    
+    CF_V2 sprite_min = sprite->transform.p;
+    CF_V2 sprite_max = sprite_min;
+    float w = sprite->w * sprite->scale.x;
+    float h = sprite->h * sprite->scale.y;
+    
+    sprite_min.x -= w / 2;
+    sprite_min.y -= h / 2;
+    sprite_max.x += w / 2;
+    sprite_max.y += h / 2;
+    CF_Aabb aabb = cf_make_aabb(sprite_min, sprite_max);
+    CF_V2 sprite_top_left = cf_top_left(aabb);
+    
+    float push_strength = 10.0f;
+    
+    CF_Ray ray;
+    ray.p = start;
+    ray.d = cf_sub_v2(end, start);
+    ray.d = cf_norm(ray.d);
+    ray.t = cf_distance(end, start);
+    
+    CF_Raycast hit_result = cf_ray_to_aabb(ray, aabb);
+    if (hit_result.hit)
+    {
+        cf_array_clear(chunks);
+        
+        CF_V2 hit_point = cf_mul_v2_f(ray.d, hit_result.t);
+        hit_point = cf_add_v2(start, hit_point);
+        
+        CF_Poly sprite_poly;
+        sprite_poly.verts[0] = sprite_min;
+        sprite_poly.verts[1] = cf_v2(sprite_min.x, sprite_max.y);
+        sprite_poly.verts[2] = cf_v2(sprite_max.x, sprite_min.y);
+        sprite_poly.verts[3] = sprite_max;
+        sprite_poly.count = 4;
+        cf_make_poly(&sprite_poly);
+        
+        const float epsilon = (float)1e-4;
+        CF_V2 n = cf_perp(ray.d);
+        
+        CF_Halfspace slice_plane = cf_plane2(n, hit_point);
+        CF_SliceOutput output = cf_slice(slice_plane, sprite_poly, epsilon);
+        
+        SpriteChunk chunk = {};
+        chunk.opacity = (uint8_t)(sprite->opacity * 255.0f);
+        chunk.color = color;
+        
+        set_sprite_chunk(&chunk, &output.front, sprite, push_strength);
+        cf_array_push(chunks, chunk);
+        
+        set_sprite_chunk(&chunk, &output.back, sprite, push_strength);
+        cf_array_push(chunks, chunk);
+    }
+}
+
+void update_sprite_chunks(SpriteChunk* chunks)
+{
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        SpriteChunk* chunk = chunks + index;
+        CF_V2 dp = cf_mul_v2_f(chunk->velocity, CF_DELTA_TIME);
+        
+        for (int vertex = 0; vertex < chunk->poly.count; ++vertex)
+        {
+            chunk->poly.verts[vertex] = cf_add_v2(chunk->poly.verts[vertex], dp);
+        }
+    }
+}
+
+void draw_sprite_chunks(SpriteChunk* chunks)
+{
+    CF_M3x2 mvp = cf_draw_peek();
+    mvp = cf_mul_m32(draw.projection, mvp);
+    CF_Vertex verts[8] = {};
+    
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        SpriteChunk* chunk = chunks + index;
+        
+        for (int vertex = 0; vertex < chunk->poly.count; ++vertex)
+        {
+            CF_Vertex* vert = verts + vertex;
+            vert->p = chunk->poly.verts[vertex];
+            vert->posH = cf_mul_m32_v2(mvp, vert->p);
+            vert->uv = chunk->uvs[vertex];
+            vert->aa = false;
+            vert->alpha = chunk->opacity;
+            vert->color = chunk->color;
+        }
+        
+        for (int vertex = 0; vertex < chunk->poly.count - 1; ++vertex)
+        {
+            cf_array_push(draw.verts, verts[0]);
+            cf_array_push(draw.verts, verts[vertex]);
+            cf_array_push(draw.verts, verts[vertex + 1]);
+        }
+    }
+    
+    for (int index = 0; index < cf_array_count(chunks); ++index)
+    {
+        SpriteChunk* chunk = chunks + index;
+        cf_draw_polyline(chunk->poly.verts, chunk->poly.count, 1.0f, true);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    int w = 640;
+    int h = 480;
+    
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
+	CF_Result result = cf_make_app("Sprite Slice", 0, 0, 0, w, h, options, argv[0]);
+	if (cf_is_error(result)) return -1;
+    
+    // need to know the atlas size otherwise without smooth_uv() the sprites will look blurry
+    int atlas_w = 2048;
+    int atlas_h = 2048;
+    CF_V2 atlas_dims = cf_v2((float)atlas_w, (float)atlas_h);
+    cf_draw_set_atlas_dimensions(atlas_w, atlas_h);
+    
+    cf_make_font_from_memory(proggy_data, proggy_sz, "ProggyClean");
+    init(w, h);
+    
+    CF_Sprite demo_sprite = cf_make_demo_sprite();
+    cf_sprite_play(&demo_sprite, "spin");
+    int frame_count = cf_array_count(demo_sprite.animation->frames);
+    demo_sprite.scale = cf_v2(8, 8);
+    
+    CF_Canvas app_canvas = cf_app_get_canvas();
+    
+    dyna SpriteChunk* chunks = NULL;
+    cf_array_fit(chunks, 8);
+    
+    CF_V2 slice_start = {};
+    CF_V2 slice_end = {};
+    
+	while (cf_app_is_running())
+	{
+		cf_app_update(NULL);
+        
+        cf_array_clear(draw.verts);
+        
+        // input
+        {
+            CF_V2 mouse = cf_v2(cf_mouse_x(), cf_mouse_y());
+            
+            if (cf_key_just_pressed(CF_KEY_R))
+            {
+                cf_array_clear(chunks);
+                cf_sprite_reset(&demo_sprite);
+            }
+            if(cf_mouse_just_pressed(CF_MOUSE_BUTTON_LEFT))
+            {
+                slice_start = cf_screen_to_world(mouse);
+                cf_sprite_pause(&demo_sprite);
+            }
+            if (cf_mouse_down(CF_MOUSE_BUTTON_LEFT))
+            {
+                slice_end = cf_screen_to_world(mouse);
+                cf_draw_line(slice_start, slice_end, 2.0f);
+            }
+            if (cf_mouse_just_released(CF_MOUSE_BUTTON_LEFT))
+            {
+                slice_sprite(&demo_sprite, slice_start, slice_end, chunks);
+                
+                if (cf_array_count(chunks) == 0)
+                {
+                    cf_sprite_unpause(&demo_sprite);
+                }
+            }
+        }
+        
+        cf_sprite_update(&demo_sprite);
+        update_sprite_chunks(chunks);
+        
+        if (cf_array_count(chunks))
+        {
+            draw_sprite_chunks(chunks);
+            
+            CF_TemporaryImage image = cf_fetch_image(&demo_sprite);
+            
+            cf_apply_canvas(app_canvas, true);
+            cf_draw_push_shader(draw.shader);
+            
+            // still relying on base shader so need to setup `u_image` and `u_texture_size`
+            // TODO: you might have more than 1 texture so this would cause
+            //       you to get bad sampling if you have a lot of sprites
+            cf_material_set_texture_fs(draw.material, "u_image", image.tex);
+            cf_material_set_uniform_fs(draw.material, "u_texture_size", &atlas_dims, CF_UNIFORM_TYPE_FLOAT2, 1);
+            
+            cf_mesh_update_vertex_data(draw.mesh, draw.verts, cf_array_count(draw.verts));
+            cf_apply_mesh(draw.mesh);
+            
+            cf_apply_shader(draw.shader, draw.material);
+            cf_draw_elements();
+            
+            cf_draw_pop_shader();
+        }
+        else
+        {
+            CF_V2 sprite_min = demo_sprite.transform.p;
+            CF_V2 sprite_max = sprite_min;
+            float w = demo_sprite.w * demo_sprite.scale.x;
+            float h = demo_sprite.h * demo_sprite.scale.y;
+            
+            sprite_min.x -= w / 2;
+            sprite_min.y -= h / 2;
+            sprite_max.x += w / 2;
+            sprite_max.y += h / 2;
+            CF_Aabb aabb = cf_make_aabb(sprite_min, sprite_max);
+            
+            cf_draw_box(aabb, 1.0f, 0.0f);
+            
+            cf_draw_sprite(&demo_sprite);
+            cf_render_to(app_canvas, true);
+        }
+        
+        const char* text = "Press Left Click to start to slice\nR to reset";
+        
+        cf_push_font("ProggyClean");
+        cf_push_font_size(26.0f);
+        CF_V2 text_size = cf_text_size(text, -1);
+        cf_draw_text(text, cf_v2(-text_size.x * 0.5f, h * -0.25f), -1);
+        cf_pop_font_size();
+        cf_pop_font();
+        
+        cf_app_draw_onto_screen(false);
+    }
+    
+    cf_destroy_app();
+    return 0;
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/1a5bd8b8-8129-4d81-8f42-29b5c565095b


https://github.com/user-attachments/assets/19b0428c-6137-415d-9e94-73ff11174616


https://github.com/user-attachments/assets/4ce4c8ae-6b78-4b8b-b76c-521d168c3070

I needed the sprite shatter for my own project but it was pretty small so it looked like a good sample. Slicing and screen shatter is there just for fun.

There is a tiny error at startup that doesn't cause any issues with the tiny sampling shader?
```
vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
{
    return texture(u_image, smooth_uv(v_uv, u_texture_size));
}
```

```
Parsing failed
ERROR: shader_stub.shd:1: 'u_texture_size' : undeclared identifier
ERROR: shader_stub.shd:1: 'smooth_uv' : no matching overloaded function found
ERROR: shader_stub.shd:1: '' : compilation terminated
ERROR: 3 compilation errors.  No code generated.
```