### PR TITLE
fixed cute_thread_id() returning 0

### DIFF
--- a/libraries/cute/cute_sync.h
+++ b/libraries/cute/cute_sync.h
@@ -609,7 +609,7 @@ cute_thread_id_t cute_thread_get_id(cute_thread_t* thread)
 
 cute_thread_id_t cute_thread_id()
 {
-	return SDL_ThreadID();
+	return SDL_GetCurrentThreadID();
 }
 
 int cute_thread_wait(cute_thread_t* thread)


### PR DESCRIPTION
SDL3 SDL_ThreadID() was returning 0 while  SDL_GetCurrentThreadID() was giving proper thread id