### PR TITLE
Fix uniform upload in GLES

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -90,6 +90,11 @@ if (CF_CUTE_SHADERC)
 	)
 endif()
 
+# Ensure that sample data is included in web build
+if (EMSCRIPTEN)
+	target_link_options(waves PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/waves_data@/waves_data")
+endif ()
+
 # Copy over some folders for certain samples.
 add_custom_command(TARGET spaceshooter PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/spaceshooter_data $<TARGET_FILE_DIR:spaceshooter>/spaceshooter_data)
 add_custom_command(TARGET waves PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/waves_data $<TARGET_FILE_DIR:waves>/waves_data)

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -359,7 +359,7 @@ static void s_draw_report(spritebatch_sprite_t* sprites, int count, int texture_
 	cf_material_set_uniform_fs(draw->material, "u_texture_size", &u_texture_size, CF_UNIFORM_TYPE_FLOAT2, 1);
 	v2 u_texel_size = cf_v2(1.0f / (float)texture_w, 1.0f / (float)texture_h);
 	cf_material_set_uniform_fs(draw->material, "u_texel_size", &u_texel_size, CF_UNIFORM_TYPE_FLOAT2, 1);
-	cf_material_set_uniform_fs(draw->material, "u_alpha_discard", &cmd.alpha_discard, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_fs(draw->material, "u_alpha_discard", &cmd.alpha_discard, CF_UNIFORM_TYPE_INT, 1);
 
 	// Apply render state.
 	cf_material_set_render_state(draw->material, cmd.render_state);
@@ -2763,7 +2763,7 @@ void static s_blit(CF_Command* cmd, CF_Canvas src, CF_Canvas dst, bool clear_dst
 	cf_canvas_get_size(cmd->canvas, &w, &h);
 	v2 canvas_dims = V2((float)w, (float)h);
 	cf_material_set_uniform_fs(draw->material, "u_texture_size", &canvas_dims, CF_UNIFORM_TYPE_FLOAT2, 1);
-	cf_material_set_uniform_fs(draw->material, "u_alpha_discard", &cmd->alpha_discard, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_fs(draw->material, "u_alpha_discard", &cmd->alpha_discard, CF_UNIFORM_TYPE_INT, 1);
 
 	// Apply render state.
 	cf_material_set_render_state(draw->material, cmd->render_state);

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -1278,7 +1278,10 @@ static void s_upload_uniforms(CF_GL_ShaderInfo* shader_info, const CF_MaterialSt
 		const CF_ShaderUniformMemberInfo* member = s_find_member_info(block, uniform->name);
 		if (member == NULL) { continue; }
 
-		// TODO: assert type consistency
+		CF_UniformType uniform_type = s_uniform_type(member->type);
+		CF_ASSERT(uniform_type == uniform->type);
+		CF_ASSERT(s_uniform_size(uniform_type) * member->array_length == uniform->size);
+
 		int block_index = block - shader_info->uniform_blocks;
 		void* uniform_data = uniform_data_ptrs[block_index];
 		if (uniform_data == NULL) {

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -427,22 +427,6 @@ CF_INLINE CF_BackendType s_query_backend()
 	}
 }
 
-CF_INLINE CF_UniformType s_uniform_type(CF_ShaderInfoDataType type)
-{
-	switch (type) {
-	case CF_SHADER_INFO_TYPE_UNKNOWN: return CF_UNIFORM_TYPE_UNKNOWN;
-	case CF_SHADER_INFO_TYPE_FLOAT:   return CF_UNIFORM_TYPE_FLOAT;
-	case CF_SHADER_INFO_TYPE_FLOAT2:  return CF_UNIFORM_TYPE_FLOAT2;
-	case CF_SHADER_INFO_TYPE_FLOAT3:  return CF_UNIFORM_TYPE_FLOAT3;
-	case CF_SHADER_INFO_TYPE_FLOAT4:  return CF_UNIFORM_TYPE_FLOAT4;
-	case CF_SHADER_INFO_TYPE_SINT:	return CF_UNIFORM_TYPE_INT;
-	case CF_SHADER_INFO_TYPE_SINT2:   return CF_UNIFORM_TYPE_INT2;
-	case CF_SHADER_INFO_TYPE_SINT4:   return CF_UNIFORM_TYPE_INT4;
-	case CF_SHADER_INFO_TYPE_MAT4:	return CF_UNIFORM_TYPE_MAT4;
-	default: return CF_UNIFORM_TYPE_UNKNOWN;
-	}
-}
-
 CF_INLINE CF_ShaderInputFormat s_wrap(CF_ShaderInfoDataType type)
 {
 	switch (type) {

--- a/src/internal/cute_graphics_internal.h
+++ b/src/internal/cute_graphics_internal.h
@@ -75,6 +75,22 @@ CF_INLINE bool s_is_compatible(CF_ShaderInputFormat input_format, CF_VertexForma
 	}
 }
 
+CF_INLINE CF_UniformType s_uniform_type(CF_ShaderInfoDataType type)
+{
+	switch (type) {
+	case CF_SHADER_INFO_TYPE_UNKNOWN: return CF_UNIFORM_TYPE_UNKNOWN;
+	case CF_SHADER_INFO_TYPE_FLOAT:   return CF_UNIFORM_TYPE_FLOAT;
+	case CF_SHADER_INFO_TYPE_FLOAT2:  return CF_UNIFORM_TYPE_FLOAT2;
+	case CF_SHADER_INFO_TYPE_FLOAT3:  return CF_UNIFORM_TYPE_FLOAT3;
+	case CF_SHADER_INFO_TYPE_FLOAT4:  return CF_UNIFORM_TYPE_FLOAT4;
+	case CF_SHADER_INFO_TYPE_SINT:	return CF_UNIFORM_TYPE_INT;
+	case CF_SHADER_INFO_TYPE_SINT2:   return CF_UNIFORM_TYPE_INT2;
+	case CF_SHADER_INFO_TYPE_SINT4:   return CF_UNIFORM_TYPE_INT4;
+	case CF_SHADER_INFO_TYPE_MAT4:	return CF_UNIFORM_TYPE_MAT4;
+	default: return CF_UNIFORM_TYPE_UNKNOWN;
+	}
+}
+
 CF_INLINE int s_uniform_size(CF_UniformType type)
 {
 	switch (type) {


### PR DESCRIPTION
This fixes uniform upload.
Reflection info from the compiler is used instead of assuming the uniform block name.
Shaders with more than one block (e.g: draw shader) should work now.