### PR TITLE
Cute color scheme

### DIFF
--- a/docs/stylesheets/cute.css
+++ b/docs/stylesheets/cute.css
@@ -1,0 +1,91 @@
+:root > * {
+  /* #fea3a8 */
+  --cute-primary-hue: 357;
+  --cute-primary-saturation: 98%;
+  --cute-primary-light: 82%;
+
+  /* #530004 */
+  --cute-primary-saturation--dark: 100%;
+  --cute-primary-light--dark: 16%;
+
+  /* #96dec6 */
+  --cute-accent-hue: 160;
+  --cute-accent-saturation: 52%;
+  --cute-accent-light: 73%;
+}
+
+[data-md-color-scheme="cute"] {
+  --md-primary-fg-color: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    var(--cute-primary-light),
+    1
+  );
+  --md-primary-fg-color--light: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    calc(var(--cute-primary-light) + 10%),
+    1
+  );
+  --md-primary-fg-color--dark: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    calc(var(--cute-primary-light) - 10%),
+    1
+  );
+
+  --md-accent-fg-color: hsla(
+    var(--cute-accent-hue),
+    var(--cute-accent-saturation),
+    calc(var(--cute-accent-light) - 10%),
+    1
+  );
+  --md-accent-fg-color--transparent: hsla(
+    var(--cute-accent-hue),
+    var(--cute-accent-saturation),
+    var(--cute-accent-light),
+    0.1
+  );
+
+  --md-typeset-a-color: var(--md-primary-fg-color--dark);
+}
+
+[data-md-color-primary="cute"] {
+  --md-primary-fg-color: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    var(--cute-primary-light),
+    1
+  );
+  --md-primary-fg-color--light: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    calc(var(--cute-primary-light) + 10%),
+    1
+  );
+  --md-primary-fg-color--dark: hsla(
+    var(--cute-primary-hue),
+    var(--cute-primary-saturation),
+    calc(var(--cute-primary-light) - 10%),
+    1
+  );
+}
+
+[data-md-color-accent="cute"] {
+  --md-accent-fg-color: hsla(
+    var(--cute-accent-hue),
+    var(--cute-accent-saturation),
+    var(--cute-accent-light),
+    1
+  );
+  --md-accent-fg-color--transparent: hsla(
+    var(--cute-accent-hue),
+    var(--cute-accent-saturation),
+    var(--cute-accent-light),
+    0.1
+  );
+}
+
+[data-md-color-scheme="slate"] {
+  --md-hue: var(--cute-primary-hue);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,23 +19,25 @@ theme:
     - content.code.copy
   palette:
     - media: "(prefers-color-scheme)"
+      scheme: cute
       toggle:
         icon: material/link
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: red
-      accent: red
+      scheme: cute
       toggle:
         icon: material/toggle-switch
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: red
-      accent: red
+      primary: cute
+      accent: cute
       toggle:
         icon: material/toggle-switch-off
         name: Switch to system preference
+
+extra_css:
+  - stylesheets/cute.css
 
 # Navigation
 not_in_nav: |


### PR DESCRIPTION
This PR sets up the Cute color scheme taken from the logo.

<img width="5953" height="892" alt="CF_Banner_Hifi" src="https://github.com/user-attachments/assets/5fbf330a-1ad8-4e91-bb48-eca783db6dc3" />

Pink for the currently active page color and header, green for the hover effect:


https://github.com/user-attachments/assets/2e309afe-d0d9-4ee0-b562-6689e9f6bac3

