### PR TITLE
Ensure that text effects are cleared at the end of text rendering

### DIFF
--- a/samples/text_drawing.cpp
+++ b/samples/text_drawing.cpp
@@ -97,10 +97,15 @@ int main(int argc, char* argv[])
 		push_font_size(13);
 		draw_text_boxed(draws.c_str(), V2(-640/2.0f + 10,-480/2.0f + 20));
 
+		push_font_size(26);
+		draw_text_boxed("Half-rendered effect <wave>groovy</wave>", V2(-230.f, 180.f), 25);
+		pop_font_size();
+
 		// Text shake effect.
 		// For moving text it helps to round positions.
 		push_font_size(30);
 		draw_text_boxed("Some <shake freq=35 x=2 y=2>shaking</shake> text.", round(V2(sinf((float)CF_SECONDS*0.25f)*100,cosf((float)CF_SECONDS*0.25f)*100)));
+
 
 		cf_push_text_id(1);
 		{

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2308,6 +2308,10 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 		hit_newline = false;
 	}
 
+	// If text_length is less than the sanitized length, there may be some left
+	// over effect that is not cleaned up
+	text_state->effects.clear();
+
 	if (render) {
 		// Draw strike-lines just after the text.
 		for (int i = 0; i < draw->strikes.size(); ++i) {


### PR DESCRIPTION
Without this, the entire text will be affected when `text_length` is less than the actual sanitized length.

I'm not sure what should be done with the effect and the markup callbacks because rendering did not reach the end.