### PR TITLE
Cmake tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ name: Build CF
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  CMAKE_BUILD_PARALLEL_LEVEL: 6
   CMAKE_C_COMPILER_LAUNCHER: ccache
   CMAKE_CXX_COMPILER_LAUNCHER: ccache
 
@@ -74,14 +73,14 @@ jobs:
 
       - name: Build project binary (non-MSVC)
         run: |
-          cmake --build build_folder
+          cmake --build build_folder --parallel
         if: matrix.platform.name != 'Windows (MSCV 17 2022)'
 
       # Default for MSVC is to build with Debug, so a special case is needed to produce
       # Release binaries.
       - name: Build project binary (MSVC)
         run: |
-          cmake --build build_folder --config Release
+          cmake --build build_folder --config Release --parallel
         if: matrix.platform.name == 'Windows (MSCV 17 2022)'
 
       # Run tests for MSVC 17

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Docs parser
         run: |
           cmake -B build/debug -DCF_RUNTIME_SHADER_COMPILATION=OFF -DCF_CUTE_SHADERC=OFF
-          cmake --build build/debug --parallel 8 --target docsparser
+          cmake --build build/debug --parallel --target docsparser
           cd build/debug
           ./docsparser
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
           sudo apt-get install -y --no-install-recommends pngquant gcc-multilib libasound2-dev libpulse-dev \
             libglfw3 libglfw3-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxext-dev libxfixes-dev


### PR DESCRIPTION
This PR moves the parallel setting to the command line and uses the default number of threads, and ensures the apt packages are always up to date in the docs workflow.