### PR TITLE
Add copyright notice

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ site_description: >-
 repo_url: https://github.com/RandyGaul/cute_framework
 repo_name: RandyGaul/cute_framework
 
+# Copyright
+copyright: Copyright &copy; 2019—2025 Randy Gaul
+
 # Configuration
 theme:
   name: material


### PR DESCRIPTION
This PR adds the copyright notice to the footer:

<img width="360" height="89" alt="image" src="https://github.com/user-attachments/assets/d77d6fbc-c8fd-4bd5-965e-6cc405a58650" />
