### PR TITLE
Fix SDL GPU depth/stencil handling

### DIFF
--- a/samples/stencil_pie_chart.c
+++ b/samples/stencil_pie_chart.c
@@ -82,7 +82,6 @@ int main(int argc, char* argv[])
 	while (cf_app_is_running()) {
 		update();
 	}
-	cf_destroy_app();
 #endif
 
 	cf_destroy_app();

--- a/samples/stencil_pie_chart.c
+++ b/samples/stencil_pie_chart.c
@@ -79,10 +79,10 @@ int main(int argc, char* argv[])
 	// Receives a function to call and some user data to provide it.
 	emscripten_set_main_loop(update, 60, true);
 #else
-	while (app_is_running()) {
+	while (cf_app_is_running()) {
 		update();
 	}
-	destroy_app();
+	cf_destroy_app();
 #endif
 
 	cf_destroy_app();

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -1145,11 +1145,8 @@ CF_Canvas cf_gles_make_canvas(CF_CanvasParams params)
 	s_bind_framebuffer(c->fbo);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, c->color, 0);
 	if (c->depth) {
-		if (params.depth_stencil_target.pixel_format == CF_PIXEL_FORMAT_D24_UNORM_S8_UINT) {
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, c->depth);
-		} else {
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, c->depth);
-		}
+		GLenum attachment = c->has_stencil ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, attachment, GL_RENDERBUFFER, c->depth);
 	}
 	CF_ASSERT(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 	CF_POLL_OPENGL_ERROR();

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -414,17 +414,19 @@ CF_INLINE SDL_GPUVertexElementFormat s_wrap(CF_VertexFormat format)
 
 CF_INLINE CF_BackendType s_query_backend()
 {
-	SDL_GPUShaderFormat format = SDL_GetGPUShaderFormats(g_ctx.device);
-	switch (format) {
-	case SDL_GPU_SHADERFORMAT_INVALID:  return CF_BACKEND_TYPE_INVALID;
-	case SDL_GPU_SHADERFORMAT_PRIVATE:  return CF_BACKEND_TYPE_PRIVATE;
-	case SDL_GPU_SHADERFORMAT_SPIRV:	return CF_BACKEND_TYPE_VULKAN;
-	case SDL_GPU_SHADERFORMAT_DXBC:	 return CF_BACKEND_TYPE_D3D11;
-	case SDL_GPU_SHADERFORMAT_DXIL:	 return CF_BACKEND_TYPE_D3D12;
-	case SDL_GPU_SHADERFORMAT_MSL:	  // Fall through.
-	case SDL_GPU_SHADERFORMAT_METALLIB: // Fall through.
-	case SDL_GPU_SHADERFORMAT_MSL | SDL_GPU_SHADERFORMAT_METALLIB: return CF_BACKEND_TYPE_METAL;
-	default: return CF_BACKEND_TYPE_INVALID;
+	const char* driver = SDL_GetGPUDeviceDriver(g_ctx.device);
+	if (sequ(driver, "vulkan")) {
+		return CF_BACKEND_TYPE_VULKAN;
+	} else if (sequ(driver, "metal")) {
+		return CF_BACKEND_TYPE_METAL;
+	} else if (sequ(driver, "direct3d11")) {
+		return CF_BACKEND_TYPE_D3D11;
+	} else if (sequ(driver, "direct3d12")) {
+		return CF_BACKEND_TYPE_D3D12;
+	} else if (sequ(driver, "private")) { // Is this the right string??
+		return CF_BACKEND_TYPE_PRIVATE;
+	} else {
+		return CF_BACKEND_TYPE_INVALID;
 	}
 }
 

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -42,6 +42,7 @@ struct CF_TextureInternal
 	SDL_GPUTexture* tex;
 	SDL_GPUTransferBuffer* buf;
 	SDL_GPUSampler* sampler;
+	CF_PixelFormat pixel_format;
 	SDL_GPUTextureFormat format;
 	SDL_GPUTextureSamplerBinding binding;
 };
@@ -516,6 +517,7 @@ static CF_Texture s_make_texture(CF_TextureParams params, CF_SampleCount sample_
 	tex_internal->tex = tex;
 	tex_internal->buf = buf;
 	tex_internal->sampler = sampler;
+	tex_internal->pixel_format = params.pixel_format;
 	tex_internal->format = tex_info.format;
 	tex_internal->binding.texture = tex;
 	tex_internal->binding.sampler = sampler;
@@ -1286,7 +1288,7 @@ static SDL_GPUGraphicsPipeline* s_build_pipeline(CF_ShaderInternal* shader, CF_R
 	const bool depth_test_requested = state->depth_write_enabled || state->depth_compare != CF_COMPARE_FUNCTION_ALWAYS;
 	CF_TextureInternal* depth_texture = has_depth_stencil_texture ? (CF_TextureInternal*)g_ctx.canvas->cf_depth_stencil.id : NULL;
 	const bool depth_test_enabled = (depth_texture != NULL) && depth_test_requested;
-	const bool stencil_capable = depth_texture && cf_pixel_format_has_stencil(depth_texture->format);
+	const bool stencil_capable = depth_texture && cf_pixel_format_has_stencil(depth_texture->pixel_format);
 	const bool stencil_test_enabled = stencil_capable && state->stencil.enabled;
 	if (depth_texture && (depth_test_enabled || stencil_test_enabled)) {
 		pip_info.target_info.depth_stencil_format = depth_texture->format;
@@ -1427,7 +1429,7 @@ void cf_sdlgpu_apply_shader(CF_Shader shader_handle, CF_Material material_handle
 	CF_TextureInternal* depth_texture = has_depth_stencil_texture ? (CF_TextureInternal*)g_ctx.canvas->cf_depth_stencil.id : NULL;
 	const bool depth_test_requested = state->depth_write_enabled || state->depth_compare != CF_COMPARE_FUNCTION_ALWAYS;
 	const bool depth_test_enabled = (depth_texture != NULL) && depth_test_requested;
-	const bool stencil_capable = depth_texture && cf_pixel_format_has_stencil(depth_texture->format);
+	const bool stencil_capable = depth_texture && cf_pixel_format_has_stencil(depth_texture->pixel_format);
 	const bool stencil_test_enabled = stencil_capable && state->stencil.enabled;
 	const bool use_depth_stencil_target = depth_texture && (depth_test_enabled || stencil_test_enabled);
 	

--- a/src/internal/cute_graphics_internal.h
+++ b/src/internal/cute_graphics_internal.h
@@ -167,6 +167,17 @@ CF_INLINE bool cf_pixel_format_is_depth(CF_PixelFormat format)
 	}
 }
 
+CF_INLINE bool cf_pixel_format_has_stencil(CF_PixelFormat format)
+{
+	switch (format) {
+	case CF_PIXEL_FORMAT_D24_UNORM_S8_UINT:
+	case CF_PIXEL_FORMAT_D32_FLOAT_S8_UINT:
+		return true;
+	default:
+		return false;
+	}
+}
+
 CF_INLINE bool cf_pixel_format_has_alpha(CF_PixelFormat format)
 {
 	switch (format) {


### PR DESCRIPTION
## Summary
- ensure SDL GPU pipelines request depth testing when compare-only reads or stencil operations are used
- preserve depth/stencil attachments across passes and reuse a shared helper to detect stencil-capable formats

## Testing
- cmake -S . -B build *(fails: missing OpenGL libraries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e45efa4c83239d7463dc5f6b5b4d