### PR TITLE
Fix imgui image

### DIFF
--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -624,13 +624,13 @@ CF_API void CF_CALL cf_generate_mipmaps(CF_Texture texture);
 CF_API uint64_t CF_CALL cf_texture_handle(CF_Texture texture);
 
 /**
- * @function cf_binding_handle
+ * @function cf_texture_binding_handle
  * @category graphics
  * @brief    Returns an SDL_GPUTextureSamplerBinding* casted to a `uint64_t`.
  * @remarks  This is useful for e.g. rendering textures in an external system like Dear ImGui.
  * @related  CF_TextureParams CF_Texture cf_make_texture
  */
-CF_API uint64_t CF_CALL cf_binding_handle(CF_Texture texture);
+CF_API uint64_t CF_CALL cf_texture_binding_handle(CF_Texture texture);
 
 //--------------------------------------------------------------------------------------------------
 // Shader.

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -623,6 +623,15 @@ CF_API void CF_CALL cf_generate_mipmaps(CF_Texture texture);
  */
 CF_API uint64_t CF_CALL cf_texture_handle(CF_Texture texture);
 
+/**
+ * @function cf_binding_handle
+ * @category graphics
+ * @brief    Returns an SDL_GPUTextureSamplerBinding* casted to a `uint64_t`.
+ * @remarks  This is useful for e.g. rendering textures in an external system like Dear ImGui.
+ * @related  CF_TextureParams CF_Texture cf_make_texture
+ */
+CF_API uint64_t CF_CALL cf_binding_handle(CF_Texture texture);
+
 //--------------------------------------------------------------------------------------------------
 // Shader.
 

--- a/samples/fetch_image.cpp
+++ b/samples/fetch_image.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char *argv[])
 {
-	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT | CF_APP_OPTIONS_GFX_DEBUG_BIT;
 	CF_Result result = cf_make_app("cute imgui image test", 0, 0, 0, 640, 480, options, argv[0]);
 	if (cf_is_error(result)) return -1;
 	
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 		{
 			CF_TemporaryImage image = cf_fetch_image(&sprite);
 
-			ImTextureID id = (ImTextureID)cf_texture_handle(image.tex);
+			ImTextureID id = (ImTextureID)cf_binding_handle(image.tex);
 			ImVec2 size = { (float)image.w * 5.0f, (float)image.h * 5.0f };
 			// y is flipped
 			ImVec2 uv0 = { image.u.x, image.v.y };

--- a/samples/fetch_image.cpp
+++ b/samples/fetch_image.cpp
@@ -5,7 +5,7 @@
 
 int main(int argc, char *argv[])
 {
-	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT | CF_APP_OPTIONS_GFX_DEBUG_BIT;
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
 	CF_Result result = cf_make_app("cute imgui image test", 0, 0, 0, 640, 480, options, argv[0]);
 	if (cf_is_error(result)) return -1;
 	

--- a/samples/fetch_image.cpp
+++ b/samples/fetch_image.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 		{
 			CF_TemporaryImage image = cf_fetch_image(&sprite);
 
-			ImTextureID id = (ImTextureID)cf_binding_handle(image.tex);
+			ImTextureID id = (ImTextureID)cf_texture_binding_handle(image.tex);
 			ImVec2 size = { (float)image.w * 5.0f, (float)image.h * 5.0f };
 			// y is flipped
 			ImVec2 uv0 = { image.u.x, image.v.y };

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2819,7 +2819,7 @@ static void s_process_command(CF_Canvas canvas, CF_Command* cmd, CF_Command* nex
 		// Process the collated drawable items. Might get split up into multiple draw calls depending on
 		// the atlas compiler.
 		draw->need_flush = false;
-		spritebatch_defrag(&draw->sb);
+		//spritebatch_defrag(&draw->sb);
 		spritebatch_flush(&draw->sb);
 	}
 }
@@ -2854,7 +2854,7 @@ void cf_render_layers_to(CF_Canvas canvas, int layer_lo, int layer_hi, bool clea
 	}
 	if (draw->need_flush) {
 		draw->need_flush = false;
-		spritebatch_defrag(&draw->sb);
+		//spritebatch_defrag(&draw->sb);
 		spritebatch_flush(&draw->sb);
 	}
 	draw->has_drawn_something = false;

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2819,7 +2819,9 @@ static void s_process_command(CF_Canvas canvas, CF_Command* cmd, CF_Command* nex
 		// Process the collated drawable items. Might get split up into multiple draw calls depending on
 		// the atlas compiler.
 		draw->need_flush = false;
-		//spritebatch_defrag(&draw->sb);
+		if (!draw->delay_defrag) {
+			spritebatch_defrag(&draw->sb);
+		}
 		spritebatch_flush(&draw->sb);
 	}
 }
@@ -2854,7 +2856,9 @@ void cf_render_layers_to(CF_Canvas canvas, int layer_lo, int layer_hi, bool clea
 	}
 	if (draw->need_flush) {
 		draw->need_flush = false;
-		//spritebatch_defrag(&draw->sb);
+		if (!draw->delay_defrag) {
+			spritebatch_defrag(&draw->sb);
+		}
 		spritebatch_flush(&draw->sb);
 	}
 	draw->has_drawn_something = false;

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -195,6 +195,8 @@ static CF_Texture s_make_texture(CF_TextureParams params, CF_SampleCount sample_
 	tex_internal->buf = buf;
 	tex_internal->sampler = sampler;
 	tex_internal->format = tex_info.format;
+	tex_internal->binding.texture = tex;
+	tex_internal->binding.sampler = sampler;
 	CF_Texture result;
 	result.id = (uint64_t)(uintptr_t)tex_internal;
 	return result;
@@ -307,6 +309,11 @@ void cf_generate_mipmaps(CF_Texture texture_handle)
 uint64_t cf_texture_handle(CF_Texture texture)
 {
 	return (uint64_t)((CF_TextureInternal*)texture.id)->tex;
+}
+
+uint64_t cf_binding_handle(CF_Texture texture)
+{
+	return (uint64_t)&((CF_TextureInternal*)texture.id)->binding;
 }
 
 static void s_shader_directory_recursive(CF_Path path)

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -311,7 +311,7 @@ uint64_t cf_texture_handle(CF_Texture texture)
 	return (uint64_t)((CF_TextureInternal*)texture.id)->tex;
 }
 
-uint64_t cf_binding_handle(CF_Texture texture)
+uint64_t cf_texture_binding_handle(CF_Texture texture)
 {
 	return (uint64_t)&((CF_TextureInternal*)texture.id)->binding;
 }

--- a/src/internal/cute_graphics_internal.h
+++ b/src/internal/cute_graphics_internal.h
@@ -54,6 +54,7 @@ struct CF_TextureInternal
 	SDL_GPUTransferBuffer* buf;
 	SDL_GPUSampler* sampler;
 	SDL_GPUTextureFormat format;
+	SDL_GPUTextureSamplerBinding binding;
 };
 
 CF_INLINE SDL_GPUSamplerCreateInfo SDL_GPUSamplerCreateInfoDefaults()


### PR DESCRIPTION
Imgui SDL_GPU backend wants `SDL_GPUTextureSamplerBinding` instead of `SDL_GPUTexture` 
Spritebatcher was defragging during `cf_render_*_to()` so texture was being thrashed before imgui was able to send anything to SDL_GPU