### PR TITLE
Use `(void)` for nullary functions

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -59,7 +59,7 @@ typedef uint32_t CF_DisplayID;
  * @brief    TODO
  * @related  TODO
  */
-CF_API CF_DisplayID CF_CALL cf_default_display();
+CF_API CF_DisplayID CF_CALL cf_default_display(void);
 
 /**
  * @function cf_display_count
@@ -68,7 +68,7 @@ CF_API CF_DisplayID CF_CALL cf_default_display();
  * @remarks  Inidices >= 0 and < the return value are valid display indices.
  * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
  */
-CF_API int CF_CALL cf_display_count();
+CF_API int CF_CALL cf_display_count(void);
 
 /**
  * @function cf_get_display_list
@@ -76,7 +76,7 @@ CF_API int CF_CALL cf_display_count();
  * @brief    TODO
  * @related  TODO
  */
-CF_API CF_DisplayID* CF_CALL cf_get_display_list();
+CF_API CF_DisplayID* CF_CALL cf_get_display_list(void);
 
 /**
  * @function cf_free_display_list
@@ -258,7 +258,7 @@ CF_API CF_Result CF_CALL cf_make_app(const char* window_title, CF_DisplayID disp
  * @brief    Cleans up all resources used by the application. Call `cf_app_signal_shutdown` first.
  * @related  cf_make_app cf_app_is_running cf_app_signal_shutdown
  */
-CF_API void CF_CALL cf_destroy_app();
+CF_API void CF_CALL cf_destroy_app(void);
 
 /**
  * @function cf_app_is_running
@@ -290,7 +290,7 @@ CF_API void CF_CALL cf_destroy_app();
  *           to signal a shutdown.
  * @related  cf_make_app cf_destroy_app cf_app_signal_shutdown
  */
-CF_API bool CF_CALL cf_app_is_running();
+CF_API bool CF_CALL cf_app_is_running(void);
 
 /**
  * @function cf_app_signal_shutdown
@@ -322,7 +322,7 @@ CF_API bool CF_CALL cf_app_is_running();
  *     }
  * @related  cf_make_app cf_destroy_app cf_app_is_running
  */
-CF_API void CF_CALL cf_app_signal_shutdown();
+CF_API void CF_CALL cf_app_signal_shutdown(void);
 
 /**
  * @function cf_app_update
@@ -379,7 +379,7 @@ CF_API void CF_CALL cf_app_get_size(int* w, int* h);
  * @brief    Returns the size of the window width in pixels.
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
-CF_API int CF_CALL cf_app_get_width();
+CF_API int CF_CALL cf_app_get_width(void);
 
 /**
  * @function cf_app_get_height
@@ -387,7 +387,7 @@ CF_API int CF_CALL cf_app_get_width();
  * @brief    Returns the size of the window height in pixels.
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
-CF_API int CF_CALL cf_app_get_height();
+CF_API int CF_CALL cf_app_get_height(void);
 
 /**
  * @function cf_app_show_window
@@ -395,7 +395,7 @@ CF_API int CF_CALL cf_app_get_height();
  * @brief    Brings the app out of a minimized/hidden state.
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
-CF_API void CF_CALL cf_app_show_window();
+CF_API void CF_CALL cf_app_show_window(void);
 
 /**
  * @function cf_app_get_dpi_scale
@@ -408,7 +408,7 @@ CF_API void CF_CALL cf_app_show_window();
  *           pixels are clustered for you under the hood.
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
  */
-CF_API float CF_CALL cf_app_get_dpi_scale();
+CF_API float CF_CALL cf_app_get_dpi_scale(void);
 
 /**
  * @function cf_app_dpi_scale_was_changed
@@ -416,7 +416,7 @@ CF_API float CF_CALL cf_app_get_dpi_scale();
  * @brief    Returns true if the DPI scaling changed, such as moving from one screen to another.
  * @related  cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
  */
-CF_API bool CF_CALL cf_app_dpi_scale_was_changed();
+CF_API bool CF_CALL cf_app_dpi_scale_was_changed(void);
 
 /**
  * @function cf_app_set_size
@@ -454,7 +454,7 @@ CF_API void CF_CALL cf_app_set_position(int x, int y);
  * @brief    Sets the window position centered on the screen.
  * @related  cf_app_get_size cf_app_set_size cf_app_get_position cf_app_center_window
  */
-CF_API void CF_CALL cf_app_center_window();
+CF_API void CF_CALL cf_app_center_window(void);
 
 /**
  * @function cf_app_was_resized
@@ -462,7 +462,7 @@ CF_API void CF_CALL cf_app_center_window();
  * @brief    Returns true if the app was resized last frame.
  * @related  cf_app_was_moved
  */
-CF_API bool CF_CALL cf_app_was_resized();
+CF_API bool CF_CALL cf_app_was_resized(void);
 
 /**
  * @function cf_app_was_moved
@@ -470,7 +470,7 @@ CF_API bool CF_CALL cf_app_was_resized();
  * @brief    Returns true if the app was moved (not resized) last frame.
  * @related  cf_app_was_resized
  */
-CF_API bool CF_CALL cf_app_was_moved();
+CF_API bool CF_CALL cf_app_was_moved(void);
 
 /**
  * @function cf_app_lost_focus
@@ -479,7 +479,7 @@ CF_API bool CF_CALL cf_app_was_moved();
  * @remarks  The app has focus if user inputs will go to the app, such as after clicking on or selecting the app.
  * @related  cf_app_gained_focus cf_app_has_focus cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_lost_focus();
+CF_API bool CF_CALL cf_app_lost_focus(void);
 
 /**
  * @function cf_app_gained_focus
@@ -488,7 +488,7 @@ CF_API bool CF_CALL cf_app_lost_focus();
  * @remarks  The app has focus if user inputs will go to the app, such as after clicking on or selecting the app.
  * @related  cf_app_lost_focus cf_app_has_focus cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_gained_focus();
+CF_API bool CF_CALL cf_app_gained_focus(void);
 
 /**
  * @function cf_app_has_focus
@@ -497,7 +497,7 @@ CF_API bool CF_CALL cf_app_gained_focus();
  * @remarks  The app has focus if user inputs will go to the app, such as after clicking on or selecting the app.
  * @related  cf_app_lost_focus cf_app_gained_focus cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_has_focus();
+CF_API bool CF_CALL cf_app_has_focus(void);
 
 /**
  * @function cf_app_request_attention
@@ -506,7 +506,7 @@ CF_API bool CF_CALL cf_app_has_focus();
  * @remarks  On Windows this flashes the tab icon, and bounces the dock icon on OSX.
  * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
  */
-CF_API void CF_CALL cf_app_request_attention();
+CF_API void CF_CALL cf_app_request_attention(void);
 
 /**
  * @function cf_app_request_attention_continuously
@@ -515,7 +515,7 @@ CF_API void CF_CALL cf_app_request_attention();
  * @remarks  On Windows this flashes the tab icon, and bounces the dock icon on OSX.
  * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
  */
-CF_API void CF_CALL cf_app_request_attention_continuously();
+CF_API void CF_CALL cf_app_request_attention_continuously(void);
 
 /**
  * @function cf_app_request_attention_cancel
@@ -523,7 +523,7 @@ CF_API void CF_CALL cf_app_request_attention_continuously();
  * @brief    Cancels any previous requests for attention.
  * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
  */
-CF_API void CF_CALL cf_app_request_attention_cancel();
+CF_API void CF_CALL cf_app_request_attention_cancel(void);
 
 /**
  * @function cf_app_was_minimized
@@ -531,7 +531,7 @@ CF_API void CF_CALL cf_app_request_attention_cancel();
  * @brief    Returns true if the app was minimized last frame.
  * @related  cf_app_was_maximized cf_app_minimized cf_app_maximized cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_was_minimized();
+CF_API bool CF_CALL cf_app_was_minimized(void);
 
 /**
  * @function cf_app_was_maximized
@@ -539,7 +539,7 @@ CF_API bool CF_CALL cf_app_was_minimized();
  * @brief    Returns true if the app was maximized last frame.
  * @related  cf_app_was_minimized cf_app_minimized cf_app_maximized cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_was_maximized();
+CF_API bool CF_CALL cf_app_was_maximized(void);
 
 /**
  * @function cf_app_minimized
@@ -547,7 +547,7 @@ CF_API bool CF_CALL cf_app_was_maximized();
  * @brief    Returns true while the app is currently minimized.
  * @related  cf_app_was_minimized cf_app_was_maximized cf_app_maximized cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_minimized();
+CF_API bool CF_CALL cf_app_minimized(void);
 
 /**
  * @function cf_app_maximized
@@ -555,7 +555,7 @@ CF_API bool CF_CALL cf_app_minimized();
  * @brief    Returns true while the app is currently maximized.
  * @related  cf_app_was_minimized cf_app_was_maximized cf_app_minimized cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_maximized();
+CF_API bool CF_CALL cf_app_maximized(void);
 
 /**
  * @function cf_app_was_restored
@@ -564,7 +564,7 @@ CF_API bool CF_CALL cf_app_maximized();
  * @remarks  Restored means a window's size/position was restored from a minimized/maximized state.
  * @related  cf_app_was_minimized cf_app_was_maximized cf_app_minimized cf_app_maximized cf_app_was_restored
  */
-CF_API bool CF_CALL cf_app_was_restored();
+CF_API bool CF_CALL cf_app_was_restored(void);
 
 /**
  * @function cf_app_mouse_entered
@@ -573,7 +573,7 @@ CF_API bool CF_CALL cf_app_was_restored();
  * @remarks  This function only deals with mouse coordinates, not focus (such as `cf_app_has_focus`).
  * @related  cf_app_mouse_exited cf_app_mouse_inside
  */
-CF_API bool CF_CALL cf_app_mouse_entered();
+CF_API bool CF_CALL cf_app_mouse_entered(void);
 
 /**
  * @function cf_app_mouse_exited
@@ -582,7 +582,7 @@ CF_API bool CF_CALL cf_app_mouse_entered();
  * @remarks  This function only deals with mouse coordinates, not focus (such as `cf_app_has_focus`).
  * @related  cf_app_mouse_entered cf_app_mouse_inside
  */
-CF_API bool CF_CALL cf_app_mouse_exited();
+CF_API bool CF_CALL cf_app_mouse_exited(void);
 
 /**
  * @function cf_app_mouse_inside
@@ -591,7 +591,7 @@ CF_API bool CF_CALL cf_app_mouse_exited();
  * @remarks  This function only deals with mouse coordinates, not focus (such as `cf_app_has_focus`).
  * @related  cf_app_mouse_entered cf_app_mouse_exited
  */
-CF_API bool CF_CALL cf_app_mouse_inside();
+CF_API bool CF_CALL cf_app_mouse_inside(void);
 
 /**
  * @function cf_app_init_imgui
@@ -601,7 +601,7 @@ CF_API bool CF_CALL cf_app_mouse_inside();
  *           After calling this init function you can call into Dear ImGui's functions.
  * @related  cf_app_get_sokol_imgui
  */
-CF_API ImGuiContext* CF_CALL cf_app_init_imgui();
+CF_API ImGuiContext* CF_CALL cf_app_init_imgui(void);
 
 /**
  * @enum     CF_MSAA
@@ -669,7 +669,7 @@ CF_API bool CF_CALL cf_app_set_msaa(int sample_count);
  *           If you fetch this canvas and have MSAA on (see `cf_app_set_msaa`) you may *not* sample from the canvas.
  * @related  cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
  */
-CF_API CF_Canvas CF_CALL cf_app_get_canvas();
+CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
 
 /**
  * @function cf_app_set_canvas_size
@@ -688,7 +688,7 @@ CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
  * @brief    Gets the app's canvas width in pixels.
  * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
  */
-CF_API int CF_CALL cf_app_get_canvas_width();
+CF_API int CF_CALL cf_app_get_canvas_width(void);
 
 /**
  * @function cf_app_get_canvas_height
@@ -696,7 +696,7 @@ CF_API int CF_CALL cf_app_get_canvas_width();
  * @brief    Gets the app's canvas height in pixels.
  * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync
  */
-CF_API int CF_CALL cf_app_get_canvas_height();
+CF_API int CF_CALL cf_app_get_canvas_height(void);
 
 /**
  * @function cf_app_set_vsync
@@ -722,7 +722,7 @@ CF_API void CF_CALL cf_app_set_vsync_mailbox(bool true_turn_on_mailbox);
  * @brief    Returns the vsync state (true for on).
  * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
  */
-CF_API bool CF_CALL cf_app_get_vsync();
+CF_API bool CF_CALL cf_app_get_vsync(void);
 
 /**
  * @function cf_app_set_windowed_mode
@@ -730,7 +730,7 @@ CF_API bool CF_CALL cf_app_get_vsync();
  * @brief    Sets the application to windowed mode.
  * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
  */
-CF_API void CF_CALL cf_app_set_windowed_mode();
+CF_API void CF_CALL cf_app_set_windowed_mode(void);
 
 /**
  * @function cf_app_set_borderless_fullscreen_mode
@@ -738,7 +738,7 @@ CF_API void CF_CALL cf_app_set_windowed_mode();
  * @brief    Sets the application mode to "fake fullscreen" without a border.
  * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
  */
-CF_API void CF_CALL cf_app_set_borderless_fullscreen_mode();
+CF_API void CF_CALL cf_app_set_borderless_fullscreen_mode(void);
 
 /**
  * @function cf_app_set_fullscreen_mode
@@ -746,7 +746,7 @@ CF_API void CF_CALL cf_app_set_borderless_fullscreen_mode();
  * @brief    Sets the application true fullscreen mode.
  * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
  */
-CF_API void CF_CALL cf_app_set_fullscreen_mode();
+CF_API void CF_CALL cf_app_set_fullscreen_mode(void);
 
 /**
  * @function cf_app_set_title
@@ -772,7 +772,7 @@ CF_API void CF_CALL cf_app_set_icon(const char* virtual_path_to_png);
  * @brief    Returns the current framerate of the application.
  * @related  cf_app_get_framerate cf_app_get_smoothed_framerate
  */
-CF_API float CF_CALL cf_app_get_framerate();
+CF_API float CF_CALL cf_app_get_framerate(void);
 
 /**
  * @function cf_app_get_smoothed_framerate
@@ -780,7 +780,7 @@ CF_API float CF_CALL cf_app_get_framerate();
  * @brief    Returns the smoothed framerate of the application. Last 60 frames are averaged. This values is controlled by `CF_FRAMERATE_SMOOTHING`.
  * @related  cf_app_get_framerate cf_app_get_smoothed_framerate
  */
-CF_API float CF_CALL cf_app_get_smoothed_framerate();
+CF_API float CF_CALL cf_app_get_smoothed_framerate(void);
 
 /**
  * @enum     CF_PowerState
@@ -852,7 +852,7 @@ typedef struct CF_PowerInfo
  * @return   Returns a `CF_PowerInfo` struct.
  * @related  CF_PowerInfo cf_power_state_to_string CF_PowerState
  */
-CF_API CF_PowerInfo CF_CALL cf_app_power_info();
+CF_API CF_PowerInfo CF_CALL cf_app_power_info(void);
 
 #ifdef __cplusplus
 }

--- a/include/cute_audio.h
+++ b/include/cute_audio.h
@@ -225,7 +225,7 @@ CF_API void CF_CALL cf_music_set_pitch(float pitch);
  * @brief    Pauses the music.
  * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
  */
-CF_API void CF_CALL cf_music_pause();
+CF_API void CF_CALL cf_music_pause(void);
 
 /**
  * @function cf_music_resume
@@ -233,7 +233,7 @@ CF_API void CF_CALL cf_music_pause();
  * @brief    Resumes the music if the music was paused.
  * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
  */
-CF_API void CF_CALL cf_music_resume();
+CF_API void CF_CALL cf_music_resume(void);
 
 /**
  * @function cf_music_switch_to
@@ -262,7 +262,7 @@ CF_API void CF_CALL cf_music_crossfade(CF_Audio audio_source, float cross_fade_t
  * @remarks  This can be useful to sync a dynamic audio system that can turn on/off different instruments or sounds.
  * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
  */
-CF_API int CF_CALL cf_music_get_sample_index();
+CF_API int CF_CALL cf_music_get_sample_index(void);
 
 /**
  * @function cf_music_set_sample_index
@@ -323,7 +323,7 @@ typedef struct CF_SoundParams
  * @brief    Returns a `CF_SoundParams` filled with default state, to use with `cf_play_sound`.
  * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
-CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults()
+CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults(void)
 {
 	CF_SoundParams params;
 	params.paused = false;

--- a/include/cute_clipboard.h
+++ b/include/cute_clipboard.h
@@ -24,7 +24,7 @@ extern "C" {
  * @brief    Returns a UTF-8 string of the clipboard contents.
  * @related  cf_clipboard_get cf_clipboard_set
  */
-CF_API char* CF_CALL cf_clipboard_get();
+CF_API char* CF_CALL cf_clipboard_get(void);
 
 /**
  * @function cf_clipboard_set

--- a/include/cute_color.h
+++ b/include/cute_color.h
@@ -655,7 +655,7 @@ CF_INLINE char* cf_color_to_string(CF_Color c) { char* s = NULL; return shex(s, 
  * @brief    Helper function to return an invisible `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_invisible() { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_invisible(void) { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
 
 /**
  * @function cf_color_clear
@@ -663,7 +663,7 @@ CF_INLINE CF_Color cf_color_invisible() { return cf_make_color_rgba_f(0.0f, 0.0f
  * @brief    Helper function to return an invisible `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_clear() { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_clear(void) { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
 
 /**
  * @function cf_color_black
@@ -671,7 +671,7 @@ CF_INLINE CF_Color cf_color_clear() { return cf_make_color_rgba_f(0.0f, 0.0f, 0.
  * @brief    Helper function to return a black `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_black() { return cf_make_color_rgb_f(0.0f, 0.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_black(void) { return cf_make_color_rgb_f(0.0f, 0.0f, 0.0f); }
 
 /**
  * @function cf_color_white
@@ -679,7 +679,7 @@ CF_INLINE CF_Color cf_color_black() { return cf_make_color_rgb_f(0.0f, 0.0f, 0.0
  * @brief    Helper function to return a white `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_white() { return cf_make_color_rgb_f(1.0f, 1.0f, 1.0f); }
+CF_INLINE CF_Color cf_color_white(void) { return cf_make_color_rgb_f(1.0f, 1.0f, 1.0f); }
 
 /**
  * @function cf_color_red
@@ -687,7 +687,7 @@ CF_INLINE CF_Color cf_color_white() { return cf_make_color_rgb_f(1.0f, 1.0f, 1.0
  * @brief    Helper function to return a red `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_red() { return cf_make_color_rgb_f(1.0f, 0.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_red(void) { return cf_make_color_rgb_f(1.0f, 0.0f, 0.0f); }
 
 /**
  * @function cf_color_green
@@ -695,7 +695,7 @@ CF_INLINE CF_Color cf_color_red() { return cf_make_color_rgb_f(1.0f, 0.0f, 0.0f)
  * @brief    Helper function to return a green `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_green() { return cf_make_color_rgb_f(0.0f, 1.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_green(void) { return cf_make_color_rgb_f(0.0f, 1.0f, 0.0f); }
 
 /**
  * @function cf_color_blue
@@ -703,7 +703,7 @@ CF_INLINE CF_Color cf_color_green() { return cf_make_color_rgb_f(0.0f, 1.0f, 0.0
  * @brief    Helper function to return a blue `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_blue() { return cf_make_color_rgb_f(0.0f, 0.0f, 1.0f); }
+CF_INLINE CF_Color cf_color_blue(void) { return cf_make_color_rgb_f(0.0f, 0.0f, 1.0f); }
 
 /**
  * @function cf_color_yellow
@@ -711,7 +711,7 @@ CF_INLINE CF_Color cf_color_blue() { return cf_make_color_rgb_f(0.0f, 0.0f, 1.0f
  * @brief    Helper function to return a yellow `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_yellow() { return cf_make_color_rgb_f(1.0f, 1.0f, 0.0f); }
+CF_INLINE CF_Color cf_color_yellow(void) { return cf_make_color_rgb_f(1.0f, 1.0f, 0.0f); }
 
 /**
  * @function cf_color_orange
@@ -719,7 +719,7 @@ CF_INLINE CF_Color cf_color_yellow() { return cf_make_color_rgb_f(1.0f, 1.0f, 0.
  * @brief    Helper function to return a orange `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_orange() { return cf_make_color_rgb_f(1.0f, 0.65f, 0.0f); }
+CF_INLINE CF_Color cf_color_orange(void) { return cf_make_color_rgb_f(1.0f, 0.65f, 0.0f); }
 
 /**
  * @function cf_color_purple
@@ -727,7 +727,7 @@ CF_INLINE CF_Color cf_color_orange() { return cf_make_color_rgb_f(1.0f, 0.65f, 0
  * @brief    Helper function to return a purple `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_purple() { return cf_make_color_rgb_f(1.0f, 0.0f, 1.0f); }
+CF_INLINE CF_Color cf_color_purple(void) { return cf_make_color_rgb_f(1.0f, 0.0f, 1.0f); }
 
 /**
  * @function cf_color_grey
@@ -735,7 +735,7 @@ CF_INLINE CF_Color cf_color_purple() { return cf_make_color_rgb_f(1.0f, 0.0f, 1.
  * @brief    Helper function to return a grey `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_grey() { return cf_make_color_rgb_f(0.5f, 0.5f, 0.5f); }
+CF_INLINE CF_Color cf_color_grey(void) { return cf_make_color_rgb_f(0.5f, 0.5f, 0.5f); }
 
 /**
  * @function cf_color_cyan
@@ -743,7 +743,7 @@ CF_INLINE CF_Color cf_color_grey() { return cf_make_color_rgb_f(0.5f, 0.5f, 0.5f
  * @brief    Helper function to return a cyan `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_cyan() { return cf_make_color_rgb(68, 220, 235); }
+CF_INLINE CF_Color cf_color_cyan(void) { return cf_make_color_rgb(68, 220, 235); }
 
 /**
  * @function cf_color_magenta
@@ -751,7 +751,7 @@ CF_INLINE CF_Color cf_color_cyan() { return cf_make_color_rgb(68, 220, 235); }
  * @brief    Helper function to return a magenta `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_magenta() { return cf_make_color_rgb(224, 70, 224); }
+CF_INLINE CF_Color cf_color_magenta(void) { return cf_make_color_rgb(224, 70, 224); }
 
 /**
  * @function cf_color_brown
@@ -759,7 +759,7 @@ CF_INLINE CF_Color cf_color_magenta() { return cf_make_color_rgb(224, 70, 224); 
  * @brief    Helper function to return a brown `CF_Color`.
  * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
  */
-CF_INLINE CF_Color cf_color_brown() { return cf_make_color_rgb(150, 105, 25); }
+CF_INLINE CF_Color cf_color_brown(void) { return cf_make_color_rgb(150, 105, 25); }
 
 /**
  * @function cf_pixel_invisible
@@ -767,7 +767,7 @@ CF_INLINE CF_Color cf_color_brown() { return cf_make_color_rgb(150, 105, 25); }
  * @brief    Helper function to return a invisible `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_invisible() { return cf_make_pixel_hex(0); }
+CF_INLINE CF_Pixel cf_pixel_invisible(void) { return cf_make_pixel_hex(0); }
 
 /**
  * @function cf_pixel_clear
@@ -775,7 +775,7 @@ CF_INLINE CF_Pixel cf_pixel_invisible() { return cf_make_pixel_hex(0); }
  * @brief    Helper function to return a invisible `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_clear() { return cf_make_pixel_hex(0); }
+CF_INLINE CF_Pixel cf_pixel_clear(void) { return cf_make_pixel_hex(0); }
 
 /**
  * @function cf_pixel_black
@@ -783,7 +783,7 @@ CF_INLINE CF_Pixel cf_pixel_clear() { return cf_make_pixel_hex(0); }
  * @brief    Helper function to return a black `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_black() { return cf_make_pixel_rgb(0, 0, 0); }
+CF_INLINE CF_Pixel cf_pixel_black(void) { return cf_make_pixel_rgb(0, 0, 0); }
 
 /**
  * @function cf_pixel_white
@@ -791,7 +791,7 @@ CF_INLINE CF_Pixel cf_pixel_black() { return cf_make_pixel_rgb(0, 0, 0); }
  * @brief    Helper function to return a invisible `white`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_white() { return cf_make_pixel_rgb(255, 255, 255); }
+CF_INLINE CF_Pixel cf_pixel_white(void) { return cf_make_pixel_rgb(255, 255, 255); }
 
 /**
  * @function cf_pixel_red
@@ -799,7 +799,7 @@ CF_INLINE CF_Pixel cf_pixel_white() { return cf_make_pixel_rgb(255, 255, 255); }
  * @brief    Helper function to return a red `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_red() { return cf_make_pixel_rgb(255, 0, 0); }
+CF_INLINE CF_Pixel cf_pixel_red(void) { return cf_make_pixel_rgb(255, 0, 0); }
 
 /**
  * @function cf_pixel_green
@@ -807,7 +807,7 @@ CF_INLINE CF_Pixel cf_pixel_red() { return cf_make_pixel_rgb(255, 0, 0); }
  * @brief    Helper function to return a green `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_green() { return cf_make_pixel_rgb(0, 255, 0); }
+CF_INLINE CF_Pixel cf_pixel_green(void) { return cf_make_pixel_rgb(0, 255, 0); }
 
 /**
  * @function cf_pixel_blue
@@ -815,7 +815,7 @@ CF_INLINE CF_Pixel cf_pixel_green() { return cf_make_pixel_rgb(0, 255, 0); }
  * @brief    Helper function to return a blue `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_blue() { return cf_make_pixel_rgb(0, 0, 255); }
+CF_INLINE CF_Pixel cf_pixel_blue(void) { return cf_make_pixel_rgb(0, 0, 255); }
 
 /**
  * @function cf_pixel_yellow
@@ -823,7 +823,7 @@ CF_INLINE CF_Pixel cf_pixel_blue() { return cf_make_pixel_rgb(0, 0, 255); }
  * @brief    Helper function to return a yellow `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_yellow() { return cf_make_pixel_rgb(255, 255, 0); }
+CF_INLINE CF_Pixel cf_pixel_yellow(void) { return cf_make_pixel_rgb(255, 255, 0); }
 
 /**
  * @function cf_pixel_orange
@@ -831,7 +831,7 @@ CF_INLINE CF_Pixel cf_pixel_yellow() { return cf_make_pixel_rgb(255, 255, 0); }
  * @brief    Helper function to return a orange `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_orange() { return cf_make_pixel_rgb(255, 165, 0); }
+CF_INLINE CF_Pixel cf_pixel_orange(void) { return cf_make_pixel_rgb(255, 165, 0); }
 
 /**
  * @function cf_pixel_purple
@@ -839,7 +839,7 @@ CF_INLINE CF_Pixel cf_pixel_orange() { return cf_make_pixel_rgb(255, 165, 0); }
  * @brief    Helper function to return a purple `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_purple() { return cf_make_pixel_rgb(255, 0, 255); }
+CF_INLINE CF_Pixel cf_pixel_purple(void) { return cf_make_pixel_rgb(255, 0, 255); }
 
 /**
  * @function cf_pixel_grey
@@ -847,7 +847,7 @@ CF_INLINE CF_Pixel cf_pixel_purple() { return cf_make_pixel_rgb(255, 0, 255); }
  * @brief    Helper function to return a grey `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_grey() { return cf_make_pixel_rgb(127, 127, 127); }
+CF_INLINE CF_Pixel cf_pixel_grey(void) { return cf_make_pixel_rgb(127, 127, 127); }
 
 /**
  * @function cf_pixel_cyan
@@ -855,7 +855,7 @@ CF_INLINE CF_Pixel cf_pixel_grey() { return cf_make_pixel_rgb(127, 127, 127); }
  * @brief    Helper function to return a cyan `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_cyan() { return cf_make_pixel_rgb(68, 220, 235); }
+CF_INLINE CF_Pixel cf_pixel_cyan(void) { return cf_make_pixel_rgb(68, 220, 235); }
 
 /**
  * @function cf_pixel_magenta
@@ -863,7 +863,7 @@ CF_INLINE CF_Pixel cf_pixel_cyan() { return cf_make_pixel_rgb(68, 220, 235); }
  * @brief    Helper function to return a magenta `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_magenta() { return cf_make_pixel_rgb(224, 70, 224); }
+CF_INLINE CF_Pixel cf_pixel_magenta(void) { return cf_make_pixel_rgb(224, 70, 224); }
 
 /**
  * @function cf_pixel_brown
@@ -871,7 +871,7 @@ CF_INLINE CF_Pixel cf_pixel_magenta() { return cf_make_pixel_rgb(224, 70, 224); 
  * @brief    Helper function to return a brown `CF_Pixel`.
  * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
  */
-CF_INLINE CF_Pixel cf_pixel_brown() { return cf_make_pixel_rgb(150, 105, 25); }
+CF_INLINE CF_Pixel cf_pixel_brown(void) { return cf_make_pixel_rgb(150, 105, 25); }
 
 #ifdef __cplusplus
 }

--- a/include/cute_coroutine.h
+++ b/include/cute_coroutine.h
@@ -212,7 +212,7 @@ CF_API size_t CF_CALL cf_coroutine_space_remaining(CF_Coroutine co);
  *           this function.
  * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
  */
-CF_API CF_Coroutine CF_CALL cf_coroutine_currently_running();
+CF_API CF_Coroutine CF_CALL cf_coroutine_currently_running(void);
 
 #ifdef __cplusplus
 }

--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -382,7 +382,7 @@ CF_API void CF_CALL cf_draw_push_layer(int layer);
  *           This can be used to pick which sprites/shapes should draw on top of each other.
  * @related  cf_draw_push_layer cf_draw_pop_layer cf_draw_peek_layer
  */
-CF_API int CF_CALL cf_draw_pop_layer();
+CF_API int CF_CALL cf_draw_pop_layer(void);
 
 /**
  * @function cf_draw_peek_layer
@@ -392,7 +392,7 @@ CF_API int CF_CALL cf_draw_pop_layer();
  *           This can be used to pick which sprites/shapes should draw on top of each other.
  * @related  cf_draw_push_layer cf_draw_pop_layer cf_draw_peek_layer
  */
-CF_API int CF_CALL cf_draw_peek_layer();
+CF_API int CF_CALL cf_draw_peek_layer(void);
 
 /**
  * @function cf_draw_push_color
@@ -411,7 +411,7 @@ CF_API void CF_CALL cf_draw_push_color(CF_Color c);
  * @remarks  Various draw functions do not specify a color. In these cases, the last color pushed will be used.
  * @related  cf_draw_push_color cf_draw_pop_color cf_draw_peek_color
  */
-CF_API CF_Color CF_CALL cf_draw_pop_color();
+CF_API CF_Color CF_CALL cf_draw_pop_color(void);
 
 /**
  * @function cf_draw_peek_color
@@ -420,7 +420,7 @@ CF_API CF_Color CF_CALL cf_draw_pop_color();
  * @remarks  Various draw functions do not specify a color. In these cases, the last color pushed will be used.
  * @related  cf_draw_push_color cf_draw_pop_color cf_draw_peek_color
  */
-CF_API CF_Color CF_CALL cf_draw_peek_color();
+CF_API CF_Color CF_CALL cf_draw_peek_color(void);
 
 /**
  * @function cf_draw_push_antialias
@@ -441,7 +441,7 @@ CF_API void CF_CALL cf_draw_push_antialias(bool antialias);
  *           but looks much smoother.
  * @related  cf_draw_push_antialias cf_draw_pop_antialias cf_draw_peek_antialias
  */
-CF_API bool CF_CALL cf_draw_pop_antialias();
+CF_API bool CF_CALL cf_draw_pop_antialias(void);
 
 /**
  * @function cf_draw_peek_antialias
@@ -451,7 +451,7 @@ CF_API bool CF_CALL cf_draw_pop_antialias();
  *           but looks much smoother.
  * @related  cf_draw_push_antialias cf_draw_pop_antialias cf_draw_peek_antialias
  */
-CF_API bool CF_CALL cf_draw_peek_antialias();
+CF_API bool CF_CALL cf_draw_peek_antialias(void);
 
 /**
  * @function cf_draw_push_antialias_scale
@@ -471,7 +471,7 @@ CF_API void CF_CALL cf_draw_push_antialias_scale(float scale);
  *           The number must be greater than 0, but probably not more than 2 or 3 for most cases. The default is 1.5.
  * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
  */
-CF_API float CF_CALL cf_draw_pop_antialias_scale();
+CF_API float CF_CALL cf_draw_pop_antialias_scale(void);
 
 /**
  * @function cf_draw_peek_antialias_scale
@@ -481,7 +481,7 @@ CF_API float CF_CALL cf_draw_pop_antialias_scale();
  *           The number must be greater than 0, but probably not more than 2 or 3 for most cases. The default is 1.5.
  * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
  */
-CF_API float CF_CALL cf_draw_peek_antialias_scale();
+CF_API float CF_CALL cf_draw_peek_antialias_scale(void);
 
 /**
  * @function cf_draw_push_vertex_attributes
@@ -511,7 +511,7 @@ CF_API void CF_CALL cf_draw_push_vertex_attributes2(CF_Color attributes);
  * @brief    Pops the current vertex attribute state, restoring the previous state.
  * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
  */
-CF_API CF_Color CF_CALL cf_draw_pop_vertex_attributes();
+CF_API CF_Color CF_CALL cf_draw_pop_vertex_attributes(void);
 
 /**
  * @function cf_draw_peek_vertex_attributes
@@ -519,7 +519,7 @@ CF_API CF_Color CF_CALL cf_draw_pop_vertex_attributes();
  * @brief    Returns the current vertex attribute state.
  * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
  */
-CF_API CF_Color CF_CALL cf_draw_peek_vertex_attributes();
+CF_API CF_Color CF_CALL cf_draw_peek_vertex_attributes(void);
 
 /**
  * @struct   CF_Vertex
@@ -658,7 +658,7 @@ CF_API void CF_CALL cf_push_font(const char* font);
  * @brief    Pops and returns the last font name used.
  * @related  cf_make_font cf_push_font cf_pop_font cf_peek_font cf_push_font_size cf_push_font_blur cf_draw_text
  */
-CF_API const char* CF_CALL cf_pop_font();
+CF_API const char* CF_CALL cf_pop_font(void);
 
 /**
  * @function cf_peek_font
@@ -666,7 +666,7 @@ CF_API const char* CF_CALL cf_pop_font();
  * @brief    Returns the last font name used.
  * @related  cf_make_font cf_push_font cf_pop_font cf_peek_font cf_push_font_size cf_push_font_blur cf_draw_text
  */
-CF_API const char* CF_CALL cf_peek_font();
+CF_API const char* CF_CALL cf_peek_font(void);
 
 /**
  * @function cf_push_font_size
@@ -683,7 +683,7 @@ CF_API void CF_CALL cf_push_font_size(float size);
  * @brief    Pops and returns the last font size.
  * @related  cf_make_font cf_push_font cf_push_font_size cf_pop_font_size cf_peek_font_size cf_push_font_blur cf_draw_text
  */
-CF_API float CF_CALL cf_pop_font_size();
+CF_API float CF_CALL cf_pop_font_size(void);
 
 /**
  * @function cf_peek_font_size
@@ -691,7 +691,7 @@ CF_API float CF_CALL cf_pop_font_size();
  * @brief    Returns the last font size.
  * @related  cf_make_font cf_push_font cf_push_font_size cf_pop_font_size cf_peek_font_size cf_push_font_blur cf_draw_text
  */
-CF_API float CF_CALL cf_peek_font_size();
+CF_API float CF_CALL cf_peek_font_size(void);
 
 /**
  * @function cf_push_font_blur
@@ -708,7 +708,7 @@ CF_API void CF_CALL cf_push_font_blur(int blur);
  * @brief    Pops and returns the last font blur.
  * @related  cf_make_font cf_push_font cf_push_font_size cf_push_font_blur cf_pop_font_blur cf_peek_font_blur cf_draw_text
  */
-CF_API int CF_CALL cf_pop_font_blur();
+CF_API int CF_CALL cf_pop_font_blur(void);
 
 /**
  * @function cf_peek_font_blur
@@ -716,7 +716,7 @@ CF_API int CF_CALL cf_pop_font_blur();
  * @brief    Returns the last font blur.
  * @related  cf_make_font cf_push_font cf_push_font_size cf_push_font_blur cf_pop_font_blur cf_peek_font_blur cf_draw_text
  */
-CF_API int CF_CALL cf_peek_font_blur();
+CF_API int CF_CALL cf_peek_font_blur(void);
 
 /**
  * @function cf_push_text_wrap_width
@@ -733,7 +733,7 @@ CF_API void CF_CALL cf_push_text_wrap_width(float width);
  * @brief    Pops and returns the last text wrap width.
  * @related  cf_make_font cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width cf_peek_text_wrap_width cf_push_text_clip_box cf_draw_text
  */
-CF_API float CF_CALL cf_pop_text_wrap_width();
+CF_API float CF_CALL cf_pop_text_wrap_width(void);
 
 /**
  * @function cf_peek_text_wrap_width
@@ -741,7 +741,7 @@ CF_API float CF_CALL cf_pop_text_wrap_width();
  * @brief    Returns the last text wrap width.
  * @related  cf_make_font cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width cf_peek_text_wrap_width cf_push_text_clip_box cf_draw_text
  */
-CF_API float CF_CALL cf_peek_text_wrap_width();
+CF_API float CF_CALL cf_peek_text_wrap_width(void);
 
 /**
  * @function cf_push_text_vertical_layout
@@ -758,7 +758,7 @@ CF_API void CF_CALL cf_push_text_vertical_layout(bool layout_vertically);
  * @brief    Pops and returns the last vertical layout state.
  * @related  cf_make_font cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout cf_peek_text_vertical_layout cf_draw_text
  */
-CF_API bool CF_CALL cf_pop_text_vertical_layout();
+CF_API bool CF_CALL cf_pop_text_vertical_layout(void);
 
 /**
  * @function cf_peek_text_vertical_layout
@@ -766,7 +766,7 @@ CF_API bool CF_CALL cf_pop_text_vertical_layout();
  * @brief    Returns the last vertical layout state.
  * @related  cf_make_font cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout cf_peek_text_vertical_layout cf_draw_text
  */
-CF_API bool CF_CALL cf_peek_text_vertical_layout();
+CF_API bool CF_CALL cf_peek_text_vertical_layout(void);
 
 /**
  * @function cf_text_width
@@ -1074,7 +1074,7 @@ CF_API void CF_CALL cf_push_text_effect_active(bool effects_on);
  * @brief    Pops the previously pushed activated state for text effects. See `cf_push_text_effect_active`.
  * @related  cf_push_text_effect_active cf_pop_text_effect_active cf_peek_text_effect_active
  */
-CF_API bool CF_CALL cf_pop_text_effect_active();
+CF_API bool CF_CALL cf_pop_text_effect_active(void);
 
 /**
  * @function cf_peek_text_effect_active
@@ -1082,7 +1082,7 @@ CF_API bool CF_CALL cf_pop_text_effect_active();
  * @brief    Returns the last text active state.
  * @related  cf_push_text_effect_active cf_pop_text_effect_active cf_peek_text_effect_active
  */
-CF_API bool CF_CALL cf_peek_text_effect_active();
+CF_API bool CF_CALL cf_peek_text_effect_active(void);
 
 /**
  * @function cf_draw_push_viewport
@@ -1099,7 +1099,7 @@ CF_API void CF_CALL cf_draw_push_viewport(CF_Rect viewport);
  * @brief    TODO
  * @related  TODO
  */
-CF_API CF_Rect CF_CALL cf_draw_pop_viewport();
+CF_API CF_Rect CF_CALL cf_draw_pop_viewport(void);
 
 /**
  * @function cf_draw_peek_viewport
@@ -1107,7 +1107,7 @@ CF_API CF_Rect CF_CALL cf_draw_pop_viewport();
  * @brief    TODO
  * @related  TODO
  */
-CF_API CF_Rect CF_CALL cf_draw_peek_viewport();
+CF_API CF_Rect CF_CALL cf_draw_peek_viewport(void);
 
 /**
  * @function cf_draw_push_scissor
@@ -1124,7 +1124,7 @@ CF_API void CF_CALL cf_draw_push_scissor(CF_Rect scissor);
  * @brief    Pops and returns the last `CF_Rect` for the scissor box.
  * @related  TODO
  */
-CF_API CF_Rect CF_CALL cf_draw_pop_scissor();
+CF_API CF_Rect CF_CALL cf_draw_pop_scissor(void);
 
 /**
  * @function cf_draw_peek_scissor
@@ -1132,7 +1132,7 @@ CF_API CF_Rect CF_CALL cf_draw_pop_scissor();
  * @brief    Returns the last `CF_Rect` for the scissor box.
  * @related  TODO
  */
-CF_API CF_Rect CF_CALL cf_draw_peek_scissor();
+CF_API CF_Rect CF_CALL cf_draw_peek_scissor(void);
 
 /**
  * @function cf_draw_push_render_state
@@ -1148,14 +1148,14 @@ CF_API void CF_CALL cf_draw_push_render_state(CF_RenderState render_state);
  * @category draw
  * @brief    Pops and returns the last `CF_RenderState`.* @related  CF_RenderState cf_draw_filter cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state cf_draw_pop_render_state cf_draw_peek_render_state cf_render_to cf_app_draw_onto_screen
  */
-CF_API CF_RenderState CF_CALL cf_draw_pop_render_state();
+CF_API CF_RenderState CF_CALL cf_draw_pop_render_state(void);
 
 /**
  * @function cf_draw_peek_render_state
  * @category draw
  * @brief    Returns the last `CF_RenderState`.* @related  CF_RenderState cf_draw_filter cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state cf_draw_pop_render_state cf_draw_peek_render_state cf_render_to cf_app_draw_onto_screen
  */
-CF_API CF_RenderState CF_CALL cf_draw_peek_render_state();
+CF_API CF_RenderState CF_CALL cf_draw_peek_render_state(void);
 
 /**
  * @function cf_draw_set_atlas_dimensions
@@ -1239,7 +1239,7 @@ CF_API void CF_CALL cf_draw_push_shader(CF_Shader shader);
  * @brief    Pops the custom shader and restores the previous state.
  * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
  */
-CF_API CF_Shader CF_CALL cf_draw_pop_shader();
+CF_API CF_Shader CF_CALL cf_draw_pop_shader(void);
 
 /**
  * @function cf_draw_peek_shader
@@ -1247,7 +1247,7 @@ CF_API CF_Shader CF_CALL cf_draw_pop_shader();
  * @brief    Returns the current custom shader.
  * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
  */
-CF_API CF_Shader CF_CALL cf_draw_peek_shader();
+CF_API CF_Shader CF_CALL cf_draw_peek_shader(void);
 
 /**
  * @function cf_draw_push_alpha_discard
@@ -1265,7 +1265,7 @@ CF_API void CF_CALL cf_draw_push_alpha_discard(bool true_enable_alpha_discard);
  * @remarks  Alpha discarding is useful to throw away pixels with zero alpha, for cutouts or as an optimization, or for certain blending techniques.
  * @related  TODO
  */
-CF_API bool CF_CALL cf_draw_pop_alpha_discard();
+CF_API bool CF_CALL cf_draw_pop_alpha_discard(void);
 
 /**
  * @function cf_draw_peek_alpha_discard
@@ -1274,7 +1274,7 @@ CF_API bool CF_CALL cf_draw_pop_alpha_discard();
  * @remarks  Alpha discarding is useful to throw away pixels with zero alpha, for cutouts or as an optimization, or for certain blending techniques.
  * @related  TODO
  */
-CF_API bool CF_CALL cf_draw_peek_alpha_discard();
+CF_API bool CF_CALL cf_draw_peek_alpha_discard(void);
 
 /**
  * @function cf_draw_set_texture
@@ -1427,7 +1427,7 @@ CF_API void CF_CALL cf_draw_TSR_absolute(CF_V2 position, CF_V2 scale, float radi
  *           ```
  * @related  cf_draw_push cf_draw_pop cf_draw_peek cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR
  */
-CF_API void CF_CALL cf_draw_push();
+CF_API void CF_CALL cf_draw_push(void);
 
 /**
  * @function cf_draw_pop
@@ -1437,7 +1437,7 @@ CF_API void CF_CALL cf_draw_push();
  *           system of anything else that needs to draw. See `cf_draw_push` for details.
  * @related  cf_draw_push cf_draw_pop cf_draw_peek cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR
  */
-CF_API void CF_CALL cf_draw_pop();
+CF_API void CF_CALL cf_draw_pop(void);
 
 /**
  * @function cf_draw_peek
@@ -1446,7 +1446,7 @@ CF_API void CF_CALL cf_draw_pop();
  * @remarks  Multiplying this matrix against a vector will transform the vector to "cam space" or "eye space".
  * @related  cf_draw_push cf_draw_pop
  */
-CF_API CF_M3x2 CF_CALL cf_draw_peek();
+CF_API CF_M3x2 CF_CALL cf_draw_peek(void);
 
 /**
  * @function cf_draw_projection
@@ -1491,7 +1491,7 @@ CF_API CF_V2 CF_CALL cf_screen_to_world(CF_V2 point);
  * @remarks  This can be useful for colliding against the screen, or implementing occlusion culling.
  * @related  cf_world_to_screen cf_screen_to_world cf_screen_bounds_to_world
  */
-CF_API CF_Aabb CF_CALL cf_screen_bounds_to_world();
+CF_API CF_Aabb CF_CALL cf_screen_bounds_to_world(void);
 
 /**
  * @function cf_draw_canvas

--- a/include/cute_file_system.h
+++ b/include/cute_file_system.h
@@ -332,7 +332,7 @@ typedef struct CF_Stat
  *           but probably is. You should probably mount the base directory with `cf_fs_mount`. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system) for an overview.
  * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount cf_fs_get_working_directory
  */
-CF_API const char* CF_CALL cf_fs_get_base_directory();
+CF_API const char* CF_CALL cf_fs_get_base_directory(void);
 
 /**
  * @function cf_fs_get_working_directory
@@ -341,7 +341,7 @@ CF_API const char* CF_CALL cf_fs_get_base_directory();
  * @remarks  Not all platforms have the concept of a working directory, but this function will sill try to return something sane in these cases.
  * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount cf_fs_get_working_directory
  */
-CF_API const char* CF_CALL cf_fs_get_working_directory();
+CF_API const char* CF_CALL cf_fs_get_working_directory(void);
 
 /**
  * @function cf_fs_set_write_directory
@@ -665,7 +665,7 @@ CF_API CF_Result CF_CALL cf_fs_write_string_range_to_file(const char* virtual_pa
  * @remarks  Feel free to call this whenever an error occurs in any of the file system functions to try and get a detailed description
  *           on what might have happened. Often times this string is already returned to you inside a `CF_Result`.
  */
-CF_API const char* CF_CALL cf_fs_get_backend_specific_error_message();
+CF_API const char* CF_CALL cf_fs_get_backend_specific_error_message(void);
 
 /**
  * @function cf_fs_get_actual_path
@@ -702,7 +702,7 @@ CF_API CF_Result CF_CALL cf_fs_init(const char* argv0);
  *           as `cf_app_destroy` already does this for you.
  * @related  cf_fs_init cf_fs_destroy
  */
-CF_API void CF_CALL cf_fs_destroy();
+CF_API void CF_CALL cf_fs_destroy(void);
 
 #ifdef __cplusplus
 }

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -163,7 +163,7 @@ CF_INLINE const char* cf_backend_type_to_string(CF_BackendType type) {
  * @brief    Returns which `CF_BackendType` is currently active.
  * @related  CF_BackendType cf_backend_type_to_string cf_query_backend
  */
-CF_API CF_BackendType CF_CALL cf_query_backend();
+CF_API CF_BackendType CF_CALL cf_query_backend(void);
 
 /**
  * @enum     CF_PixelFormat
@@ -1592,7 +1592,7 @@ typedef struct CF_RenderState
  * @brief    Returns a good set of default parameters for a `CF_RenderState`.
  * @related  CF_RenderState cf_render_state_defaults cf_material_set_render_state
  */
-CF_API CF_RenderState CF_CALL cf_render_state_defaults();
+CF_API CF_RenderState CF_CALL cf_render_state_defaults(void);
 
 //--------------------------------------------------------------------------------------------------
 // Material.
@@ -1655,7 +1655,7 @@ CF_INLINE const char* cf_uniform_type_string(CF_UniformType type) {
  *           uniforms (see `CF_UniformType`). For an overview see `CF_Material`.
  * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
  */
-CF_API CF_Material CF_CALL cf_make_material();
+CF_API CF_Material CF_CALL cf_make_material(void);
 
 /**
  * @function cf_destroy_material
@@ -1863,7 +1863,7 @@ CF_API void CF_CALL cf_apply_shader(CF_Shader shader, CF_Material material);
  * @brief    Draws all elements within the last applied mesh.
  * @related  CF_Mesh cf_create_mesh cf_apply_shader cf_apply_canvas
  */
-CF_API void CF_CALL cf_draw_elements();
+CF_API void CF_CALL cf_draw_elements(void);
 
 /**
  * @function cf_commit
@@ -1872,7 +1872,7 @@ CF_API void CF_CALL cf_draw_elements();
  * @remarks  You must call this after calling `cf_apply_shader` to "complete" the rendering pass.
  * @related  CF_Canvas cf_apply_canvas cf_apply_mesh cf_apply_shader
  */
-CF_API void CF_CALL cf_commit();
+CF_API void CF_CALL cf_commit(void);
 
 #ifdef __cplusplus
 }

--- a/include/cute_input.h
+++ b/include/cute_input.h
@@ -615,7 +615,7 @@ CF_API bool CF_CALL cf_key_repeating(CF_KeyButton key);
  * @brief    Returns true if the left or right control key is currently down.
  * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
  */
-CF_API bool CF_CALL cf_key_ctrl();
+CF_API bool CF_CALL cf_key_ctrl(void);
 
 /**
  * @function cf_key_shift
@@ -623,7 +623,7 @@ CF_API bool CF_CALL cf_key_ctrl();
  * @brief    Returns true if the left or right shift key is currently down.
  * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
  */
-CF_API bool CF_CALL cf_key_shift();
+CF_API bool CF_CALL cf_key_shift(void);
 
 /**
  * @function cf_key_alt
@@ -631,7 +631,7 @@ CF_API bool CF_CALL cf_key_shift();
  * @brief    Returns true if the left or right alt key is currently down.
  * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
  */
-CF_API bool CF_CALL cf_key_alt();
+CF_API bool CF_CALL cf_key_alt(void);
 
 /**
  * @function cf_key_gui
@@ -640,7 +640,7 @@ CF_API bool CF_CALL cf_key_alt();
  * @remarks  Windows key in Windows, Command key in OSX.
  * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
  */
-CF_API bool CF_CALL cf_key_gui();
+CF_API bool CF_CALL cf_key_gui(void);
 
 /**
  * @function cf_clear_key_states
@@ -648,7 +648,7 @@ CF_API bool CF_CALL cf_key_gui();
  * @brief    Zeroes out all internal keyboard state.
  * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
  */
-CF_API void CF_CALL cf_clear_key_states();
+CF_API void CF_CALL cf_clear_key_states(void);
 
 /**
  * @function cf_register_key_callback
@@ -665,7 +665,7 @@ CF_API void CF_CALL cf_register_key_callback(void (*key_callback)(CF_KeyButton k
  * @remarks  (0, 0) is the top-left of the screen, y-downards.
  * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
  */
-CF_API float CF_CALL cf_mouse_x();
+CF_API float CF_CALL cf_mouse_x(void);
 
 /**
  * @function cf_mouse_y
@@ -674,7 +674,7 @@ CF_API float CF_CALL cf_mouse_x();
  * @remarks  (0, 0) is the top-left of the screen, y-downwards.
  * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
  */
-CF_API float CF_CALL cf_mouse_y();
+CF_API float CF_CALL cf_mouse_y(void);
 
 /**
  * @function cf_mouse_motion_x
@@ -683,7 +683,7 @@ CF_API float CF_CALL cf_mouse_y();
  * @remarks  (0, 0) means there is no mouse movement, y-downwards.
  * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
  */
-CF_API float CF_CALL cf_mouse_motion_x();
+CF_API float CF_CALL cf_mouse_motion_x(void);
 
 /**
  * @function cf_mouse_motion_y
@@ -692,7 +692,7 @@ CF_API float CF_CALL cf_mouse_motion_x();
  * @remarks  (0, 0) means there is no mouse movement, y-downwards.
  * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
  */
-CF_API float CF_CALL cf_mouse_motion_y();
+CF_API float CF_CALL cf_mouse_motion_y(void);
 
 /**
  * @function cf_mouse_down
@@ -724,7 +724,7 @@ CF_API bool CF_CALL cf_mouse_just_released(CF_MouseButton button);
  * @brief    Returns a signed integer representing by how much the mouse wheel was rotated.
  * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
  */
-CF_API float CF_CALL cf_mouse_wheel_motion();
+CF_API float CF_CALL cf_mouse_wheel_motion(void);
 
 /**
  * @function cf_mouse_double_click_held
@@ -757,7 +757,7 @@ CF_API void CF_CALL cf_mouse_hide(bool true_to_hide);
  * @return   True means hidden, false means not hidden.
  * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window
  */
-CF_API bool CF_CALL cf_mouse_hidden();
+CF_API bool CF_CALL cf_mouse_hidden(void);
 
 /**
  * @function cf_mouse_lock_inside_window
@@ -811,7 +811,7 @@ CF_API void CF_CALL cf_input_text_add_utf8(const char* text);
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
  * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
  */
-CF_API int CF_CALL cf_input_text_pop_utf32();
+CF_API int CF_CALL cf_input_text_pop_utf32(void);
 
 /**
  * @function cf_input_text_has_data
@@ -821,7 +821,7 @@ CF_API int CF_CALL cf_input_text_pop_utf32();
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
  * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
  */
-CF_API bool CF_CALL cf_input_text_has_data();
+CF_API bool CF_CALL cf_input_text_has_data(void);
 
 /**
  * @function cf_input_text_get_buffer
@@ -842,7 +842,7 @@ CF_API bool CF_CALL cf_input_text_get_buffer(CF_InputTextBuffer* buffer);
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
  * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
  */
-CF_API void CF_CALL cf_input_text_clear();
+CF_API void CF_CALL cf_input_text_clear(void);
 
 /**
  * @function cf_input_enable_ime
@@ -852,7 +852,7 @@ CF_API void CF_CALL cf_input_text_clear();
  *           of different language inputs. This is usually a feature of the underlying operating system.
  * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
  */
-CF_API void CF_CALL cf_input_enable_ime();
+CF_API void CF_CALL cf_input_enable_ime(void);
 
 /**
  * @function cf_input_disable_ime
@@ -862,7 +862,7 @@ CF_API void CF_CALL cf_input_enable_ime();
  *           of different language inputs. This is usually a feature of the underlying operating system.
  * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
  */
-CF_API void CF_CALL cf_input_disable_ime();
+CF_API void CF_CALL cf_input_disable_ime(void);
 
 /**
  * @function cf_input_is_ime_enabled
@@ -872,7 +872,7 @@ CF_API void CF_CALL cf_input_disable_ime();
  *           of different language inputs. This is usually a feature of the underlying operating system.
  * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
  */
-CF_API bool CF_CALL cf_input_is_ime_enabled();
+CF_API bool CF_CALL cf_input_is_ime_enabled(void);
 
 /**
  * @function cf_input_has_ime_keyboard_support
@@ -882,7 +882,7 @@ CF_API bool CF_CALL cf_input_is_ime_enabled();
  *           of different language inputs. This is usually a feature of the underlying operating system.
  * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
  */
-CF_API bool CF_CALL cf_input_has_ime_keyboard_support();
+CF_API bool CF_CALL cf_input_has_ime_keyboard_support(void);
 
 /**
  * @function cf_input_is_ime_keyboard_shown
@@ -892,7 +892,7 @@ CF_API bool CF_CALL cf_input_has_ime_keyboard_support();
  *           of different language inputs. This is usually a feature of the underlying operating system.
  * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
  */
-CF_API bool CF_CALL cf_input_is_ime_keyboard_shown();
+CF_API bool CF_CALL cf_input_is_ime_keyboard_shown(void);
 
 /**
  * @function cf_input_set_ime_rect

--- a/include/cute_joypad.h
+++ b/include/cute_joypad.h
@@ -266,7 +266,7 @@ CF_API CF_Result CF_CALL cf_joypad_add_mapping(const char* mapping);
  *           be seen by Cute Framework.
  * @related  CF_Joypad cf_joypad_count cf_joypad_open cf_joypad_close
  */
-CF_API int CF_CALL cf_joypad_count();
+CF_API int CF_CALL cf_joypad_count(void);
 
 /**
  * @function cf_joypad_is_connected

--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -1108,7 +1108,7 @@ CF_INLINE CF_V2 cf_sign_v2(CF_V2 a) { return cf_v2(cf_sign(a.x), cf_sign(a.y)); 
  * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
  */
 CF_INLINE CF_SinCos cf_sincos_f(float radians) { CF_SinCos r; r.s = CF_SINF(radians); r.c = CF_COSF(radians); return r; }
-CF_INLINE CF_SinCos cf_sincos() { CF_SinCos r; r.c = 1.0f; r.s = 0; return r; }
+CF_INLINE CF_SinCos cf_sincos(void) { CF_SinCos r; r.c = 1.0f; r.s = 0; return r; }
 
 /**
  * @function cf_x_axis
@@ -1274,7 +1274,7 @@ CF_INLINE CF_M3x2 cf_mul_m32(CF_M3x2 a, CF_M3x2 b) { CF_M3x2 c; c.m = cf_mul_m2(
  * @brief    Returns an identity `CF_M3x2`.
  * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
  */
-CF_INLINE CF_M3x2 cf_make_identity() { CF_M3x2 m; m.m.x = cf_v2(1, 0); m.m.y = cf_v2(0, 1); m.p = cf_v2(0, 0); return m; }
+CF_INLINE CF_M3x2 cf_make_identity(void) { CF_M3x2 m; m.m.x = cf_v2(1, 0); m.m.y = cf_v2(0, 1); m.p = cf_v2(0, 0); return m; }
 
 /**
  * @function cf_make_translation_f
@@ -1394,7 +1394,7 @@ CF_INLINE CF_M3x2 cf_ortho_2d(float x, float y, float scale_x, float scale_y)
  * @brief    Returns an identity `CF_Transform`.
  * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
  */
-CF_INLINE CF_Transform cf_make_transform() { CF_Transform x; x.p = cf_v2(0, 0); x.r = cf_sincos(); return x; }
+CF_INLINE CF_Transform cf_make_transform(void) { CF_Transform x; x.p = cf_v2(0, 0); x.r = cf_sincos(); return x; }
 
 /**
  * @function cf_make_transform_TR

--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -149,7 +149,7 @@ CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
  * @brief    Returns a cryptography key in a cryptographically secure way.
  * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token
  */
-CF_API CF_CryptoKey CF_CALL cf_crypto_generate_key();
+CF_API CF_CryptoKey CF_CALL cf_crypto_generate_key(void);
 
 /**
  * @function cf_crypto_random_bytes
@@ -426,7 +426,7 @@ typedef struct CF_ServerConfig
  * @brief    Returns a good set of default parameters for `cf_make_server`.
  * @related  CF_ServerConfig cf_server_config_defaults cf_make_server
  */
-CF_INLINE CF_ServerConfig CF_CALL cf_server_config_defaults()
+CF_INLINE CF_ServerConfig CF_CALL cf_server_config_defaults(void)
 {
 	CF_ServerConfig config;
 	config.application_id = 0;

--- a/include/cute_png_cache.h
+++ b/include/cute_png_cache.h
@@ -69,7 +69,7 @@ typedef struct CF_Png
  * @return   Returns an empty `CF_Png` struct.
  * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
  */
-CF_INLINE CF_Png cf_png_defaults()
+CF_INLINE CF_Png cf_png_defaults(void)
 {
 	CF_Png result = { 0 };
 	result.id = ~0;

--- a/include/cute_result.h
+++ b/include/cute_result.h
@@ -69,7 +69,7 @@ CF_INLINE CF_Result cf_result_error(const char* details) { CF_Result result; res
  * @brief    Returns a `CF_Result` as a success, containing no error information.
  * @related  CF_Result cf_is_error cf_result_make cf_result_error cf_result_success
  */
-CF_INLINE CF_Result cf_result_success() { CF_Result result; result.code = CF_RESULT_SUCCESS; result.details = NULL; return result; }
+CF_INLINE CF_Result cf_result_success(void) { CF_Result result; result.code = CF_RESULT_SUCCESS; result.details = NULL; return result; }
 
 /**
  * @enum     CF_MessageBoxType

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -199,7 +199,7 @@ typedef struct CF_Sprite
  *           you may be looking for `cf_make_sprite` or `cf_make_easy_sprite`.
  * @related  CF_Sprite cf_sprite_defaults cf_make_easy_sprite cf_make_sprite
  */
-CF_INLINE CF_Sprite cf_sprite_defaults()
+CF_INLINE CF_Sprite cf_sprite_defaults(void)
 {
 	CF_Sprite sprite = { 0 };
 	sprite.scale = cf_v2(1, 1);
@@ -284,7 +284,7 @@ CF_API CF_Sprite CF_CALL cf_make_sprite_from_memory(const char* unique_name, con
  * @return   The sprite contains a few animations called "up", "side", "hold_down", "hold_side", "hold_up", "idle" you may try out.
  * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
  */
-CF_API CF_Sprite CF_CALL cf_make_demo_sprite();
+CF_API CF_Sprite CF_CALL cf_make_demo_sprite(void);
 
 /**
  * @function cf_sprite_unload

--- a/include/cute_time.h
+++ b/include/cute_time.h
@@ -230,7 +230,7 @@ CF_API bool CF_CALL cf_on_timestamp(double timestamp);
  * @remarks  Pause means from `cf_pause_for` or `cf_pause_for_ticks`.
  * @related  CF_PAUSE_TIME_LEFT cf_is_paused cf_pause_for cf_pause_for_ticks
  */
-CF_API bool CF_CALL cf_is_paused();
+CF_API bool CF_CALL cf_is_paused(void);
 
 /**
  * @function cf_get_ticks
@@ -240,7 +240,7 @@ CF_API bool CF_CALL cf_is_paused();
  *           queries the application for the number of ticks _right now_. Mostly useful for performance measuring.
  * @related  cf_get_ticks cf_get_tick_frequency
  */
-CF_API uint64_t CF_CALL cf_get_ticks();
+CF_API uint64_t CF_CALL cf_get_ticks(void);
 
 /**
  * @function cf_get_tick_frequency
@@ -248,7 +248,7 @@ CF_API uint64_t CF_CALL cf_get_ticks();
  * @brief    Returns the machine-dependent number of ticks that occur in one second.
  * @related  cf_get_ticks cf_get_tick_frequency
  */
-CF_API uint64_t CF_CALL cf_get_tick_frequency();
+CF_API uint64_t CF_CALL cf_get_tick_frequency(void);
 
 /**
  * @function cf_sleep
@@ -285,7 +285,7 @@ typedef struct CF_Stopwatch
  *           `cf_stopwatch_milliseconds`, or `cf_microseconds`.
  * @related  CF_Stopwatch cf_make_stopwatch cf_stopwatch_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
  */
-CF_API CF_Stopwatch CF_CALL cf_make_stopwatch();
+CF_API CF_Stopwatch CF_CALL cf_make_stopwatch(void);
 
 /**
  * @function cf_stopwatch_seconds


### PR DESCRIPTION
Because in C: `f()` actually means `f(...)` and even though the calling convention makes it OK, it's weird to have no errors for: `cf_draw_pop_color(color)`.