### PR TITLE
Set default DPI accordingly

### DIFF
--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -296,6 +296,8 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	app->w = w;
 	app->h = h;
 	SDL_GetWindowPosition(app->window, &app->x, &app->y);
+	app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
+	app->dpi_scale_prev = app->dpi_scale;
 	::app = app;
 	cf_make_aseprite_cache();
 	cf_make_png_cache();


### PR DESCRIPTION
On macOS, HiDPI screen, the dpi_scale was set to 1.0, as it uses the struct's default.

When making the app, we should read the window's DPI setting and set it, as shown in https://wiki.libsdl.org/SDL3/README-highdpi.