### PR TITLE
Fix WebGL sync waits

### DIFF
--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include <cute_graphics.h>
+#include <cute_time.h>
 #include <spirv_cross_c.h>
 
 #ifdef CF_EMSCRIPTEN
@@ -265,7 +266,7 @@ static GLsizeiptr s_align_up(GLsizeiptr value, GLsizeiptr alignment)
 static GLenum s_poll_fence(GLsync fence)
 {
 	if (!fence) return GL_ALREADY_SIGNALED;
-    return glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
+	return glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 0);
 }
 
 static CF_GL_Slot* s_acquire_slot(CF_GL_Ring* ring, uint32_t frame, int* out_index)
@@ -307,9 +308,26 @@ static CF_GL_Slot* s_force_slot(CF_GL_Ring* ring, uint32_t frame, int* out_index
 	if (slot.fence) {
 		// Block the CPU until the GPU is done with this slot.
 		// If you're seeing this on the hot-path of a profile or flame-graph it means you're GPU bound.
+#ifdef CF_EMSCRIPTEN
+		while (slot.fence) {
+			GLenum status = s_poll_fence(slot.fence);
+			if (status == GL_ALREADY_SIGNALED || status == GL_CONDITION_SATISFIED) {
+				glDeleteSync(slot.fence);
+				slot.fence = 0;
+				break;
+			}
+			if (status == GL_WAIT_FAILED) {
+				glDeleteSync(slot.fence);
+				slot.fence = 0;
+				break;
+			}
+			cf_sleep(0);
+		}
+#else
 		glClientWaitSync(slot.fence, GL_SYNC_FLUSH_COMMANDS_BIT, GL_TIMEOUT_IGNORED);
 		glDeleteSync(slot.fence);
 		slot.fence = 0;
+#endif
 	}
 	slot.last_use_frame = frame;
 	ring->head = (index + 1) % ring->count;
@@ -330,6 +348,9 @@ static void s_set_slot_fence(CF_GL_Slot& slot)
 		glDeleteSync(slot.fence);
 	}
 	slot.fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+#ifdef CF_EMSCRIPTEN
+	glFlush();
+#endif
 }
 
 static CF_GL_RenderState s_default_state(CF_GL_Canvas* canvas)


### PR DESCRIPTION
## Summary
- avoid invalid WebGL sync waits by polling fences with zero timeout on Emscripten builds
- ensure fences are submitted on the GPU path by flushing after creation when running on the web backend
- keep polling Emscripten fences until they signal so resource uploads are not dropped when the GPU is still busy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c931b0588323b87c6be53d2c4d3f