### PR TITLE
CMake: Output all libraries to the same directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           robocopy include dist *.h
           robocopy build_folder\Release\lib dist cute.lib 
-          robocopy build_folder\lib dist libcute.a
+          robocopy build_folder\lib dist libcute*.a
           7z a ${{ matrix.platform.artifact }}.zip .\dist\*
         if: runner.os == 'Windows'
 
@@ -113,7 +113,7 @@ jobs:
         run: |
           mkdir -p ./dist
           cp -v ./include/*.h ./dist
-          cp -R -v ./build_folder/lib/libcute.a ./dist
+          cp -R -v ./build_folder/lib/libcute*.a ./dist
           tar -czvf ${{ matrix.platform.artifact }}.tar.gz -C dist .
         if: runner.os == 'macOS'
 
@@ -121,7 +121,7 @@ jobs:
         run: |
           mkdir -p ./dist
           cp -v ./include/*.h ./dist
-          cp -v ./build_folder/lib/libcute.a ./dist
+          cp -v ./build_folder/lib/libcute*.a ./dist
           tar -czvf ${{ matrix.platform.artifact }}.tar.gz -C dist .
         if: runner.os == 'Linux'
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,8 +104,8 @@ jobs:
         shell: cmd
         run: |
           robocopy include dist *.h
-          robocopy build_folder\Release dist cute.lib 
-          robocopy build_folder dist libcute.a
+          robocopy build_folder\Release\lib dist cute.lib 
+          robocopy build_folder\lib dist libcute.a
           7z a ${{ matrix.platform.artifact }}.zip .\dist\*
         if: runner.os == 'Windows'
 
@@ -113,7 +113,7 @@ jobs:
         run: |
           mkdir -p ./dist
           cp -v ./include/*.h ./dist
-          cp -R -v ./build_folder/libcute.a ./dist
+          cp -R -v ./build_folder/lib/libcute.a ./dist
           tar -czvf ${{ matrix.platform.artifact }}.tar.gz -C dist .
         if: runner.os == 'macOS'
 
@@ -121,7 +121,7 @@ jobs:
         run: |
           mkdir -p ./dist
           cp -v ./include/*.h ./dist
-          cp -v ./build_folder/libcute.a ./dist
+          cp -v ./build_folder/lib/libcute.a ./dist
           tar -czvf ${{ matrix.platform.artifact }}.tar.gz -C dist .
         if: runner.os == 'Linux'
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
         shell: cmd
         run: |
           robocopy include dist *.h
-          robocopy build_folder\Release\lib dist cute.lib 
+          robocopy build_folder\Release\lib dist cute*.lib 
           robocopy build_folder\lib dist libcute*.a
           7z a ${{ matrix.platform.artifact }}.zip .\dist\*
         if: runner.os == 'Windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ option(CF_RUNTIME_SHADER_COMPILATION "Build CF with online shader compilation su
 option(CF_CUTE_SHADERC "Build cute-shaderc, an offline shader compiler (requires python 3.x installation)." ON)
 option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
 
+# Make sure all libraries are placed into the same output folder.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
 # Platform detection.
 if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
 	set(EMSCRIPTEN TRUE)


### PR DESCRIPTION
Rather than having all the libraries spread across all the dependency directories, this setting enforces one unified place where all the static and dynamic libraries are generated to.

This simplifies the task of finding the dynamic ones, and/or linking against when not using CMake as the build tool in the actual app.

```
🍔 ls build/lib
libcute-shader.a                      libSDL3.a              libSPIRV-Tools-lint.a
libcute.a                             libSDL3.dylib          libSPIRV-Tools-opt.a
libGenericCodeGen.a                   libSDL_uclibc.a        libSPIRV-Tools-reduce.a
libglslang-default-resource-limits.a  libspirv-cross-c.a     libSPIRV-Tools-shared.dylib
libglslang.a                          libspirv-cross-core.a  libSPIRV-Tools.a
libMachineIndependent.a               libspirv-cross-glsl.a  libSPIRV.a
libOSDependent.a                      libspirv-cross-msl.a   libSPVRemapper.a
libphysfs.a                           libSPIRV-Tools-diff.a
libSDL3.0.dylib                       libSPIRV-Tools-link.a
```

@RandyGaul Do we want to add the libcute-shader.a to the dist?