### PR TITLE
Fix GLES depth and stencil handling

### DIFF
--- a/samples/stencil_pie_chart.c
+++ b/samples/stencil_pie_chart.c
@@ -1,78 +1,89 @@
 #include <cute.h>
 
+void update()
+{
+	cf_app_update(NULL);
+	CF_RenderState state = cf_render_state_defaults();
+	state.stencil.enabled = true;
+
+	cf_draw_push_antialias(false);
+	cf_draw_push_alpha_discard(true);
+
+	// Render a full white circle.
+	// Increment stencil buffer.
+	state.stencil.back = state.stencil.front = (CF_StencilFunction) {
+		.compare = CF_COMPARE_FUNCTION_ALWAYS,
+		.pass_op = CF_STENCIL_OP_INCREMENT_CLAMP,
+	};
+	state.stencil.read_mask = 0x0;
+	state.stencil.write_mask = 0xFF;
+	state.stencil.reference = 1;
+	cf_draw_push_render_state(state);
+	{
+		cf_draw_circle_fill2(cf_v2(0, 0), 100);
+		cf_render_to(cf_app_get_canvas(), true);
+	}
+	cf_draw_pop_render_state();
+
+	// Draw the wedge as an oversized triangle.
+	// Increment stencil buffer again; 0->1, 1->2, where 1->2 is the intersection of the wedge + circle.
+	state.stencil.back = state.stencil.front = (CF_StencilFunction) {
+		.compare = CF_COMPARE_FUNCTION_ALWAYS,
+		.pass_op = CF_STENCIL_OP_INCREMENT_CLAMP,
+	};
+	state.stencil.read_mask = 0x0;
+	state.stencil.write_mask = 0xFF;
+	state.stencil.reference = 1;
+	cf_draw_push_render_state(state);
+	{
+		cf_draw_push_color(cf_color_red());
+		cf_draw_tri_fill(cf_v2(0,0), cf_v2(150,150), cf_v2(-150,150), 0);
+		cf_render_to(cf_app_get_canvas(), false);
+	}
+	cf_draw_pop_render_state();
+
+	// Clear everything except the intersection.
+	cf_draw_push_alpha_discard(false);
+	state.stencil.back = state.stencil.front = (CF_StencilFunction) {
+		.compare = CF_COMPARE_FUNCTION_NOT_EQUAL,
+		.pass_op = CF_STENCIL_OP_ZERO,
+	};
+	state.stencil.read_mask = 0xFF;
+	state.stencil.write_mask = 0x0;
+	state.stencil.reference = 2;
+	cf_draw_push_render_state(state);
+	{
+		cf_draw_push_color(cf_color_invisible());
+		cf_draw_box_fill(cf_make_aabb(cf_v2(-1000,-1000), cf_v2(1000,1000)), 0);
+		cf_render_to(cf_app_get_canvas(), false);
+	}
+	cf_draw_pop_render_state();
+
+	// Draw yellow border.
+	cf_draw_push_antialias(true);
+	cf_draw_push_alpha_discard(true);
+	cf_draw_push_color(cf_color_yellow());
+	cf_draw_circle2(cf_v2(0,0), 100, 3);
+
+	// Draw the result onto the screen
+	cf_app_draw_onto_screen(false);
+}
+
 int main(int argc, char* argv[])
 {
 	int w = 640, h = 480;
 	cf_make_app("Stencil Outline", 0, 0, 0, w, h, CF_APP_OPTIONS_RESIZABLE_BIT | CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
 	cf_set_target_framerate(200);
 
-	while (cf_app_is_running()) {
-		cf_app_update(NULL);
-		CF_RenderState state = cf_render_state_defaults();
-		state.stencil.enabled = true;
-
-		cf_draw_push_antialias(false);
-		cf_draw_push_alpha_discard(true);
-
-		// Render a full white circle.
-		// Increment stencil buffer.
-		state.stencil.back = state.stencil.front = (CF_StencilFunction) {
-			.compare = CF_COMPARE_FUNCTION_ALWAYS,
-			.pass_op = CF_STENCIL_OP_INCREMENT_CLAMP,
-		};
-		state.stencil.read_mask = 0x0;
-		state.stencil.write_mask = 0xFF;
-		state.stencil.reference = 1;
-		cf_draw_push_render_state(state);
-		{
-			cf_draw_circle_fill2(cf_v2(0, 0), 100);
-			cf_render_to(cf_app_get_canvas(), true);
-		}
-		cf_draw_pop_render_state();
-
-		// Draw the wedge as an oversized triangle.
-		// Increment stencil buffer again; 0->1, 1->2, where 1->2 is the intersection of the wedge + circle.
-		state.stencil.back = state.stencil.front = (CF_StencilFunction) {
-			.compare = CF_COMPARE_FUNCTION_ALWAYS,
-			.pass_op = CF_STENCIL_OP_INCREMENT_CLAMP,
-		};
-		state.stencil.read_mask = 0x0;
-		state.stencil.write_mask = 0xFF;
-		state.stencil.reference = 1;
-		cf_draw_push_render_state(state);
-		{
-			cf_draw_push_color(cf_color_red());
-			cf_draw_tri_fill(cf_v2(0,0), cf_v2(150,150), cf_v2(-150,150), 0);
-			cf_render_to(cf_app_get_canvas(), false);
-		}
-		cf_draw_pop_render_state();
-
-		// Clear everything except the intersection.
-		cf_draw_push_alpha_discard(false);
-		state.stencil.back = state.stencil.front = (CF_StencilFunction) {
-			.compare = CF_COMPARE_FUNCTION_NOT_EQUAL,
-			.pass_op = CF_STENCIL_OP_ZERO,
-		};
-		state.stencil.read_mask = 0xFF;
-		state.stencil.write_mask = 0x0;
-		state.stencil.reference = 2;
-		cf_draw_push_render_state(state);
-		{
-			cf_draw_push_color(cf_color_invisible());
-			cf_draw_box_fill(cf_make_aabb(cf_v2(-1000,-1000), cf_v2(1000,1000)), 0);
-			cf_render_to(cf_app_get_canvas(), false);
-		}
-		cf_draw_pop_render_state();
-
-		// Draw yellow border.
-		cf_draw_push_antialias(true);
-		cf_draw_push_alpha_discard(true);
-		cf_draw_push_color(cf_color_yellow());
-		cf_draw_circle2(cf_v2(0,0), 100, 3);
-
-		// Draw the result onto the screen
-		cf_app_draw_onto_screen(false);
+#ifdef CF_EMSCRIPTEN
+	// Receives a function to call and some user data to provide it.
+	emscripten_set_main_loop(update, 60, true);
+#else
+	while (app_is_running()) {
+		update();
 	}
+	destroy_app();
+#endif
 
 	cf_destroy_app();
 


### PR DESCRIPTION
## Summary
- track depth/stencil availability on CF_GL_Canvas and add helpers for querying it
- only clear depth/stencil buffers when present and ensure canvas binding updates state correctly
- update GLES shader application to configure depth and stencil state, including stencil operations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5cc0f454c83238f0a20c237284929