### PR TITLE
Cmake project settings version configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ site/
 cute_framework.zip
 github_release
 imgui.ini
+src/cute_version.cpp
+include/cute_version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.14)
-project(cute_framework)
+project(cute_framework
+	DESCRIPTION "The cutest framework out there for creating 2D games in C++!"
+	LANGUAGES C CXX
+	VERSION 1.1.0
+)
 
 # Must have at least C++20.
 set(CMAKE_CXX_STANDARD 20)
@@ -429,12 +433,12 @@ elseif(APPLE)
 		set_target_properties(cute PROPERTIES FRAMEWORK TRUE)
 		if (CF_FRAMEWORK_STATIC)
 		set_target_properties(cute PROPERTIES
-			FRAMEWORK_VERSION "1.0.0"
+			FRAMEWORK_VERSION "${PROJECT_VERSION}"
 			MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.static"
 		)
 		else()
 		set_target_properties(cute PROPERTIES
-			FRAMEWORK_VERSION "1.0.0"
+			FRAMEWORK_VERSION "${PROJECT_VERSION}"
 			MACOSX_FRAMEWORK_IDENTIFIER "com.cuteframework.shared"
 		)
 		endif()
@@ -581,8 +585,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 			if (APPLE)
 				set_target_properties(${CURRENT_TARGET} PROPERTIES
 					MACOSX_BUNDLE_GUI_IDENTIFIER "com.cuteframework.${CURRENT_TARGET}"
-					MACOSX_BUNDLE_BUNDLE_VERSION "1.0.0"
-					MACOSX_BUNDLE_SHORT_VERSION_STRING "1.0.0"
+					MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}"
+					MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_VERSION}"
 				)
 			endif()
 			set_target_properties(${CURRENT_TARGET} PROPERTIES FOLDER "samples")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(cute_framework
 	DESCRIPTION "The cutest framework out there for creating 2D games in C++!"
+	HOMEPAGE_URL "https://github.com/RandyGaul/cute_framework"
 	LANGUAGES C CXX
 	VERSION 1.1.0
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,17 @@ if(CF_FRAMEWORK_WITH_HTTPS MATCHES OFF)
 endif()
 
 add_definitions("-DIMGUI_USER_CONFIG=\"cimgui/cimconfig.h\"")
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/cute_version.h.in"
+	"${CMAKE_CURRENT_SOURCE_DIR}/include/cute_version.h"
+	@ONLY
+)
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/cute_version.cpp.in"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/cute_version.cpp"
+	@ONLY
+)
+
 
 # Common directories for compiler/linker path.
 include_directories(src libraries test)

--- a/include/cute_version.h.in
+++ b/include/cute_version.h.in
@@ -13,7 +13,7 @@
 //--------------------------------------------------------------------------------------------------
 // C API
 
-#define CF_VERSION_STRING_COMPILED "Cute Framework Version 1.1.0"
+#define CF_VERSION_STRING_COMPILED "Cute Framework Version @PROJECT_VERSION@"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/cute_version.cpp.in
+++ b/src/cute_version.cpp.in
@@ -9,5 +9,5 @@
 
 const char* cf_version_string_linked()
 {
-	return "Cute Framework Version 1.1.0";
+	return "Cute Framework Version @PROJECT_VERSION@";
 }


### PR DESCRIPTION
This PR configures the version source files as templates so that the version number can be injected from the CMake's project version.

Requires https://github.com/RandyGaul/cute_framework/pull/313