### PR TITLE
Refine header related-link documentation

### DIFF
--- a/include/cute_alloc.h
+++ b/include/cute_alloc.h
@@ -19,7 +19,7 @@ extern "C" {
  * @category allocator
  * @brief    A simple way to allocate memory without calling `malloc` too often.
  * @remarks  Individual allocations cannot be free'd, instead the entire allocator can reset.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_allocator_restore_default cf_alloc
  */
 typedef struct CF_Allocator
 {
@@ -47,7 +47,7 @@ typedef struct CF_Allocator
  * @remarks  The default allocator simply calls malloc/free and friends. You may override this behavior by passing
  *           a `CF_Allocator` to this function. This lets you hook up your own custom allocator. Usually you only want
  *           to do this on certain platforms for performance optimizations, but is not a necessary thing to do for many games.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_restore_default cf_alloc cf_free
  */
 CF_API void CF_CALL cf_allocator_override(CF_Allocator allocator);
 
@@ -58,7 +58,7 @@ CF_API void CF_CALL cf_allocator_override(CF_Allocator allocator);
  * @remarks  The default allocator simply calls malloc/free and friends. You may override this behavior by passing
  *           a `CF_Allocator` to this function. This lets you hook up your own custom allocator. Usually you only want
  *           to do this on certain platforms for performance optimizations, but is not a necessary thing to do for many games.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_alloc cf_free
  */
 CF_API void CF_CALL cf_allocator_restore_default(void);
 
@@ -66,7 +66,7 @@ CF_API void CF_CALL cf_allocator_restore_default(void);
  * @function cf_alloc
  * @category allocator
  * @brief    Allocates a block of memory of `size` bytes and returns it.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_allocator_restore_default cf_free
  */
 CF_API void* CF_CALL cf_alloc(size_t size);
 
@@ -74,7 +74,7 @@ CF_API void* CF_CALL cf_alloc(size_t size);
  * @function cf_free
  * @category allocator
  * @brief    Frees a block of memory previously allocated by `cf_alloc`.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_allocator_restore_default cf_alloc
  */
 CF_API void CF_CALL cf_free(void* ptr);
 
@@ -84,7 +84,7 @@ CF_API void CF_CALL cf_free(void* ptr);
  * @brief    Allocates a block of memory `size * count` bytes in size.
  * @remarks  The memory returned is completely zero'd out. Generally this is more efficient than calling `cf_malloc` and
  *           then clearing the memory to zero yourself. Though, it's not a concern for most games.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_allocator_restore_default cf_alloc
  */
 CF_API void* CF_CALL cf_calloc(size_t size, size_t count);
 
@@ -94,7 +94,7 @@ CF_API void* CF_CALL cf_calloc(size_t size, size_t count);
  * @brief    Reallocates a block of memory to a new size.
  * @remarks  You must reassign your old pointer! Generally this is more efficient than calling `cf_malloc`, `cf_free`, and
  *           `CF_MEMCPY` yourself. Though, this is not a concern for most games.
- * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
+ * @related  cf_allocator_override cf_allocator_restore_default cf_alloc
  */
 CF_API void* CF_CALL cf_realloc(void* ptr, size_t size);
 
@@ -167,7 +167,7 @@ typedef struct CF_Arena
  * @param    arena         The arena to initialize.
  * @param    alignment     An alignment boundary, must be a power of two.
  * @param    block_size    The default size of each internal call to `malloc` to form pages to further allocate from.
- * @related  cf_arena_init cf_arena_alloc cf_arena_reset cf_arena_free
+ * @related  cf_arena_alloc cf_arena_reset cf_arena_free
  */
 CF_API CF_Arena CF_CALL cf_make_arena(int alignment, int block_size);
 
@@ -178,7 +178,7 @@ CF_API CF_Arena CF_CALL cf_make_arena(int alignment, int block_size);
  * @param    arena         The arena to allocate from.
  * @param    size          The size of the allocation, it cannot be larger than `block_size` from `cf_arena_init`.
  * @return   Returns an aligned pointer of `size` bytes.
- * @related  cf_arena_init cf_arena_alloc cf_arena_reset cf_arena_free
+ * @related  cf_arena_init cf_arena_reset cf_arena_free
  */
 CF_API void* CF_CALL cf_arena_alloc(CF_Arena* arena, int size);
 
@@ -192,7 +192,7 @@ CF_API void* CF_CALL cf_arena_alloc(CF_Arena* arena, int size);
  *           only the most recent allocation(s) can be freed. It does not support freeing allocations in 
  *           arbitrary order. Minimal error checking is performed, so only call this function if you
  *           know what you're doing, otherwise you'll get memory corruption issues.
- * @related  cf_arena_init cf_arena_alloc cf_arena_reset cf_arena_free
+ * @related  cf_arena_init cf_arena_alloc cf_arena_reset
  */
 CF_API void CF_CALL cf_arena_free(CF_Arena* arena, int ptr);
 
@@ -203,7 +203,7 @@ CF_API void CF_CALL cf_arena_free(CF_Arena* arena, int ptr);
  * @param    arena         The arena to reset.
  * @remarks  This does not free up internal resources, and will reuse all previously allocated
  *           resources to fulfill subsequent `cf_arena_alloc` calls.
- * @related  cf_arena_init cf_arena_alloc cf_arena_reset cf_arena_free
+ * @related  cf_arena_init cf_arena_alloc cf_arena_free
  */
 CF_API void CF_CALL cf_arena_reset(CF_Arena* arena);
 
@@ -212,7 +212,7 @@ CF_API void CF_CALL cf_arena_reset(CF_Arena* arena);
  * @category allocator
  * @brief    Free's up all resources used by the allocator.
  * @param    arena         The arena to free.
- * @related  cf_arena_init cf_arena_alloc cf_arena_reset cf_arena_free
+ * @related  cf_arena_init cf_arena_alloc cf_arena_reset
  */
 CF_API void CF_CALL cf_destroy_arena(CF_Arena* arena);
 
@@ -230,7 +230,7 @@ typedef struct CF_MemoryPool CF_MemoryPool;
 
  * @param    alignment      An alignment boundary, must be a power of two.
  * @return   Returns a memory pool pointer.
- * @related  cf_destroy_memory_pool cf_memory_pool_alloc cf_memory_pool_free
+ * @related  cf_memory_pool_alloc cf_memory_pool_free cf_destroy_memory_pool
  */
 CF_API CF_MemoryPool* CF_CALL cf_make_memory_pool(int element_size, int element_count, int alignment);
 
@@ -249,7 +249,7 @@ CF_API void CF_CALL cf_destroy_memory_pool(CF_MemoryPool* pool);
  * @brief    Allocates a chunk of memory from the pool. The allocation size was determined by `element_size` in `cf_make_memory_pool`.
  * @param    pool           The pool.
  * @return   Returns an aligned pointer of `size` bytes.
- * @related  cf_make_memory_pool cf_destroy_memory_pool cf_memory_pool_free
+ * @related  cf_memory_pool_free cf_make_memory_pool cf_destroy_memory_pool
  */
 CF_API void* CF_CALL cf_memory_pool_alloc(CF_MemoryPool* pool);
 
@@ -259,7 +259,7 @@ CF_API void* CF_CALL cf_memory_pool_alloc(CF_MemoryPool* pool);
  * @brief    Frees an allocation made by `cf_memory_pool_alloc`.
  * @param    pool           The pool.
  * @param    element        The pointer to deallocate.
- * @related  cf_make_memory_pool cf_destroy_memory_pool cf_memory_pool_alloc
+ * @related  cf_memory_pool_alloc cf_make_memory_pool cf_destroy_memory_pool
  */
 CF_API void CF_CALL cf_memory_pool_free(CF_MemoryPool* pool, void* element);
 

--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -62,7 +62,7 @@ CF_API CF_DisplayID CF_CALL cf_default_display(void);
  * @category app
  * @brief    Returns the number of displays on the system.
  * @remarks  Inidices >= 0 and < the return value are valid display indices.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_x cf_display_y cf_display_width
  */
 CF_API int CF_CALL cf_display_count(void);
 
@@ -88,7 +88,7 @@ CF_API void CF_CALL cf_free_display_list(CF_DisplayID* display_list);
  * @brief    Returns the x position, in pixels, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
  * @remarks  Display positions are in a global space, so different displays have different but unique coordinates.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_y cf_display_width
  */
 CF_API int CF_CALL cf_display_x(CF_DisplayID display_id);
 
@@ -98,7 +98,7 @@ CF_API int CF_CALL cf_display_x(CF_DisplayID display_id);
  * @brief    Returns the y position, in pixels, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
  * @remarks  Display positions are in a global space, so different displays have different but unique coordinates.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_width
  */
 CF_API int CF_CALL cf_display_y(CF_DisplayID display_id);
 
@@ -107,7 +107,7 @@ CF_API int CF_CALL cf_display_y(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the width, in pixels, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API int CF_CALL cf_display_width(CF_DisplayID display_id);
 
@@ -116,7 +116,7 @@ CF_API int CF_CALL cf_display_width(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the height, in pixels, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API int CF_CALL cf_display_height(CF_DisplayID display_id);
 
@@ -125,7 +125,7 @@ CF_API int CF_CALL cf_display_height(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the refresh rate, in hz, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API float CF_CALL cf_display_refresh_rate(CF_DisplayID display_id);
 
@@ -134,7 +134,7 @@ CF_API float CF_CALL cf_display_refresh_rate(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the bounds, in pixels, of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API CF_Rect CF_CALL cf_display_bounds(CF_DisplayID display_id);
 
@@ -143,7 +143,7 @@ CF_API CF_Rect CF_CALL cf_display_bounds(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the name of the display.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API const char* CF_CALL cf_display_name(CF_DisplayID display_id);
 
@@ -152,7 +152,7 @@ CF_API const char* CF_CALL cf_display_name(CF_DisplayID display_id);
  * @category app
  * @brief    Returns the orientation.
  * @param    display_id    The id of the display. See `cf_get_display_list`.
- * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
+ * @related  cf_display_count cf_display_x cf_display_y
  */
 CF_API CF_DisplayOrientation CF_CALL cf_display_orientation(CF_DisplayID display_id);
 
@@ -171,7 +171,7 @@ CF_API CF_DisplayOrientation CF_CALL cf_display_orientation(CF_DisplayID display
  *         return 0;
  *     }
  * @remarks  The `app_options` parameter of `cf_make_app` is a bitmask flag. Simply take the `APP_OPTIONS_*` flags listed above and OR them together.
- * @related  CF_AppOptionFlagBits cf_make_app cf_destroy_app
+ * @related  cf_destroy_app cf_make_app
  */
 #define CF_APP_OPTION_DEFS \
 	/* @entry Does not initialize any graphics backend at all (for servers or headless mode). */ \
@@ -246,7 +246,7 @@ typedef enum CF_AppOptionFlagBits
  *     }
  * @remarks  The options parameter is an enum from `app_options`. Different options can be OR'd together.
  *           Parameters `w` and `h` are ignored if the window is initialized to fullscreen mode with `APP_OPTIONS_FULLSCREEN`.
- * @related  CF_AppOptionFlagBits cf_app_is_running cf_app_signal_shutdown cf_destroy_app
+ * @related  cf_app_is_running cf_app_signal_shutdown cf_destroy_app
  */
 CF_API CF_Result CF_CALL cf_make_app(const char* window_title, CF_DisplayID display_id, int x, int y, int w, int h, CF_AppOptionFlags options, const char* argv0);
 
@@ -286,7 +286,7 @@ CF_API void CF_CALL cf_destroy_app(void);
  * @remarks  Some OS events, like clicking the red X on the app, will signal the app should shutdown.
  *           This will cause this function to return false. You may manually call `cf_app_signal_shutdown`
  *           to signal a shutdown.
- * @related  cf_make_app cf_destroy_app cf_app_signal_shutdown
+ * @related  cf_app_signal_shutdown cf_make_app cf_destroy_app
  */
 CF_API bool CF_CALL cf_app_is_running(void);
 
@@ -318,7 +318,7 @@ CF_API bool CF_CALL cf_app_is_running(void);
  *         
  *         return 0;
  *     }
- * @related  cf_make_app cf_destroy_app cf_app_is_running
+ * @related  cf_app_is_running cf_make_app cf_destroy_app
  */
 CF_API void CF_CALL cf_app_signal_shutdown(void);
 
@@ -327,7 +327,7 @@ CF_API void CF_CALL cf_app_signal_shutdown(void);
  * @category app
  * @brief    Updates the application. Must be called once per frame, at the beginning of the frame.
  * @param    on_update  Called for each update tick.
- * @related  cf_make_app cf_app_is_running cf_app_signal_shutdown cf_destroy_app
+ * @related  cf_app_is_running cf_app_signal_shutdown cf_make_app
  */
 CF_API void CF_CALL cf_app_update(CF_OnUpdateFn* on_update);
 
@@ -357,7 +357,7 @@ CF_API void CF_CALL cf_app_update(CF_OnUpdateFn* on_update);
  *         return 0;
  *     }
  * @remarks  Call this at the *end* of your main loop. You may only call this function once per game tick.
- * @related  cf_make_app cf_app_is_running cf_app_signal_shutdown cf_destroy_app
+ * @related  cf_app_is_running cf_app_signal_shutdown cf_make_app
  */
 CF_API int CF_CALL cf_app_draw_onto_screen(bool clear);
 
@@ -367,7 +367,7 @@ CF_API int CF_CALL cf_app_draw_onto_screen(bool clear);
  * @brief    Gets the size of the window in pixels.
  * @param    w          The width of the window in pixels.
  * @param    h          The height of the window in pixels.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_get_position cf_app_get_width cf_app_get_height
  */
 CF_API void CF_CALL cf_app_get_size(int* w, int* h);
 
@@ -375,7 +375,7 @@ CF_API void CF_CALL cf_app_get_size(int* w, int* h);
  * @function cf_app_get_width
  * @category app
  * @brief    Returns the size of the window width in pixels.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_get_position cf_app_get_height cf_app_get_dpi_scale
  */
 CF_API int CF_CALL cf_app_get_width(void);
 
@@ -383,7 +383,7 @@ CF_API int CF_CALL cf_app_get_width(void);
  * @function cf_app_get_height
  * @category app
  * @brief    Returns the size of the window height in pixels.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_get_position cf_app_get_width cf_app_get_dpi_scale
  */
 CF_API int CF_CALL cf_app_get_height(void);
 
@@ -391,7 +391,7 @@ CF_API int CF_CALL cf_app_get_height(void);
  * @function cf_app_show_window
  * @category app
  * @brief    Brings the app out of a minimized/hidden state.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_set_size cf_app_set_position cf_app_get_position
  */
 CF_API void CF_CALL cf_app_show_window(void);
 
@@ -404,7 +404,7 @@ CF_API void CF_CALL cf_app_show_window(void);
  *           to aid in readability. These devices have very small pixels. Most of the time you should ignore dpi and let the OS
  *           handle this. CF enables DPI settings by default, but, you can see if this function returns 2.0f to let you know if
  *           pixels are clustered for you under the hood.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
+ * @related  cf_app_get_position cf_app_get_width cf_app_get_height
  */
 CF_API float CF_CALL cf_app_get_dpi_scale(void);
 
@@ -412,7 +412,7 @@ CF_API float CF_CALL cf_app_get_dpi_scale(void);
  * @function cf_app_dpi_scale_was_changed
  * @category app
  * @brief    Returns true if the DPI scaling changed, such as moving from one screen to another.
- * @related  cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
+ * @related  cf_app_get_dpi_scale
  */
 CF_API bool CF_CALL cf_app_dpi_scale_was_changed(void);
 
@@ -422,7 +422,7 @@ CF_API bool CF_CALL cf_app_dpi_scale_was_changed(void);
  * @brief    Sets the size of the window in pixels.
  * @param    w          The width of the window in pixels.
  * @param    h          The height of the window in pixels.
- * @related  cf_app_get_size cf_app_get_position cf_app_set_position
+ * @related  cf_app_set_position cf_app_get_size cf_app_get_position
  */
 CF_API void CF_CALL cf_app_set_size(int w, int h);
 
@@ -432,7 +432,7 @@ CF_API void CF_CALL cf_app_set_size(int w, int h);
  * @brief    Gets the position of the window in pixels.
  * @param    x          The x position of the window in pixels.
  * @param    y          The y position of the window in pixels.
- * @related  cf_app_get_size cf_app_set_size cf_app_set_position cf_app_center_window
+ * @related  cf_app_get_size cf_app_set_size cf_app_set_position
  */
 CF_API void CF_CALL cf_app_get_position(int* x, int* y);
 
@@ -442,7 +442,7 @@ CF_API void CF_CALL cf_app_get_position(int* x, int* y);
  * @brief    Sets the position of the window in pixels.
  * @param    x          The x position of the window in pixels.
  * @param    y          The y position of the window in pixels.
- * @related  cf_app_get_size cf_app_set_size cf_app_get_position cf_app_center_window
+ * @related  cf_app_set_size cf_app_get_size cf_app_get_position
  */
 CF_API void CF_CALL cf_app_set_position(int x, int y);
 
@@ -450,7 +450,7 @@ CF_API void CF_CALL cf_app_set_position(int x, int y);
  * @function cf_app_center_window
  * @category app
  * @brief    Sets the window position centered on the screen.
- * @related  cf_app_get_size cf_app_set_size cf_app_get_position cf_app_center_window
+ * @related  cf_app_get_size cf_app_set_size cf_app_get_position
  */
 CF_API void CF_CALL cf_app_center_window(void);
 
@@ -502,7 +502,7 @@ CF_API bool CF_CALL cf_app_has_focus(void);
  * @category app
  * @brief    Requests attention for the window for a brief period.
  * @remarks  On Windows this flashes the tab icon, and bounces the dock icon on OSX.
- * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
+ * @related  cf_app_request_attention_continuously cf_app_request_attention_cancel
  */
 CF_API void CF_CALL cf_app_request_attention(void);
 
@@ -511,7 +511,7 @@ CF_API void CF_CALL cf_app_request_attention(void);
  * @category app
  * @brief    Requests attention for the window for continuously.
  * @remarks  On Windows this flashes the tab icon, and bounces the dock icon on OSX.
- * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
+ * @related  cf_app_request_attention_cancel cf_app_request_attention
  */
 CF_API void CF_CALL cf_app_request_attention_continuously(void);
 
@@ -519,7 +519,7 @@ CF_API void CF_CALL cf_app_request_attention_continuously(void);
  * @function cf_app_request_attention_cancel
  * @category app
  * @brief    Cancels any previous requests for attention.
- * @related  cf_app_request_attention cf_app_request_attention_continuously cf_app_request_attention_cancel
+ * @related  cf_app_request_attention_continuously cf_app_request_attention
  */
 CF_API void CF_CALL cf_app_request_attention_cancel(void);
 
@@ -527,7 +527,7 @@ CF_API void CF_CALL cf_app_request_attention_cancel(void);
  * @function cf_app_was_minimized
  * @category app
  * @brief    Returns true if the app was minimized last frame.
- * @related  cf_app_was_maximized cf_app_minimized cf_app_maximized cf_app_was_restored
+ * @related  cf_app_was_maximized cf_app_was_restored cf_app_minimized
  */
 CF_API bool CF_CALL cf_app_was_minimized(void);
 
@@ -535,7 +535,7 @@ CF_API bool CF_CALL cf_app_was_minimized(void);
  * @function cf_app_was_maximized
  * @category app
  * @brief    Returns true if the app was maximized last frame.
- * @related  cf_app_was_minimized cf_app_minimized cf_app_maximized cf_app_was_restored
+ * @related  cf_app_was_minimized cf_app_was_restored cf_app_minimized
  */
 CF_API bool CF_CALL cf_app_was_maximized(void);
 
@@ -543,7 +543,7 @@ CF_API bool CF_CALL cf_app_was_maximized(void);
  * @function cf_app_minimized
  * @category app
  * @brief    Returns true while the app is currently minimized.
- * @related  cf_app_was_minimized cf_app_was_maximized cf_app_maximized cf_app_was_restored
+ * @related  cf_app_maximized cf_app_was_minimized cf_app_was_maximized
  */
 CF_API bool CF_CALL cf_app_minimized(void);
 
@@ -551,7 +551,7 @@ CF_API bool CF_CALL cf_app_minimized(void);
  * @function cf_app_maximized
  * @category app
  * @brief    Returns true while the app is currently maximized.
- * @related  cf_app_was_minimized cf_app_was_maximized cf_app_minimized cf_app_was_restored
+ * @related  cf_app_minimized cf_app_was_minimized cf_app_was_maximized
  */
 CF_API bool CF_CALL cf_app_maximized(void);
 
@@ -560,7 +560,7 @@ CF_API bool CF_CALL cf_app_maximized(void);
  * @category app
  * @brief    Returns true if the app was restored last frame.
  * @remarks  Restored means a window's size/position was restored from a minimized/maximized state.
- * @related  cf_app_was_minimized cf_app_was_maximized cf_app_minimized cf_app_maximized cf_app_was_restored
+ * @related  cf_app_was_minimized cf_app_was_maximized cf_app_minimized
  */
 CF_API bool CF_CALL cf_app_was_restored(void);
 
@@ -606,7 +606,7 @@ CF_API void* CF_CALL cf_app_init_imgui(void);
  * @category app
  * @brief    Multisample count used for MSAA for the app's offscreen canvas.
  * @remarks  This function turns on .
- * @related  cf_app_set_msaa cf_msaa_string
+ * @related  cf_msaa_string cf_app_set_msaa
  */
 #define CF_MSAA_DEFS \
 	/* @entry No multisampling. */                          \
@@ -652,7 +652,7 @@ CF_INLINE const char* cf_msaa_string(CF_MSAA msaa) {
  *           The value should match a supported sample count for the current GPU.
  *           Note: If this is enabled you can not sample from the app's canvas, i.e. `cf_app_get_canvas` is then
  *           effectively write-only.
- * @related  CF_MSAA cf_app_get_msaa CF_Canvas
+ * @related  cf_app_get_msaa CF_MSAA CF_Canvas
  */
 CF_API bool CF_CALL cf_app_set_msaa(int sample_count);
 
@@ -665,7 +665,7 @@ CF_API bool CF_CALL cf_app_set_msaa(int sample_count);
  *           calling `cf_app_set_canvas_size`, as it will invalidate any references to the app's canvas.
  *           
  *           If you fetch this canvas and have MSAA on (see `cf_app_set_msaa`) you may *not* sample from the canvas.
- * @related  cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas_width cf_app_get_canvas_height cf_app_get_vsync
  */
 CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
 
@@ -676,7 +676,7 @@ CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
  * @param    w          The width in pixels to resize the canvas to.
  * @param    h          The height in pixels to resize the canvas to.
  * @remarks  Be careful about calling this function, as it will invalidate any old references from `cf_app_get_canvas`.
- * @related  cf_app_get_canvas cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_set_vsync cf_app_get_canvas cf_app_get_canvas_width
  */
 CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
 
@@ -684,7 +684,7 @@ CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
  * @function cf_app_get_canvas_width
  * @category app
  * @brief    Gets the app's canvas width in pixels.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas_height cf_app_get_canvas cf_app_get_vsync
  */
 CF_API int CF_CALL cf_app_get_canvas_width(void);
 
@@ -692,7 +692,7 @@ CF_API int CF_CALL cf_app_get_canvas_width(void);
  * @function cf_app_get_canvas_height
  * @category app
  * @brief    Gets the app's canvas height in pixels.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas_width cf_app_get_canvas cf_app_get_vsync
  */
 CF_API int CF_CALL cf_app_get_canvas_height(void);
 
@@ -700,7 +700,7 @@ CF_API int CF_CALL cf_app_get_canvas_height(void);
  * @function cf_app_set_vsync
  * @category app
  * @brief    Turns on vsync via the graphical backend (if supported).
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
+ * @related  cf_app_set_vsync_mailbox cf_app_set_canvas_size cf_app_get_canvas
  */
 CF_API void CF_CALL cf_app_set_vsync(bool true_turn_on_vsync);
 
@@ -710,7 +710,7 @@ CF_API void CF_CALL cf_app_set_vsync(bool true_turn_on_vsync);
  * @brief    Turns on vsync via the graphical backend (if supported) in mailbox mode.
  * @remarks  Similar to vsync but with reduced latency. When rendering too quickly the frame may be updated
  *           more than once before it is sent off the GPU.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
+ * @related  cf_app_set_vsync cf_app_set_canvas_size cf_app_get_canvas
  */
 CF_API void CF_CALL cf_app_set_vsync_mailbox(bool true_turn_on_mailbox);
 
@@ -718,7 +718,7 @@ CF_API void CF_CALL cf_app_set_vsync_mailbox(bool true_turn_on_mailbox);
  * @function cf_app_get_vsync
  * @category app
  * @brief    Returns the vsync state (true for on).
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
+ * @related  cf_app_get_canvas cf_app_get_canvas_width cf_app_set_canvas_size
  */
 CF_API bool CF_CALL cf_app_get_vsync(void);
 
@@ -726,7 +726,7 @@ CF_API bool CF_CALL cf_app_get_vsync(void);
  * @function cf_app_set_windowed_mode
  * @category app
  * @brief    Sets the application to windowed mode.
- * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
+ * @related  cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
  */
 CF_API void CF_CALL cf_app_set_windowed_mode(void);
 
@@ -734,7 +734,7 @@ CF_API void CF_CALL cf_app_set_windowed_mode(void);
  * @function cf_app_set_borderless_fullscreen_mode
  * @category app
  * @brief    Sets the application mode to "fake fullscreen" without a border.
- * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
+ * @related  cf_app_set_windowed_mode cf_app_set_fullscreen_mode cf_app_set_title
  */
 CF_API void CF_CALL cf_app_set_borderless_fullscreen_mode(void);
 
@@ -742,7 +742,7 @@ CF_API void CF_CALL cf_app_set_borderless_fullscreen_mode(void);
  * @function cf_app_set_fullscreen_mode
  * @category app
  * @brief    Sets the application true fullscreen mode.
- * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title
+ * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_title
  */
 CF_API void CF_CALL cf_app_set_fullscreen_mode(void);
 
@@ -750,7 +750,7 @@ CF_API void CF_CALL cf_app_set_fullscreen_mode(void);
  * @function cf_app_set_title
  * @category app
  * @brief    Sets the application' true fullscreen mode's title.
- * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode cf_app_set_title cf_app_set_icon
+ * @related  cf_app_set_windowed_mode cf_app_set_borderless_fullscreen_mode cf_app_set_fullscreen_mode
  */
 CF_API void CF_CALL cf_app_set_title(const char* title);
 
@@ -760,7 +760,7 @@ CF_API void CF_CALL cf_app_set_title(const char* title);
  * @brief    Sets the icon for the application.
  * @param    virtual_path_to_png  A path to a png file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @remarks  The icon file must be a png image. Suggested image dimensions are 32x32, 48x48, or 64x64.
- * @related  cf_app_set_title cf_app_set_icon
+ * @related  cf_app_set_title
  */
 CF_API void CF_CALL cf_app_set_icon(const char* virtual_path_to_png);
 
@@ -768,7 +768,7 @@ CF_API void CF_CALL cf_app_set_icon(const char* virtual_path_to_png);
  * @function cf_app_get_framerate
  * @category app
  * @brief    Returns the current framerate of the application.
- * @related  cf_app_get_framerate cf_app_get_smoothed_framerate
+ * @related  cf_app_get_smoothed_framerate
  */
 CF_API float CF_CALL cf_app_get_framerate(void);
 
@@ -776,7 +776,7 @@ CF_API float CF_CALL cf_app_get_framerate(void);
  * @function cf_app_get_smoothed_framerate
  * @category app
  * @brief    Returns the smoothed framerate of the application. Last 60 frames are averaged. This values is controlled by `CF_FRAMERATE_SMOOTHING`.
- * @related  cf_app_get_framerate cf_app_get_smoothed_framerate
+ * @related  cf_app_get_framerate
  */
 CF_API float CF_CALL cf_app_get_smoothed_framerate(void);
 
@@ -784,7 +784,7 @@ CF_API float CF_CALL cf_app_get_smoothed_framerate(void);
  * @enum     CF_PowerState
  * @category app
  * @brief    The states of power for the application.
- * @related  CF_PowerInfo cf_app_power_info
+ * @related  cf_app_power_info CF_PowerInfo
  */
 #define CF_POWER_STATE_DEFS \
 	/* @entry error determining power status. */        \
@@ -828,7 +828,7 @@ CF_INLINE const char* cf_power_state_to_string(CF_PowerState state) {
  * @struct   CF_PowerInfo
  * @category app
  * @brief    Detailed information about the power level/status of the application.
- * @related  cf_app_power_info cf_power_state_to_string CF_PowerState
+ * @related  cf_app_power_info CF_PowerState
  */
 typedef struct CF_PowerInfo
 {
@@ -848,7 +848,7 @@ typedef struct CF_PowerInfo
  * @category app
  * @brief    Fetches detailed power info about the application.
  * @return   Returns a `CF_PowerInfo` struct.
- * @related  CF_PowerInfo cf_power_state_to_string CF_PowerState
+ * @related  cf_power_state_to_string CF_PowerInfo CF_PowerState
  */
 CF_API CF_PowerInfo CF_CALL cf_app_power_info(void);
 

--- a/include/cute_array.h
+++ b/include/cute_array.h
@@ -31,7 +31,7 @@
  *           on typed pointers, there's no actual array struct type. It can get really annoying to sometimes forget if a pointer is an
  *           array, a hashtable, or just a pointer. This macro can be used to markup the type to make it much more clear for function
  *           parameters or struct member definitions. It's saying "Hey, I'm a dynamic array!" to mitigate this downside.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define dyna
 
@@ -48,7 +48,7 @@
  *     CF_ASSERT(alen(a) == 0);
  *     afree(a);
  * @remarks  `a` must not by `NULL`. This function returns a proper l-value, so you can assign to it, i.e. increment/decrement can be quite useful.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  alast asize acount
  */
 #define alen(a) cf_array_len(a)
 
@@ -63,7 +63,7 @@
  *     CF_ASSERT(asize(a) == 1);
  *     afree(a);
  * @remarks  `a` can be `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  aset astatic acount
  */
 #define asize(a) cf_array_size(a)
 
@@ -78,7 +78,7 @@
  *     CF_ASSERT(acount(a) == 1);
  *     afree(a);
  * @remarks  `a` can be `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  acap aclear asize
  */
 #define acount(a) cf_array_count(a)
 
@@ -89,7 +89,7 @@
  * @param    a             The array.
  * @remarks  `a` can be `NULL`. The capacity automatically grows if the size of the array grows over the capacity.
  *            You can use `afit` to ensure a minimum capacity as an optimization.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  acount aclear asize
  */
 #define acap(a) cf_array_capacity(a)
 
@@ -103,7 +103,7 @@
  * @remarks  This function does not change the number of live elements, the count/size, of the array. Only the capacity.
  *           This function is only useful as an optimization to avoid extra/unnecessary internal allocations. `a` is
  *           automatically re-assigned to a new pointer if the array was internally regrown.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  afree asize acount
  */
 #define afit(a, n) cf_array_fit(a, n)
 
@@ -124,7 +124,7 @@
  *     afree(a);
  * @remarks  `a` is automatically re-assigned to a new pointer if the array was internally regrown. If `a` is `NULL` a new
  *           dynamic array is allocated on-the-spot for you, and assigned back to `a`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  apop asize acount
  */
 #define apush(a, ...) cf_array_push(a, (__VA_ARGS__))
 
@@ -135,7 +135,7 @@
  * @param    a             The array. Can not be `NULL`.
  * @return   Returns the popped element.
  * @remarks  The last element of the array is fetched and will be returned. The size of the array is decremented by one.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  apush asize acount
  */
 #define apop(a) cf_array_pop(a)
 
@@ -144,7 +144,7 @@
  * @category array
  * @brief    Returns a pointer one element beyond the end of the array.
  * @param    a             The array. Can be `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define aend(a) cf_array_end(a)
 
@@ -153,7 +153,7 @@
  * @category array
  * @brief    Returns the last element in the array.
  * @param    a             The array. Can not be `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define alast(a) cf_array_last(a)
 
@@ -163,7 +163,7 @@
  * @brief    Sets the array's count to zero. Does not free any resources.
  * @param    a             The array. Can be `NULL`.
  * @return   Returns zero.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  acount acap asize
  */
 #define aclear(a) cf_array_clear(a)
 
@@ -174,7 +174,7 @@
  * @param    a             The array to copy into (destination).
  * @param    b             The array to copy from (source).
  * @return   Returns a pointer to `a`. `a` will automatically be reassigned to any new pointer.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize astatic acount
  */
 #define aset(a, b) cf_array_set(a, b)
 
@@ -183,7 +183,7 @@
  * @category array
  * @brief    Reverses the elements in an array.
  * @param    a             The array. Can be `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define arev(a) cf_array_reverse(a)
 
@@ -192,7 +192,7 @@
  * @category array
  * @brief    Returns the hash of all the bytes in the array.
  * @param    a             The array.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define ahash(a) cf_array_hash(a)
 
@@ -204,7 +204,7 @@
  * @param    i             The index of the element to remove.
  * @remarks  The last element of the array is swapped into the index `i`. This is a constant time
  *           operation, but does *not preserve order* of the array.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize acount acap
  */
 #define adel(a, i) cf_array_del(a, i)
 
@@ -219,7 +219,7 @@
  * @remarks  This macro is useful as an optimization to avoid any dynamic memory allocation in the common case for implementing
  *           certain data structures (such as strings or stack vectors). As the array grows too large for the `buffer` it will
  *           dynamically grow into the heap.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  asize aset acount
  */
 #define astatic(a, buffer, buffer_size) cf_array_static(a, buffer, buffer_size)
 
@@ -229,7 +229,7 @@
  * @brief    Frees up all resources used by the array.
  * @param    a             The array.
  * @remarks  Sets `a` to `NULL`.
- * @related  dyna asize acount acap afit apush apop aend alast aclear aset arev ahash adel astatic afree
+ * @related  afit asize acount
  */
 #define afree(a) cf_array_free(a)
 

--- a/include/cute_audio.h
+++ b/include/cute_audio.h
@@ -23,7 +23,7 @@ extern "C" {
  * @struct   CF_Sound
  * @category audio
  * @brief    An opaque pointer representing a sound created by `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_params_defaults cf_sound_is_active cf_sound_get_is_paused
  */
 typedef struct CF_Sound { uint64_t id; } CF_Sound;
 // @end
@@ -32,7 +32,7 @@ typedef struct CF_Sound { uint64_t id; } CF_Sound;
  * @struct   CF_Audio
  * @category audio
  * @brief    An opaque pointer representing raw audio samples loaded as a resource.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy cf_music_play cf_music_switch_to cf_music_crossfade cf_play_sound
+ * @related  cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav
  */
 typedef struct CF_Audio { uint64_t id; } CF_Audio;
 // @end
@@ -43,7 +43,7 @@ typedef struct CF_Audio { uint64_t id; } CF_Audio;
  * @brief    Loads a .ogg audio file.
  * @param    path         The virtual path to a .ogg file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @return   Returns a pointer to `CF_Audio`. Free it up with `cf_audio_destroy` when done.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy
+ * @related  cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory
  */
 CF_API CF_Audio CF_CALL cf_audio_load_ogg(const char* path);
 
@@ -53,7 +53,7 @@ CF_API CF_Audio CF_CALL cf_audio_load_ogg(const char* path);
  * @brief    Loads a .wav audio file.
  * @param    path         The virtual path to a .wav file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @return   Returns a pointer to `CF_Audio`. Free it up with `cf_audio_destroy` when done.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy
+ * @related  cf_audio_load_wav_from_memory cf_audio_load_ogg cf_audio_load_ogg_from_memory
  */
 CF_API CF_Audio CF_CALL cf_audio_load_wav(const char* path);
 
@@ -64,7 +64,7 @@ CF_API CF_Audio CF_CALL cf_audio_load_wav(const char* path);
  * @param    memory       A buffer containing the bytes of a .ogg file.
  * @param    byte_count   The number of bytes in `memory`.
  * @return   Returns a pointer to `CF_Audio`. Free it up with `cf_audio_destroy` when done.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy
+ * @related  cf_audio_load_ogg cf_audio_load_wav cf_audio_load_wav_from_memory
  */
 CF_API CF_Audio CF_CALL cf_audio_load_ogg_from_memory(void* memory, int byte_count);
 
@@ -75,7 +75,7 @@ CF_API CF_Audio CF_CALL cf_audio_load_ogg_from_memory(void* memory, int byte_cou
  * @param    memory       A buffer containing the bytes of a .wav file.
  * @param    byte_count   The number of bytes in `memory`.
  * @return   Returns a pointer to `CF_Audio`. Free it up with `cf_audio_destroy` when done.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy
+ * @related  cf_audio_load_wav cf_audio_load_ogg cf_audio_load_ogg_from_memory
  */
 CF_API CF_Audio CF_CALL cf_audio_load_wav_from_memory(void* memory, int byte_count);
 
@@ -84,7 +84,7 @@ CF_API CF_Audio CF_CALL cf_audio_load_wav_from_memory(void* memory, int byte_cou
  * @category audio
  * @brief    Frees all resources used by a `CF_Audio`.
  * @param    audio        A pointer to the `CF_Audio`.
- * @related  CF_Audio cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav cf_audio_load_wav_from_memory cf_audio_destroy
+ * @related  cf_audio_load_ogg cf_audio_load_ogg_from_memory cf_audio_load_wav
  */
 CF_API void CF_CALL cf_audio_destroy(CF_Audio audio);
 
@@ -100,7 +100,7 @@ CF_API void CF_CALL cf_audio_destroy(CF_Audio audio);
  *           get culled within a particular timespan is variable -- but usually you still want this option turned on.
  *
  *           When on this applies to both sound FX and music.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume
+ * @related  cf_sound_params_defaults cf_play_sound cf_sound_is_active
  */
 CF_API void CF_CALL cf_audio_cull_duplicates(bool true_to_cull_duplicates);
 
@@ -108,7 +108,7 @@ CF_API void CF_CALL cf_audio_cull_duplicates(bool true_to_cull_duplicates);
  * @function cf_audio_sample_rate
  * @category audio
  * @brief    Returns the sample rate for a loaded audio resource.
- * @related  CF_Audio cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
+ * @related  cf_audio_sample_count cf_audio_channel_count CF_Audio
  */
 CF_API int CF_CALL cf_audio_sample_rate(CF_Audio audio);
 
@@ -116,7 +116,7 @@ CF_API int CF_CALL cf_audio_sample_rate(CF_Audio audio);
  * @function cf_audio_sample_count
  * @category audio
  * @brief    Returns the sample count for a loaded audio resource.
- * @related  CF_Audio cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
+ * @related  cf_audio_sample_rate cf_audio_channel_count CF_Audio
  */
 CF_API int CF_CALL cf_audio_sample_count(CF_Audio audio);
 
@@ -124,7 +124,7 @@ CF_API int CF_CALL cf_audio_sample_count(CF_Audio audio);
  * @function cf_audio_channel_count
  * @category audio
  * @brief    Returns the channel count for a loaded audio resource.
- * @related  CF_Audio cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
+ * @related  cf_audio_sample_rate cf_audio_sample_count CF_Audio
  */
 CF_API int CF_CALL cf_audio_channel_count(CF_Audio audio);
 
@@ -136,7 +136,7 @@ CF_API int CF_CALL cf_audio_channel_count(CF_Audio audio);
  * @category audio
  * @brief    Sets the global stereo pan for all audio.
  * @param    pan          0.5f means perfect balance for left/right speakers. 0.0f means only left speaker, 1.0f means only right speaker.
- * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause
+ * @related  cf_audio_set_pause cf_audio_set_global_volume cf_audio_set_sound_volume
  */
 CF_API void CF_CALL cf_audio_set_pan(float pan);
 
@@ -145,7 +145,7 @@ CF_API void CF_CALL cf_audio_set_pan(float pan);
  * @category audio
  * @brief    Sets the global volume for all audio.
  * @param    volume       A value from 0.0f to 1.0f, where 0.0f means no volume, and 1.0f means full volume.
- * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause
+ * @related  cf_audio_set_pan cf_audio_set_sound_volume cf_audio_set_pause
  */
 CF_API void CF_CALL cf_audio_set_global_volume(float volume);
 
@@ -155,7 +155,7 @@ CF_API void CF_CALL cf_audio_set_global_volume(float volume);
  * @brief    Sets the volume for all sound effects.
  * @param    volume       A value from 0.0f to 1.0f, where 0.0f means no volume, and 1.0f means full volume.
  * @remarks  Sounds come from `cf_play_sound`, as opposed to music coming from `cf_music_play`.
- * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause cf_play_sound
+ * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_pause
  */
 CF_API void CF_CALL cf_audio_set_sound_volume(float volume);
 
@@ -164,7 +164,7 @@ CF_API void CF_CALL cf_audio_set_sound_volume(float volume);
  * @category audio
  * @brief    Pauses all audio.
  * @param    true_for_paused  True to pause all audio, false to unpause.
- * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause
+ * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume
  */
 CF_API void CF_CALL cf_audio_set_pause(bool true_for_paused);
 
@@ -177,7 +177,7 @@ CF_API void CF_CALL cf_audio_set_pause(bool true_for_paused);
  * @brief    Plays audio as music.
  * @param    audio_source   A `CF_Audio` containing your music.
  * @param    fade_in_time   A number of seconds to fade the music in. Can be 0.0f to instantly play your music.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_pause cf_music_stop cf_music_set_volume
  */
 CF_API void CF_CALL cf_music_play(CF_Audio audio_source, float fade_in_time);
 
@@ -186,7 +186,7 @@ CF_API void CF_CALL cf_music_play(CF_Audio audio_source, float fade_in_time);
  * @category audio
  * @brief    Stop the music currently playing.
  * @param    fade_out_time  A number of seconds to fade the music out. Can be 0.0f to instantly stop your music.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_set_volume cf_music_set_loop cf_music_switch_to
  */
 CF_API void CF_CALL cf_music_stop(float fade_out_time);
 
@@ -195,7 +195,7 @@ CF_API void CF_CALL cf_music_stop(float fade_out_time);
  * @category audio
  * @brief    Set the volume for music.
  * @param    volume         A value from 0.0f to 1.0f, where 0.0f means no volume, and 1.0f means full volume.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_set_loop cf_music_set_sample_index cf_music_set_pitch
  */
 CF_API void CF_CALL cf_music_set_volume(float volume);
 
@@ -204,7 +204,7 @@ CF_API void CF_CALL cf_music_set_volume(float volume);
  * @category audio
  * @brief    Turns on or off music looping.
  * @param    true_to_loop   True to loop the music.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_set_volume cf_music_set_sample_index cf_music_set_pitch
  */
 CF_API void CF_CALL cf_music_set_loop(bool true_to_loop);
 
@@ -215,7 +215,7 @@ CF_API void CF_CALL cf_music_set_loop(bool true_to_loop);
  * @param    pitch    The pitch to set, default to 1.0f.
  * @remarks  This is a playback speed multiplier, meaning negative numbers will play the music backwards,
  *           while positive numbers play forwards.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_set_volume cf_music_set_loop cf_music_set_sample_index
  */
 CF_API void CF_CALL cf_music_set_pitch(float pitch);
 
@@ -223,7 +223,7 @@ CF_API void CF_CALL cf_music_set_pitch(float pitch);
  * @function cf_music_pause
  * @category audio
  * @brief    Pauses the music.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_play cf_music_stop cf_music_set_volume
  */
 CF_API void CF_CALL cf_music_pause(void);
 
@@ -231,7 +231,7 @@ CF_API void CF_CALL cf_music_pause(void);
  * @function cf_music_resume
  * @category audio
  * @brief    Resumes the music if the music was paused.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_play cf_music_stop cf_music_set_volume
  */
 CF_API void CF_CALL cf_music_resume(void);
 
@@ -242,7 +242,7 @@ CF_API void CF_CALL cf_music_resume(void);
  * @param    fade_out_time  A number of seconds to fade the currently playing track out. Can be 0.0f to instantly stop your music.
  * @param    fade_in_time   A number of seconds to fade the next track in. Can be 0.0f to instantly play your music.
  * @remarks  The currently playing track is faded out, then the second track is faded in.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_stop cf_music_set_volume cf_music_set_loop
  */
 CF_API void CF_CALL cf_music_switch_to(CF_Audio audio_source, float fade_out_time, float fade_in_time);
 
@@ -251,7 +251,7 @@ CF_API void CF_CALL cf_music_switch_to(CF_Audio audio_source, float fade_out_tim
  * @category audio
  * @brief    Crossfades the currently playing track out with the next track in.
  * @param    cross_fade_time  A number of seconds to crossfade to the next track. Can be 0.0f to instantly switch to the next track.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_play cf_music_stop cf_music_set_volume
  */
 CF_API void CF_CALL cf_music_crossfade(CF_Audio audio_source, float cross_fade_time);
 
@@ -260,7 +260,7 @@ CF_API void CF_CALL cf_music_crossfade(CF_Audio audio_source, float cross_fade_t
  * @category audio
  * @brief    Returns the current sample index the music is playing at.
  * @remarks  This can be useful to sync a dynamic audio system that can turn on/off different instruments or sounds.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_play cf_music_stop cf_music_set_volume
  */
 CF_API int CF_CALL cf_music_get_sample_index(void);
 
@@ -270,7 +270,7 @@ CF_API int CF_CALL cf_music_get_sample_index(void);
  * @brief    Sets the sample index to play at for the music.
  * @param    sample_index   Tells where to play music from within the `CF_Audio` for the currently playing music track.
  * @remarks  This can be useful to sync a dynamic audio system that can turn on/off different instruments or sounds.
- * @related  cf_music_play cf_music_stop cf_music_set_volume cf_music_set_loop cf_music_pause cf_music_resume cf_music_switch_to cf_music_crossfade cf_music_get_sample_index cf_music_set_sample_index cf_music_set_pitch
+ * @related  cf_music_set_volume cf_music_set_loop cf_music_set_pitch
  */
 CF_API CF_Result CF_CALL cf_music_set_sample_index(int sample_index);
 
@@ -281,7 +281,7 @@ CF_API CF_Result CF_CALL cf_music_set_sample_index(int sample_index);
  * @param    on_finished      Called whenever the current song finishes.
  * @param    udata            An optional pointer handed back to you within the `on_finished` callback.
  * @param    single_threaded  Set to true to queue up callbacks and invoke them on the main thread. Otherwise this callback is called from the mixing thread directly.
- * @related  CF_Audio cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
+ * @related  cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
  */
 CF_API void CF_CALL cf_music_set_on_finish_callback(void (*on_finished)(void* udata), void* udata, bool single_threaded);
 
@@ -293,7 +293,7 @@ CF_API void CF_CALL cf_music_set_on_finish_callback(void (*on_finished)(void* ud
  * @category audio
  * @brief    Parameters for the function `cf_play_sound`.
  * @remarks  You can use default settings from the `cf_sound_params_defaults` function.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop  cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_params_defaults cf_sound_is_active cf_play_sound
  */
 typedef struct CF_SoundParams
 {
@@ -321,7 +321,7 @@ typedef struct CF_SoundParams
  * @function cf_sound_params_defaults
  * @category audio
  * @brief    Returns a `CF_SoundParams` filled with default state, to use with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped
  */
 CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults(void)
 {
@@ -342,7 +342,7 @@ CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults(void)
  * @param    audio_source   The `CF_Audio` samples for the sound to play.
  * @param    params         `CF_SoundParams` on how to play the sound. You can use default values by calling `cf_sound_params_defaults`.
  * @return   Returns a playing sound `CF_Sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_params_defaults cf_sound_is_active cf_sound_get_is_paused
  */
 CF_API CF_Sound CF_CALL cf_play_sound(CF_Audio audio_source, CF_SoundParams params);
 
@@ -353,7 +353,7 @@ CF_API CF_Sound CF_CALL cf_play_sound(CF_Audio audio_source, CF_SoundParams para
  * @param    on_finished      Called whenever a `CF_Sound` finishes playing, excluding music.
  * @param    udata            An optional pointer handed back to you within the `on_finished` callback.
  * @param    single_threaded  Set to true to queue up callbacks and invoke them on the main thread. Otherwise this callback is called from the mixing thread directly.
- * @related  CF_Audio cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
+ * @related  cf_audio_sample_rate cf_audio_sample_count cf_audio_channel_count
  */
 CF_API void CF_CALL cf_sound_set_on_finish_callback(void (*on_finished)(CF_Sound snd, void* udata), void* udata, bool single_threaded);
 
@@ -363,7 +363,7 @@ CF_API void CF_CALL cf_sound_set_on_finish_callback(void (*on_finished)(CF_Sound
  * @brief    Returns whether or not a sound is active.
  * @param    sound          The sound.
  * @return   Rreturns true if the sound is active, or false if it finished playing (and was not looped).
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_params_defaults cf_sound_get_is_paused cf_sound_get_is_looped
  */
 CF_API bool CF_CALL cf_sound_is_active(CF_Sound sound);
 
@@ -373,7 +373,7 @@ CF_API bool CF_CALL cf_sound_is_active(CF_Sound sound);
  * @brief    Returns whether or not a sound is paused.
  * @param    sound          The sound.
  * @remarks  You can set a sound to paused with `cf_sound_set_is_paused`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index
  */
 CF_API bool CF_CALL cf_sound_get_is_paused(CF_Sound sound);
 
@@ -383,7 +383,7 @@ CF_API bool CF_CALL cf_sound_get_is_paused(CF_Sound sound);
  * @brief    Returns whether or not a sound is looped.
  * @param    sound          The sound.
  * @remarks  You can set a sound to looped with `cf_sound_set_is_looped`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_get_is_paused cf_sound_get_volume cf_sound_get_sample_index
  */
 CF_API bool CF_CALL cf_sound_get_is_looped(CF_Sound sound);
 
@@ -393,7 +393,7 @@ CF_API bool CF_CALL cf_sound_get_is_looped(CF_Sound sound);
  * @brief    Returns the volume of the sound.
  * @param    sound          The sound.
  * @remarks  You can set a sound volume with `cf_sound_set_volume`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_sample_index
  */
 CF_API float CF_CALL cf_sound_get_volume(CF_Sound sound);
 
@@ -403,7 +403,7 @@ CF_API float CF_CALL cf_sound_get_volume(CF_Sound sound);
  * @brief    Returns the pitch of the sound.
  * @param    sound          The sound.
  * @remarks  You can set a sound volume with `cf_sound_set_volume`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume
  */
 CF_API float CF_CALL cf_sound_get_pitch(CF_Sound sound);
 
@@ -414,7 +414,7 @@ CF_API float CF_CALL cf_sound_get_pitch(CF_Sound sound);
  * @param    sound          The sound.
  * @remarks  You can set a sound's playing index with `cf_sound_set_sample_index`. This can be useful to sync a dynamic audio system that
  *           can turn on/off different instruments or sounds.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume
  */
 CF_API int CF_CALL cf_sound_get_sample_index(CF_Sound sound);
 
@@ -425,7 +425,7 @@ CF_API int CF_CALL cf_sound_get_sample_index(CF_Sound sound);
  * @param    sound            The sound.
  * @param    true_for_paused  The pause state to set.
  * @remarks  You can get a sound's paused state with `cf_sound_get_is_paused`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_is_looped cf_sound_set_sample_index cf_sound_set_volume
  */
 CF_API void CF_CALL cf_sound_set_is_paused(CF_Sound sound, bool true_for_paused);
 
@@ -436,7 +436,7 @@ CF_API void CF_CALL cf_sound_set_is_paused(CF_Sound sound, bool true_for_paused)
  * @param    sound            The sound.
  * @param    true_for_looped  The loop state to set.
  * @remarks  You can get a sound's looped state with `cf_sound_get_is_looped`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_is_paused cf_sound_set_sample_index cf_sound_set_volume
  */
 CF_API void CF_CALL cf_sound_set_is_looped(CF_Sound sound, bool true_for_looped);
 
@@ -447,7 +447,7 @@ CF_API void CF_CALL cf_sound_set_is_looped(CF_Sound sound, bool true_for_looped)
  * @param    sound      The sound.
  * @param    volume     A value from 0.0f to 1.0f. 0.0f meaning silent, 1.0f meaning max volume.
  * @remarks  You can get a sound's volume with `cf_sound_get_volume`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped
  */
 CF_API void CF_CALL cf_sound_set_volume(CF_Sound sound, float volume);
 
@@ -456,7 +456,7 @@ CF_API void CF_CALL cf_sound_set_volume(CF_Sound sound, float volume);
  * @category audio
  * @brief    Sets pitch for the sound.
  * @remarks  Defaults to 1.0f.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped
  */
 CF_API void CF_CALL cf_sound_set_pitch(CF_Sound sound, float pitch);
 
@@ -468,7 +468,7 @@ CF_API void CF_CALL cf_sound_set_pitch(CF_Sound sound, float pitch);
  * @param    sample_index  The index of the sample to play the sound from.
  * @remarks  You can get a sound's playing index with `cf_sound_get_sample_index`. This can be useful to sync a dynamic audio system that
  *           can turn on/off different instruments or sounds.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume
  */
 CF_API void CF_CALL cf_sound_set_sample_index(CF_Sound sound, int sample_index);
 
@@ -476,7 +476,7 @@ CF_API void CF_CALL cf_sound_set_sample_index(CF_Sound sound, int sample_index);
  * @function cf_sound_stop
  * @category audio
  * @brief    Stops the sound instance so it no longer plays.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_sample_index cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  cf_sound_set_sample_index cf_sound_set_is_paused cf_sound_set_is_looped
  */
 CF_API void CF_CALL cf_sound_stop(CF_Sound sound);
 

--- a/include/cute_base64.h
+++ b/include/cute_base64.h
@@ -29,7 +29,7 @@ extern "C" {
  * @remarks  Use this for the `dst_size` in `cf_base64_encode`.
  *           Base64 encoding is useful for storing data as text in a copy-paste-safe manner. For more information about
  *           base64 encoding see this link: [RFC-4648](https://tools.ietf.org/html/rfc4648) or [Wikipedia Base64](https://en.wikipedia.org/wiki/Base64).
- * @related  CF_BASE64_ENCODED_SIZE CF_BASE64_DECODED_SIZE cf_base64_encode cf_base64_decode
+ * @related  cf_base64_encode cf_base64_decode CF_BASE64_DECODED_SIZE
  */
 #define CF_BASE64_ENCODED_SIZE(size) ((((size) + 2) / 3) * 4)
 
@@ -42,7 +42,7 @@ extern "C" {
  * @remarks  Use this for the `dst_size` in `cf_base64_decode`.
  *           Base64 encoding is useful for storing data as text in a copy-paste-safe manner. For more information about
  *           base64 encoding see this link: [RFC-4648](https://tools.ietf.org/html/rfc4648) or [Wikipedia Base64](https://en.wikipedia.org/wiki/Base64).
- * @related  CF_BASE64_ENCODED_SIZE CF_BASE64_DECODED_SIZE cf_base64_encode cf_base64_decode
+ * @related  cf_base64_decode cf_base64_encode CF_BASE64_ENCODED_SIZE
  */
 #define CF_BASE64_DECODED_SIZE(size) ((((size) + 3) / 4) * 3)
 
@@ -57,7 +57,7 @@ extern "C" {
  * @return   Returns a `CF_Result` containing information about any errors.
  * @remarks  Base64 encoding is useful for storing data as text in a copy-paste-safe manner. For more information about
  *           base64 encoding see this link: [RFC-4648](https://tools.ietf.org/html/rfc4648) or [Wikipedia Base64](https://en.wikipedia.org/wiki/Base64).
- * @related  CF_BASE64_ENCODED_SIZE CF_BASE64_DECODED_SIZE cf_base64_encode cf_base64_decode
+ * @related  cf_base64_decode CF_BASE64_ENCODED_SIZE CF_BASE64_DECODED_SIZE
  */
 CF_API CF_Result CF_CALL cf_base64_encode(void* dst, size_t dst_size, const void* src, size_t src_size);
 
@@ -72,7 +72,7 @@ CF_API CF_Result CF_CALL cf_base64_encode(void* dst, size_t dst_size, const void
  * @return   Returns a `CF_Result` containing information about any errors.
  * @remarks  Base64 encoding is useful for storing data as text in a copy-paste-safe manner. For more information about
  *           base64 encoding see this link: [RFC-4648](https://tools.ietf.org/html/rfc4648) or [Wikipedia Base64](https://en.wikipedia.org/wiki/Base64).
- * @related  CF_BASE64_ENCODED_SIZE CF_BASE64_DECODED_SIZE cf_base64_encode cf_base64_decode
+ * @related  cf_base64_encode CF_BASE64_DECODED_SIZE CF_BASE64_ENCODED_SIZE
  */
 CF_API CF_Result CF_CALL cf_base64_decode(void* dst, size_t dst_size, const void* src, size_t src_size);
 

--- a/include/cute_clipboard.h
+++ b/include/cute_clipboard.h
@@ -22,7 +22,7 @@ extern "C" {
  * @function cf_clipboard_get
  * @category input
  * @brief    Returns a UTF-8 string of the clipboard contents.
- * @related  cf_clipboard_get cf_clipboard_set
+ * @related  cf_clipboard_set
  */
 CF_API char* CF_CALL cf_clipboard_get(void);
 
@@ -30,7 +30,7 @@ CF_API char* CF_CALL cf_clipboard_get(void);
  * @function cf_clipboard_set
  * @category input
  * @brief    Sets a UTF-8 string of the clipboard contents.
- * @related  cf_clipboard_get cf_clipboard_set
+ * @related  cf_clipboard_get
  */
 CF_API CF_Result CF_CALL cf_clipboard_set(const char* string);
 

--- a/include/cute_color.h
+++ b/include/cute_color.h
@@ -23,7 +23,7 @@ extern "C" {
  * @struct   CF_Color
  * @category graphics
  * @brief    16-byte value with 0.0f to 1.0f components, representing an RGBA (red green blue alpha) color.
- * @related  CF_Color CF_Pixel
+ * @related  CF_Pixel
  */
 typedef struct CF_Color
 {
@@ -45,7 +45,7 @@ typedef struct CF_Color
  * @struct   CF_Pixel
  * @category graphics
  * @brief    4-byte value with 0-255 components, representing an RGBA (red green blue alpha) color.
- * @related  CF_Color CF_Pixel
+ * @related  CF_Color
  */
 typedef union CF_Pixel
 {
@@ -77,7 +77,7 @@ typedef union CF_Pixel
  * @param    g          The green component from 0.0f to 1.0f.
  * @param    b          The blue component from 0.0f to 1.0f.
  * @remarks  The alpha component is set to 1.0f;
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_rgb cf_make_color_rgba_f cf_make_color_rgba
  */
 CF_INLINE CF_Color cf_make_color_rgb_f(float r, float g, float b) { CF_Color color; color.r = r; color.g = g; color.b = b; color.a = 1.0f; return color; }
 
@@ -89,7 +89,7 @@ CF_INLINE CF_Color cf_make_color_rgb_f(float r, float g, float b) { CF_Color col
  * @param    g          The green component from 0.0f to 1.0f.
  * @param    b          The blue component from 0.0f to 1.0f.
  * @param    a          The alpha component from 0.0f to 1.0f.
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_rgba cf_make_color_rgb_f cf_make_color_rgb
  */
 CF_INLINE CF_Color cf_make_color_rgba_f(float r, float g, float b, float a) { CF_Color color; color.r = r; color.g = g; color.b = b; color.a = a; return color; }
 
@@ -101,7 +101,7 @@ CF_INLINE CF_Color cf_make_color_rgba_f(float r, float g, float b, float a) { CF
  * @param    g          The green component from 0 to 255.
  * @param    b          The blue component from 0 to 255.
  * @remarks  The alpha component is set to 1.0f;
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgba
  */
 CF_INLINE CF_Color cf_make_color_rgb(uint8_t r, uint8_t g, uint8_t b) { CF_Color color; color.r = (float)r / 255.0f; color.g = (float)g / 255.0f; color.b = (float)b / 255.0f; color.a = 1.0f; return color; }
 
@@ -113,7 +113,7 @@ CF_INLINE CF_Color cf_make_color_rgb(uint8_t r, uint8_t g, uint8_t b) { CF_Color
  * @param    g          The green component from 0 to 255.
  * @param    b          The blue component from 0 to 255.
  * @param    a          The alpha component from 0 to 255.
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_rgba_f cf_make_color_rgb_f cf_make_color_rgb
  */
 CF_INLINE CF_Color cf_make_color_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a) { CF_Color color; color.r = (float)r / 255.0f; color.g = (float)g / 255.0f; color.b = (float)b / 255.0f; color.a = (float)a / 255.0f; return color; }
 
@@ -123,7 +123,7 @@ CF_INLINE CF_Color cf_make_color_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a
  * @brief    Returns a `CF_Color` made from integer hex input.
  * @param    hex        An integer value, e.g. 0xFFAACC.
  * @remarks  The opacity of the output color is set to 0xFF (fully opaque).
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_hex_string cf_make_color_rgb_f cf_make_color_rgba_f
  */
 CF_INLINE CF_Color cf_make_color_hex(int hex) { return cf_make_color_rgba((uint8_t)((hex & 0xFF0000) >> 16), (uint8_t)((hex & 0x00FF00) >> 8), (uint8_t)(hex & 0x0000FF), 0xFF); }
 
@@ -132,7 +132,7 @@ CF_INLINE CF_Color cf_make_color_hex(int hex) { return cf_make_color_rgba((uint8
  * @category graphics
  * @brief    Returns a `CF_Color` made from integer hex input.
  * @param    hex        An integer value, e.g. 0xFFAACC, and alpha e.g. 0xFF.
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_hex cf_make_color_hex_string cf_make_color_rgb_f
  */
 CF_INLINE CF_Color cf_make_color_hex2(int hex, int alpha) { return cf_make_color_rgba((uint8_t)((hex & 0xFF0000) >> 16), (uint8_t)((hex & 0x00FF00) >> 8), (uint8_t)(hex & 0x0000FF), (uint8_t)(alpha & 0xFF)); }
 
@@ -141,7 +141,7 @@ CF_INLINE CF_Color cf_make_color_hex2(int hex, int alpha) { return cf_make_color
  * @category graphics
  * @brief    Returns a `CF_Color` made from hex-value string, such as "#42f563" or "0x42f563FF".
  * @param    hex        A hex-value string, such as "#42f563" or "0x42f563FF".
- * @related  CF_Color cf_make_color_rgb_f cf_make_color_rgba_f cf_make_color_rgb cf_make_color_rgba cf_make_color_hex cf_make_color_hex_string
+ * @related  cf_make_color_hex cf_make_color_rgb_f cf_make_color_rgba_f
  */
 CF_INLINE CF_Color cf_make_color_hex_string(const char* hex) { return cf_make_color_hex((int)stohex(hex)); }
 
@@ -153,7 +153,7 @@ CF_INLINE CF_Color cf_make_color_hex_string(const char* hex) { return cf_make_co
  * @param    g          The green component from 0.0f to 1.0f.
  * @param    b          The blue component from 0.0f to 1.0f.
  * @remarks  The alpha component is set to 255.
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_rgb cf_make_pixel_rgba_f cf_make_pixel_rgba
  */
 CF_INLINE CF_Pixel cf_make_pixel_rgb_f(float r, float g, float b) { CF_Pixel p; p.colors.r = (uint8_t)(r * 255.0f); p.colors.g = (uint8_t)(g * 255.0f); p.colors.b = (uint8_t)(b * 255.0f); p.colors.a = 255; return p; }
 
@@ -165,7 +165,7 @@ CF_INLINE CF_Pixel cf_make_pixel_rgb_f(float r, float g, float b) { CF_Pixel p; 
  * @param    g          The green component from 0.0f to 1.0f.
  * @param    b          The blue component from 0.0f to 1.0f.
  * @param    b          The alpha component from 0.0f to 1.0f.
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_rgba cf_make_pixel_rgb_f cf_make_pixel_rgb
  */
 CF_INLINE CF_Pixel cf_make_pixel_rgba_f(float r, float g, float b, float a) { CF_Pixel p; p.colors.r = (uint8_t)(r * 255.0f); p.colors.g = (uint8_t)(g * 255.0f); p.colors.b = (uint8_t)(b * 255.0f); p.colors.a = (uint8_t)(a * 255.0f); return p; }
 
@@ -177,7 +177,7 @@ CF_INLINE CF_Pixel cf_make_pixel_rgba_f(float r, float g, float b, float a) { CF
  * @param    g          The green component from 0 to 255.
  * @param    b          The blue component from 0 to 255.
  * @remarks  The alpha component is set to 255.
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgba
  */
 CF_INLINE CF_Pixel cf_make_pixel_rgb(uint8_t r, uint8_t g, uint8_t b) { CF_Pixel p; p.colors.r = r; p.colors.g = g; p.colors.b = b; p.colors.a = 255; return p; }
 
@@ -189,7 +189,7 @@ CF_INLINE CF_Pixel cf_make_pixel_rgb(uint8_t r, uint8_t g, uint8_t b) { CF_Pixel
  * @param    g          The green component from 0 to 255.
  * @param    b          The blue component from 0 to 255.
  * @param    a          The alpha component from 0 to 255.
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_rgba_f cf_make_pixel_rgb_f cf_make_pixel_rgb
  */
 CF_INLINE CF_Pixel cf_make_pixel_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a) { CF_Pixel p; p.colors.r = r; p.colors.g = g; p.colors.b = b; p.colors.a = a; return p; }
 
@@ -198,7 +198,7 @@ CF_INLINE CF_Pixel cf_make_pixel_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a
  * @category graphics
  * @brief    Returns a `CF_Pixel` made from integer hex input.
  * @param    hex        An integer value, e.g. 0xFFAACC11.
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_hex_string cf_make_pixel_rgb_f cf_make_pixel_rgba_f
  */
 CF_INLINE CF_Pixel cf_make_pixel_hex(int hex) { return cf_make_pixel_rgba((uint8_t)((hex & 0xFF000000) >> 24), (uint8_t)((hex & 0x00FF0000) >> 16), (uint8_t)((hex & 0x0000FF00) >> 8), (uint8_t)(hex & 0x000000FF)); }
 
@@ -207,7 +207,7 @@ CF_INLINE CF_Pixel cf_make_pixel_hex(int hex) { return cf_make_pixel_rgba((uint8
  * @category graphics
  * @brief    Returns a `CF_Pixel` made from hex-value string, such as "#42f563" or "0x42f563FF".
  * @param    hex        A hex-value string, such as "#42f563" or "0x42f563FF".
- * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
+ * @related  cf_make_pixel_hex cf_make_pixel_rgb_f cf_make_pixel_rgba_f
  */
 CF_INLINE CF_Pixel cf_make_pixel_hex_string(const char* hex) { return cf_make_pixel_hex((int)stohex(hex)); }
 
@@ -218,7 +218,7 @@ CF_INLINE CF_Pixel cf_make_pixel_hex_string(const char* hex) { return cf_make_pi
  * @param    a          The color.
  * @param    s          A value to multiply with.
  * @return   Returns the multiplied color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_mul_color2 cf_mod_color cf_div_color
  */
 CF_INLINE CF_Color cf_mul_color(CF_Color a, float s) { return cf_make_color_rgba_f(a.r * s, a.g * s, a.b * s, a.a * s); }
 
@@ -229,7 +229,7 @@ CF_INLINE CF_Color cf_mul_color(CF_Color a, float s) { return cf_make_color_rgba
  * @param    a          The first color.
  * @param    b          The second color.
  * @return   For colors `a` and `a` the color `{ a.r*b.r, a.g*b.g, a.b*b.b, a.a*b.a }` is returned.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_mul_color cf_mod_color cf_div_color
  */
 CF_INLINE CF_Color cf_mul_color2(CF_Color a, CF_Color b) { return cf_make_color_rgba_f(a.r*b.r, a.g*b.g, a.b*b.b, a.a*b.a); }
 
@@ -240,7 +240,7 @@ CF_INLINE CF_Color cf_mul_color2(CF_Color a, CF_Color b) { return cf_make_color_
  * @param    a          The color.
  * @param    s          A value to divide with.
  * @return   Returns the divided color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_mul_color cf_mul_color2 cf_add_color
  */
 CF_INLINE CF_Color cf_div_color(CF_Color a, float s) { return cf_make_color_rgba_f(a.r/s, a.g/s, a.b/s, a.a/s); }
 
@@ -250,7 +250,7 @@ CF_INLINE CF_Color cf_div_color(CF_Color a, float s) { return cf_make_color_rgba
  * @brief    Returns two colors added together.
  * @param    a          The first color.
  * @param    b          The second color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_abs_color cf_mul_color cf_mul_color2
  */
 CF_INLINE CF_Color cf_add_color(CF_Color a, CF_Color b) { return cf_make_color_rgba_f(a.r+b.r, a.g+b.g, a.b+b.b, a.a+b.a); }
 
@@ -260,7 +260,7 @@ CF_INLINE CF_Color cf_add_color(CF_Color a, CF_Color b) { return cf_make_color_r
  * @brief    Returns two color `b` subtracted from color `a`.
  * @param    a          The first color.
  * @param    b          The second color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_splat_color cf_mul_color cf_mul_color2
  */
 CF_INLINE CF_Color cf_sub_color(CF_Color a, CF_Color b) { return cf_make_color_rgba_f(a.r-b.r, a.g-b.g, a.b-b.b, a.a-b.a); }
 
@@ -269,7 +269,7 @@ CF_INLINE CF_Color cf_sub_color(CF_Color a, CF_Color b) { return cf_make_color_r
  * @category graphics
  * @brief    Returns the component-wise absolute value of a color.
  * @param    a          The color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_add_color cf_mul_color cf_mul_color2
  */
 CF_INLINE CF_Color cf_abs_color(CF_Color a) { return cf_make_color_rgba_f(cf_abs(a.r), cf_abs(a.g), cf_abs(a.b), cf_abs(a.a)); }
 
@@ -278,7 +278,7 @@ CF_INLINE CF_Color cf_abs_color(CF_Color a) { return cf_make_color_rgba_f(cf_abs
  * @category graphics
  * @brief    Returns the fractional portion of each component of a color.
  * @param    a          The color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_mul_color cf_mul_color2 cf_div_color
  */
 CF_INLINE CF_Color cf_fract_color(CF_Color a) { return cf_make_color_rgba_f(cf_fract(a.r), cf_fract(a.g), cf_fract(a.b), cf_fract(a.a)); }
 
@@ -287,7 +287,7 @@ CF_INLINE CF_Color cf_fract_color(CF_Color a) { return cf_make_color_rgba_f(cf_f
  * @category graphics
  * @brief    Returns a color where all components are the same value.
  * @param    v          The value to set each color component to.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_sub_color cf_mul_color cf_mul_color2
  */
 CF_INLINE CF_Color cf_splat_color(float v) { CF_Color color; color.r = v; color.g = v; color.b = v; color.a = v; return color; }
 
@@ -296,7 +296,7 @@ CF_INLINE CF_Color cf_splat_color(float v) { CF_Color color; color.r = v; color.
  * @category graphics
  * @brief    Returns the component-wise mod of a color.
  * @param    m          The mod value.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_mul_color cf_mul_color2 cf_div_color
  */
 CF_INLINE CF_Color cf_mod_color(CF_Color a, float m) { return cf_make_color_rgba_f(cf_mod(a.r, m), cf_mod(a.g, m), cf_mod(a.b, m), cf_mod(a.a, m)); }
 
@@ -307,7 +307,7 @@ CF_INLINE CF_Color cf_mod_color(CF_Color a, float m) { return cf_make_color_rgba
  * @param    a          The color.
  * @param    lo         The min value for clamping.
  * @param    hi         The max value for clamping.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_clamp_color01 cf_color_lerp cf_color_premultiply
  */
 CF_INLINE CF_Color cf_clamp_color(CF_Color a, CF_Color lo, CF_Color hi) { return cf_make_color_rgba_f(cf_clamp(a.r, lo.r, hi.r), cf_clamp(a.g, lo.g, hi.g), cf_clamp(a.b, lo.b, hi.b), cf_clamp(a.a, lo.a, hi.a)); }
 
@@ -316,7 +316,7 @@ CF_INLINE CF_Color cf_clamp_color(CF_Color a, CF_Color lo, CF_Color hi) { return
  * @category graphics
  * @brief    Returns the component-wise clamp of `a` between 0.0f and 1.0f.
  * @param    a          The color.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_clamp_color cf_color_lerp cf_color_premultiply
  */
 CF_INLINE CF_Color cf_clamp_color01(CF_Color a) { return cf_make_color_rgba_f(cf_clamp(a.r, 0, 1.0f), cf_clamp(a.g, 0, 1.0f), cf_clamp(a.b, 0, 1.0f), cf_clamp(a.a, 0, 1.0f)); }
 
@@ -327,7 +327,7 @@ CF_INLINE CF_Color cf_clamp_color01(CF_Color a) { return cf_make_color_rgba_f(cf
  * @param    a          The first color.
  * @param    b          The second color.
  * @param    s          The interpolant from 0.0f to 1.0f.
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_color_premultiply cf_clamp_color cf_clamp_color01
  */
 CF_INLINE CF_Color cf_color_lerp(CF_Color a, CF_Color b, float s) { return cf_add_color(a, cf_mul_color(cf_sub_color(b, a), s)); }
 
@@ -337,7 +337,7 @@ CF_INLINE CF_Color cf_color_lerp(CF_Color a, CF_Color b, float s) { return cf_ad
  * @brief    Returns a color in premultiplied alpha form.
  * @param    c          The color.
  * @remarks  Read here for more information about [premultiplied alpha](https://limnu.com/premultiplied-alpha-primer-artists/).
- * @related  CF_Color cf_mul_color cf_mul_color2 cf_div_color cf_add_color cf_sub_color cf_abs_color cf_fract_color cf_splat_color cf_mod_color cf_clamp_color cf_clamp_color01 cf_color_lerp cf_color_premultiply
+ * @related  cf_color_lerp cf_clamp_color cf_clamp_color01
  */
 CF_INLINE CF_Color cf_color_premultiply(CF_Color c) { c.r *= c.a; c.g *= c.a; c.b *= c.a; return c; }
 
@@ -353,7 +353,7 @@ CF_INLINE CF_Color cf_color_premultiply(CF_Color c) { c.r *= c.a; c.g *= c.a; c.
  *           look way better than in RGB form. Sometimes it's a good idea to convert to HSV, interpolate, then convert back to RGB in order to interpolate
  *           between two RGB colors. If you interpolate between RGB colors without the intermediate HSV conversion, you may find the middle color to be
  *           some kind of ugly grey color. The intermediate HSV conversion may avoid this grey interpolation artifact.
- * @related  CF_Color cf_rgb_to_hsv cf_hsv_to_rgb
+ * @related  cf_hsv_to_rgb CF_Color
  */
 CF_INLINE CF_Color cf_rgb_to_hsv(CF_Color c)
 {
@@ -374,7 +374,7 @@ CF_INLINE CF_Color cf_rgb_to_hsv(CF_Color c)
  *           look way better than in RGB form. Sometimes it's a good idea to convert to HSV, interpolate, then convert back to RGB in order to interpolate
  *           between two RGB colors. If you interpolate between RGB colors without the intermediate HSV conversion, you may find the middle color to be
  *           some kind of ugly grey color. The intermediate HSV conversion may avoid this grey interpolation artifact.
- * @related  CF_Color cf_rgb_to_hsv cf_hsv_to_rgb
+ * @related  cf_rgb_to_hsv CF_Color
  */
 CF_INLINE CF_Color cf_hsv_to_rgb(CF_Color c)
 {
@@ -396,7 +396,7 @@ CF_INLINE CF_Color cf_hsv_to_rgb(CF_Color c)
  * @param    base       The original color.
  * @param    tint       The blend color to apply a hue-tint effect with.
  * @remarks  This function attempts to mimic the Hue [Photoshop blend-layer](https://helpx.adobe.com/photoshop/using/blending-modes.html) mode.
- * @related  CF_Color cf_hue cf_overlay_color cf_softlight_color cf_overlay cf_softlight
+ * @related  cf_overlay_color cf_softlight_color cf_overlay
  */
 CF_INLINE CF_Color cf_hue(CF_Color base, CF_Color tint)
 {
@@ -414,7 +414,7 @@ CF_INLINE CF_Color cf_hue(CF_Color base, CF_Color tint)
  * @param    blend      The blend color to apply an overlay effect with.
  * @remarks  This function attempts to mimic the Overlay [Photoshop blend-layer](https://helpx.adobe.com/photoshop/using/blending-modes.html) mode.
  *           The `blend` color is used to adjust colors in the `base`, while still preserving shadows and highlights of the `base`.
- * @related  CF_Color cf_hue cf_overlay_color cf_softlight_color cf_overlay cf_softlight
+ * @related  cf_overlay_color cf_hue cf_softlight_color
  */
 CF_INLINE float cf_overlay(float base, float blend) { return (base <= 0.5f) ? 2*base * blend : 1-2*(1-base) * (1-blend); }
 
@@ -426,7 +426,7 @@ CF_INLINE float cf_overlay(float base, float blend) { return (base <= 0.5f) ? 2*
  * @param    blend      The blend color to apply a softlight effect with.
  * @remarks  This function attempts to mimic the Softlight [Photoshop blend-layer](https://helpx.adobe.com/photoshop/using/blending-modes.html) mode.
  *           The `blend` color is used to adjust colors in the `base`, while still preserving shadows and highlights of the `base`.
- * @related  CF_Color cf_hue cf_overlay_color cf_softlight_color cf_overlay cf_softlight
+ * @related  cf_softlight_color cf_hue cf_overlay_color
  */
 CF_INLINE float cf_softlight(float base, float blend) { if (blend <= 0.5f) return base - (1-2*blend)*base*(1-base); else return base + (2*blend-1) * (((base <= 0.25f) ? ((16*base-12) * base+4) * base : CF_SQRTF(base)) - base); }
 
@@ -438,7 +438,7 @@ CF_INLINE float cf_softlight(float base, float blend) { if (blend <= 0.5f) retur
  * @param    blend      The blend color to apply an overlay effect with.
  * @remarks  This function attempts to mimic the Overlay [Photoshop blend-layer](https://helpx.adobe.com/photoshop/using/blending-modes.html) mode.
  *           The `blend` color is used to adjust colors in the `base`, while still preserving shadows and highlights of the `base`.
- * @related  CF_Color cf_hue cf_overlay_color cf_softlight_color cf_overlay cf_softlight
+ * @related  cf_overlay cf_hue cf_softlight_color
  */
 CF_INLINE CF_Color cf_overlay_color(CF_Color base, CF_Color blend) { return cf_make_color_rgba_f(cf_overlay(base.r, blend.r), cf_overlay(base.g, blend.g), cf_overlay(base.b, blend.b), base.a); }
 
@@ -450,7 +450,7 @@ CF_INLINE CF_Color cf_overlay_color(CF_Color base, CF_Color blend) { return cf_m
  * @param    blend      The blend color to apply a softlight effect with.
  * @remarks  This function attempts to mimic the Softlight [Photoshop blend-layer](https://helpx.adobe.com/photoshop/using/blending-modes.html) mode.
  *           The `blend` color is used to adjust colors in the `base`, while still preserving shadows and highlights of the `base`.
- * @related  CF_Color cf_hue cf_overlay_color cf_softlight_color cf_overlay cf_softlight
+ * @related  cf_softlight cf_hue cf_overlay_color
  */
 CF_INLINE CF_Color cf_softlight_color(CF_Color base, CF_Color blend) { return cf_make_color_rgba_f(cf_softlight(base.r, blend.r), cf_softlight(base.g, blend.g), cf_softlight(base.b, blend.b), base.a); }
 
@@ -462,7 +462,7 @@ CF_INLINE CF_Color cf_softlight_color(CF_Color base, CF_Color blend) { return cf
  * @param    b          An 8-bit value promoted to an `int` upon calling.
  * @remarks  This is a helper-function intended for advanced users.
  *           The core calculation is done with full integers to help avoid intermediate overflows on 8-bit values.
- * @related  cf_mul_un8 cf_div_un8 cf_add_un8 cf_sub_un8
+ * @related  cf_div_un8 cf_add_un8 cf_sub_un8
  */
 CF_INLINE uint8_t cf_mul_un8(int a, int b) { int t = (a * b) + 0x80; return (uint8_t)(((t >> 8) + t) >> 8); }
 
@@ -474,7 +474,7 @@ CF_INLINE uint8_t cf_mul_un8(int a, int b) { int t = (a * b) + 0x80; return (uin
  * @param    b          An 8-bit value promoted to an `int` upon calling.
  * @remarks  This is a helper-function intended for advanced users.
  *           The core calculation is done with full integers to help avoid intermediate overflows on 8-bit values.
- * @related  cf_mul_un8 cf_div_un8 cf_add_un8 cf_sub_un8
+ * @related  cf_mul_un8 cf_add_un8 cf_sub_un8
  */
 CF_INLINE uint8_t cf_div_un8(int a, int b) { return (uint8_t)(((b) * 0xFF + ((a) / 2)) / (a)); }
 
@@ -486,7 +486,7 @@ CF_INLINE uint8_t cf_div_un8(int a, int b) { return (uint8_t)(((b) * 0xFF + ((a)
  * @param    b          An 8-bit value promoted to an `int` upon calling.
  * @remarks  This is a helper-function intended for advanced users.
  *           The core calculation is done with full integers to help avoid intermediate overflows on 8-bit values.
- * @related  cf_mul_un8 cf_div_un8 cf_add_un8 cf_sub_un8
+ * @related  cf_mul_un8 cf_div_un8 cf_sub_un8
  */
 CF_INLINE uint8_t cf_add_un8(int a, int b) { int t = a + b; return (uint8_t)(t | (t >> 8)); }
 
@@ -498,7 +498,7 @@ CF_INLINE uint8_t cf_add_un8(int a, int b) { int t = a + b; return (uint8_t)(t |
  * @param    b          An 8-bit value promoted to an `int` upon calling.
  * @remarks  This is a helper-function intended for advanced users.
  *           The core calculation is done with full integers to help avoid intermediate overflows on 8-bit values.
- * @related  cf_mul_un8 cf_div_un8 cf_add_un8 cf_sub_un8
+ * @related  cf_mul_un8 cf_div_un8 cf_add_un8
  */
 CF_INLINE uint8_t cf_sub_un8(int a, int b) { int t = a - b; if (t < 0) t = 0; return (uint8_t)(t | (t >> 8)); }
 
@@ -508,7 +508,7 @@ CF_INLINE uint8_t cf_sub_un8(int a, int b) { int t = a - b; if (t < 0) t = 0; re
  * @brief    Multiplies a `CF_Pixel` by an unsigned 8-bit number.
  * @param    a          The pixel.
  * @param    b          An 8-bit value.
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_div_pixel cf_add_pixel cf_sub_pixel
  */
 CF_INLINE CF_Pixel cf_mul_pixel(CF_Pixel a, uint8_t s) { return cf_make_pixel_rgba_f(cf_mul_un8(a.colors.r, s), cf_mul_un8(a.colors.g, s), cf_mul_un8(a.colors.b, s), cf_mul_un8(a.colors.a, s)); }
 
@@ -518,7 +518,7 @@ CF_INLINE CF_Pixel cf_mul_pixel(CF_Pixel a, uint8_t s) { return cf_make_pixel_rg
  * @brief    Divides a `CF_Pixel` by an unsigned 8-bit number.
  * @param    a          The pixel.
  * @param    b          An 8-bit value.
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_mul_pixel cf_add_pixel cf_sub_pixel
  */
 CF_INLINE CF_Pixel cf_div_pixel(CF_Pixel a, uint8_t s) { return cf_make_pixel_rgba_f(cf_div_un8(a.colors.r, s), cf_div_un8(a.colors.g, s), cf_div_un8(a.colors.b, s), cf_div_un8(a.colors.a, s)); }
 
@@ -528,7 +528,7 @@ CF_INLINE CF_Pixel cf_div_pixel(CF_Pixel a, uint8_t s) { return cf_make_pixel_rg
  * @brief    Adds two `CF_Pixel`s together.
  * @param    a          The first pixel.
  * @param    b          The second pixel.
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_mul_pixel cf_div_pixel cf_sub_pixel
  */
 CF_INLINE CF_Pixel cf_add_pixel(CF_Pixel a, CF_Pixel b) { return cf_make_pixel_rgba(cf_add_un8(a.colors.r, b.colors.r), cf_add_un8(a.colors.g, b.colors.g), cf_add_un8(a.colors.b, b.colors.b), cf_add_un8(a.colors.a, b.colors.a)); }
 
@@ -538,7 +538,7 @@ CF_INLINE CF_Pixel cf_add_pixel(CF_Pixel a, CF_Pixel b) { return cf_make_pixel_r
  * @brief    Subtracts one `CF_Pixel` from another.
  * @param    a          The first pixel.
  * @param    b          The second pixel.
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_mul_pixel cf_div_pixel cf_add_pixel
  */
 CF_INLINE CF_Pixel cf_sub_pixel(CF_Pixel a, CF_Pixel b) { return cf_make_pixel_rgba(cf_sub_un8(a.colors.r, b.colors.r), cf_sub_un8(a.colors.g, b.colors.g), cf_sub_un8(a.colors.b, b.colors.b), cf_sub_un8(a.colors.a, b.colors.a)); }
 
@@ -552,7 +552,7 @@ CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c);
  * @param    a          The first pixel.
  * @param    b          The second pixel.
  * @param    s          The interpolant from 0 to 1.
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_pixel_premultiply cf_mul_pixel cf_div_pixel
  */
 CF_INLINE CF_Pixel cf_pixel_lerp(CF_Pixel a, CF_Pixel b, float s) { CF_Color A = cf_pixel_to_color(a); return cf_color_to_pixel(cf_add_color(A, cf_mul_color(cf_sub_color(cf_pixel_to_color(b), A), s))); }
 
@@ -562,7 +562,7 @@ CF_INLINE CF_Pixel cf_pixel_lerp(CF_Pixel a, CF_Pixel b, float s) { CF_Color A =
  * @brief    Returns a premultiplied `CF_Pixel` by its alpha component.
  * @param    a          The pixel.
  * @remarks  Read here for more information about [premultiplied alpha](https://limnu.com/premultiplied-alpha-primer-artists/).
- * @related  cf_mul_pixel cf_div_pixel cf_add_pixel cf_sub_pixel cf_pixel_lerp cf_pixel_premultiply
+ * @related  cf_pixel_lerp cf_mul_pixel cf_div_pixel
  */
 CF_INLINE CF_Pixel cf_pixel_premultiply(CF_Pixel c) { c.colors.r = cf_mul_un8(c.colors.r, c.colors.a); c.colors.g = cf_mul_un8(c.colors.g, c.colors.a); c.colors.b = cf_mul_un8(c.colors.b, c.colors.a); return c; }
 
@@ -572,7 +572,7 @@ CF_INLINE CF_Pixel cf_pixel_premultiply(CF_Pixel c) { c.colors.r = cf_mul_un8(c.
  * @brief    Converts a `CF_Pixel` to a color.
  * @param    p          The pixel.
  * @return   Returns a `CF_Color` (0.0f-1.0f) converted from pixel form (0-255).
- * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
+ * @related  cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
  */
 CF_INLINE CF_Color cf_pixel_to_color(CF_Pixel p) { return cf_make_color_rgba(p.colors.r, p.colors.g, p.colors.b, p.colors.a); }
 
@@ -583,7 +583,7 @@ CF_INLINE CF_Color cf_pixel_to_color(CF_Pixel p) { return cf_make_color_rgba(p.c
  * @param    p          The pixel.
  * @return   Returns an unsigned 32-bit integer of the packed pixel components. The first byte is the red component, the second byte is
  *           the green component, the third byte is the blue component, the fourth byte is 0xFF or full-alpha.
- * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
+ * @related  cf_pixel_to_int_rgba cf_pixel_to_color cf_pixel_to_string
  */
 CF_INLINE uint32_t cf_pixel_to_int_rgb(CF_Pixel p) { return p.val | 0xFF000000; }
 
@@ -594,7 +594,7 @@ CF_INLINE uint32_t cf_pixel_to_int_rgb(CF_Pixel p) { return p.val | 0xFF000000; 
  * @param    p          The pixel.
  * @return   Returns an unsigned 32-bit integer of the packed pixel components. The first byte is the red component, the second byte is
  *           the green component, the third byte is the blue component, the fourth byte is the alpha component.
- * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
+ * @related  cf_pixel_to_int_rgb cf_pixel_to_color cf_pixel_to_string
  */
 CF_INLINE uint32_t cf_pixel_to_int_rgba(CF_Pixel p) { return p.val; }
 
@@ -604,7 +604,7 @@ CF_INLINE uint32_t cf_pixel_to_int_rgba(CF_Pixel p) { return p.val; }
  * @brief    Converts a `CF_Pixel` to a dynamic string. Free it with `sfree` when done.
  * @param    p          The pixel.
  * @remarks  Since this function dynamically allocates a Cute Framework C-string, it must be free'd up with `sfree` when you're done with it.
- * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
+ * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb
  */
 CF_INLINE char* cf_pixel_to_string(CF_Pixel p) { char* s = NULL; return shex(s, p.val); } // Call `sfree` when done.
 
@@ -613,7 +613,7 @@ CF_INLINE char* cf_pixel_to_string(CF_Pixel p) { char* s = NULL; return shex(s, 
  * @category graphics
  * @brief    Converts a `CF_Color` (0.0f to 1.0f) to a `CF_Pixel` (0-255).
  * @param    c          The color.
- * @related  cf_color_to_pixel cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
+ * @related  cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
  */
 CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c) { CF_Pixel p; p.colors.r = (int)((uint8_t)(c.r * 255.0f)); p.colors.g = (int)((uint8_t)(c.g * 255.0f)); p.colors.b = (int)((uint8_t)(c.b * 255.0f)); p.colors.a = (int)((uint8_t)(c.a * 255.0f)); return p; }
 
@@ -624,7 +624,7 @@ CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c) { CF_Pixel p; p.colors.r = (int
  * @param    c          The color.
  * @return   Returns an unsigned 32-bit integer of the packed pixel components. The first byte is the red component, the second byte is
  *           the green component, the third byte is the blue component, the fourth byte is 0xFF or full-alpha.
- * @related  cf_color_to_pixel cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
+ * @related  cf_color_to_int_rgba cf_color_to_pixel cf_color_to_string
  */
 CF_INLINE uint32_t cf_color_to_int_rgb(CF_Color c) { return cf_color_to_pixel(c).val | 0xFF000000; }
 
@@ -635,7 +635,7 @@ CF_INLINE uint32_t cf_color_to_int_rgb(CF_Color c) { return cf_color_to_pixel(c)
  * @param    c          The color.
  * @return   Returns an unsigned 32-bit integer of the packed pixel components. The first byte is the red component, the second byte is
  *           the green component, the third byte is the blue component, the fourth byte is the alpha component.
- * @related  cf_color_to_pixel cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
+ * @related  cf_color_to_int_rgb cf_color_to_pixel cf_color_to_string
  */
 CF_INLINE uint32_t cf_color_to_int_rgba(CF_Color c) { return cf_color_to_pixel(c).val; }
 
@@ -645,7 +645,7 @@ CF_INLINE uint32_t cf_color_to_int_rgba(CF_Color c) { return cf_color_to_pixel(c
  * @brief    Converts a `CF_Color` to a dynamic string. Free it with `sfree` when done.
  * @param    p          The pixel.
  * @remarks  Since this function dynamically allocates a Cute Framework C-string, it must be free'd up with `sfree` when you're done with it.
- * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb cf_pixel_to_string
+ * @related  cf_pixel_to_color cf_pixel_to_int_rgba cf_pixel_to_int_rgb
  */
 CF_INLINE char* cf_color_to_string(CF_Color c) { char* s = NULL; return shex(s, cf_color_to_pixel(c).val); }
 
@@ -653,7 +653,7 @@ CF_INLINE char* cf_color_to_string(CF_Color c) { char* s = NULL; return shex(s, 
  * @function cf_color_invisible
  * @category graphics
  * @brief    Helper function to return an invisible `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_black cf_color_white cf_color_red
  */
 CF_INLINE CF_Color cf_color_invisible(void) { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
 
@@ -661,7 +661,7 @@ CF_INLINE CF_Color cf_color_invisible(void) { return cf_make_color_rgba_f(0.0f, 
  * @function cf_color_clear
  * @category graphics
  * @brief    Helper function to return an invisible `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_cyan cf_color_invisible cf_color_black
  */
 CF_INLINE CF_Color cf_color_clear(void) { return cf_make_color_rgba_f(0.0f, 0.0f, 0.0f, 0.0f); }
 
@@ -669,7 +669,7 @@ CF_INLINE CF_Color cf_color_clear(void) { return cf_make_color_rgba_f(0.0f, 0.0f
  * @function cf_color_black
  * @category graphics
  * @brief    Helper function to return a black `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_blue cf_color_invisible cf_color_white
  */
 CF_INLINE CF_Color cf_color_black(void) { return cf_make_color_rgb_f(0.0f, 0.0f, 0.0f); }
 
@@ -677,7 +677,7 @@ CF_INLINE CF_Color cf_color_black(void) { return cf_make_color_rgb_f(0.0f, 0.0f,
  * @function cf_color_white
  * @category graphics
  * @brief    Helper function to return a white `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_red
  */
 CF_INLINE CF_Color cf_color_white(void) { return cf_make_color_rgb_f(1.0f, 1.0f, 1.0f); }
 
@@ -685,7 +685,7 @@ CF_INLINE CF_Color cf_color_white(void) { return cf_make_color_rgb_f(1.0f, 1.0f,
  * @function cf_color_red
  * @category graphics
  * @brief    Helper function to return a red `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_red(void) { return cf_make_color_rgb_f(1.0f, 0.0f, 0.0f); }
 
@@ -693,7 +693,7 @@ CF_INLINE CF_Color cf_color_red(void) { return cf_make_color_rgb_f(1.0f, 0.0f, 0
  * @function cf_color_green
  * @category graphics
  * @brief    Helper function to return a green `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_grey cf_color_invisible cf_color_black
  */
 CF_INLINE CF_Color cf_color_green(void) { return cf_make_color_rgb_f(0.0f, 1.0f, 0.0f); }
 
@@ -701,7 +701,7 @@ CF_INLINE CF_Color cf_color_green(void) { return cf_make_color_rgb_f(0.0f, 1.0f,
  * @function cf_color_blue
  * @category graphics
  * @brief    Helper function to return a blue `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_black cf_color_invisible cf_color_white
  */
 CF_INLINE CF_Color cf_color_blue(void) { return cf_make_color_rgb_f(0.0f, 0.0f, 1.0f); }
 
@@ -709,7 +709,7 @@ CF_INLINE CF_Color cf_color_blue(void) { return cf_make_color_rgb_f(0.0f, 0.0f, 
  * @function cf_color_yellow
  * @category graphics
  * @brief    Helper function to return a yellow `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_yellow(void) { return cf_make_color_rgb_f(1.0f, 1.0f, 0.0f); }
 
@@ -717,7 +717,7 @@ CF_INLINE CF_Color cf_color_yellow(void) { return cf_make_color_rgb_f(1.0f, 1.0f
  * @function cf_color_orange
  * @category graphics
  * @brief    Helper function to return a orange `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_orange(void) { return cf_make_color_rgb_f(1.0f, 0.65f, 0.0f); }
 
@@ -725,7 +725,7 @@ CF_INLINE CF_Color cf_color_orange(void) { return cf_make_color_rgb_f(1.0f, 0.65
  * @function cf_color_purple
  * @category graphics
  * @brief    Helper function to return a purple `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_purple(void) { return cf_make_color_rgb_f(1.0f, 0.0f, 1.0f); }
 
@@ -733,7 +733,7 @@ CF_INLINE CF_Color cf_color_purple(void) { return cf_make_color_rgb_f(1.0f, 0.0f
  * @function cf_color_grey
  * @category graphics
  * @brief    Helper function to return a grey `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_green cf_color_invisible cf_color_black
  */
 CF_INLINE CF_Color cf_color_grey(void) { return cf_make_color_rgb_f(0.5f, 0.5f, 0.5f); }
 
@@ -741,7 +741,7 @@ CF_INLINE CF_Color cf_color_grey(void) { return cf_make_color_rgb_f(0.5f, 0.5f, 
  * @function cf_color_cyan
  * @category graphics
  * @brief    Helper function to return a cyan `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_cyan(void) { return cf_make_color_rgb(68, 220, 235); }
 
@@ -749,7 +749,7 @@ CF_INLINE CF_Color cf_color_cyan(void) { return cf_make_color_rgb(68, 220, 235);
  * @function cf_color_magenta
  * @category graphics
  * @brief    Helper function to return a magenta `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_invisible cf_color_black cf_color_white
  */
 CF_INLINE CF_Color cf_color_magenta(void) { return cf_make_color_rgb(224, 70, 224); }
 
@@ -757,7 +757,7 @@ CF_INLINE CF_Color cf_color_magenta(void) { return cf_make_color_rgb(224, 70, 22
  * @function cf_color_brown
  * @category graphics
  * @brief    Helper function to return a brown `CF_Color`.
- * @related  cf_color_invisible cf_color_black cf_color_white cf_color_red cf_color_green cf_color_blue cf_color_yellow cf_color_orange cf_color_purple cf_color_grey cf_color_cyan cf_color_magenta
+ * @related  cf_color_black cf_color_blue cf_color_invisible
  */
 CF_INLINE CF_Color cf_color_brown(void) { return cf_make_color_rgb(150, 105, 25); }
 
@@ -765,7 +765,7 @@ CF_INLINE CF_Color cf_color_brown(void) { return cf_make_color_rgb(150, 105, 25)
  * @function cf_pixel_invisible
  * @category graphics
  * @brief    Helper function to return a invisible `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_black cf_pixel_white cf_pixel_red
  */
 CF_INLINE CF_Pixel cf_pixel_invisible(void) { return cf_make_pixel_hex(0); }
 
@@ -773,7 +773,7 @@ CF_INLINE CF_Pixel cf_pixel_invisible(void) { return cf_make_pixel_hex(0); }
  * @function cf_pixel_clear
  * @category graphics
  * @brief    Helper function to return a invisible `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_cyan cf_pixel_invisible cf_pixel_black
  */
 CF_INLINE CF_Pixel cf_pixel_clear(void) { return cf_make_pixel_hex(0); }
 
@@ -781,7 +781,7 @@ CF_INLINE CF_Pixel cf_pixel_clear(void) { return cf_make_pixel_hex(0); }
  * @function cf_pixel_black
  * @category graphics
  * @brief    Helper function to return a black `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_blue cf_pixel_invisible cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_black(void) { return cf_make_pixel_rgb(0, 0, 0); }
 
@@ -789,7 +789,7 @@ CF_INLINE CF_Pixel cf_pixel_black(void) { return cf_make_pixel_rgb(0, 0, 0); }
  * @function cf_pixel_white
  * @category graphics
  * @brief    Helper function to return a invisible `white`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_red
  */
 CF_INLINE CF_Pixel cf_pixel_white(void) { return cf_make_pixel_rgb(255, 255, 255); }
 
@@ -797,7 +797,7 @@ CF_INLINE CF_Pixel cf_pixel_white(void) { return cf_make_pixel_rgb(255, 255, 255
  * @function cf_pixel_red
  * @category graphics
  * @brief    Helper function to return a red `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_red(void) { return cf_make_pixel_rgb(255, 0, 0); }
 
@@ -805,7 +805,7 @@ CF_INLINE CF_Pixel cf_pixel_red(void) { return cf_make_pixel_rgb(255, 0, 0); }
  * @function cf_pixel_green
  * @category graphics
  * @brief    Helper function to return a green `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_grey cf_pixel_invisible cf_pixel_black
  */
 CF_INLINE CF_Pixel cf_pixel_green(void) { return cf_make_pixel_rgb(0, 255, 0); }
 
@@ -813,7 +813,7 @@ CF_INLINE CF_Pixel cf_pixel_green(void) { return cf_make_pixel_rgb(0, 255, 0); }
  * @function cf_pixel_blue
  * @category graphics
  * @brief    Helper function to return a blue `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_black cf_pixel_invisible cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_blue(void) { return cf_make_pixel_rgb(0, 0, 255); }
 
@@ -821,7 +821,7 @@ CF_INLINE CF_Pixel cf_pixel_blue(void) { return cf_make_pixel_rgb(0, 0, 255); }
  * @function cf_pixel_yellow
  * @category graphics
  * @brief    Helper function to return a yellow `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_yellow(void) { return cf_make_pixel_rgb(255, 255, 0); }
 
@@ -829,7 +829,7 @@ CF_INLINE CF_Pixel cf_pixel_yellow(void) { return cf_make_pixel_rgb(255, 255, 0)
  * @function cf_pixel_orange
  * @category graphics
  * @brief    Helper function to return a orange `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_orange(void) { return cf_make_pixel_rgb(255, 165, 0); }
 
@@ -837,7 +837,7 @@ CF_INLINE CF_Pixel cf_pixel_orange(void) { return cf_make_pixel_rgb(255, 165, 0)
  * @function cf_pixel_purple
  * @category graphics
  * @brief    Helper function to return a purple `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_purple(void) { return cf_make_pixel_rgb(255, 0, 255); }
 
@@ -845,7 +845,7 @@ CF_INLINE CF_Pixel cf_pixel_purple(void) { return cf_make_pixel_rgb(255, 0, 255)
  * @function cf_pixel_grey
  * @category graphics
  * @brief    Helper function to return a grey `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_green cf_pixel_invisible cf_pixel_black
  */
 CF_INLINE CF_Pixel cf_pixel_grey(void) { return cf_make_pixel_rgb(127, 127, 127); }
 
@@ -853,7 +853,7 @@ CF_INLINE CF_Pixel cf_pixel_grey(void) { return cf_make_pixel_rgb(127, 127, 127)
  * @function cf_pixel_cyan
  * @category graphics
  * @brief    Helper function to return a cyan `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_cyan(void) { return cf_make_pixel_rgb(68, 220, 235); }
 
@@ -861,7 +861,7 @@ CF_INLINE CF_Pixel cf_pixel_cyan(void) { return cf_make_pixel_rgb(68, 220, 235);
  * @function cf_pixel_magenta
  * @category graphics
  * @brief    Helper function to return a magenta `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white
  */
 CF_INLINE CF_Pixel cf_pixel_magenta(void) { return cf_make_pixel_rgb(224, 70, 224); }
 
@@ -869,7 +869,7 @@ CF_INLINE CF_Pixel cf_pixel_magenta(void) { return cf_make_pixel_rgb(224, 70, 22
  * @function cf_pixel_brown
  * @category graphics
  * @brief    Helper function to return a brown `CF_Pixel`.
- * @related  cf_pixel_invisible cf_pixel_black cf_pixel_white cf_pixel_red cf_pixel_green cf_pixel_blue cf_pixel_yellow cf_pixel_orange cf_pixel_purple cf_pixel_grey cf_pixel_cyan cf_pixel_magenta
+ * @related  cf_pixel_black cf_pixel_blue cf_pixel_invisible
  */
 CF_INLINE CF_Pixel cf_pixel_brown(void) { return cf_make_pixel_rgb(150, 105, 25); }
 

--- a/include/cute_coroutine.h
+++ b/include/cute_coroutine.h
@@ -28,7 +28,7 @@ extern "C" {
  *           can pause itself with `cf_coroutine_yield`. Then, later, someone else can call `cf_coroutine_resume`. The coroutine
  *           will then continue running just after the last call to `cf_coroutine_yield`. This makes a coroutine great for
  *           preserving state between yield/resume calls, for example to perform some complex action over multiple frames.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield
  */
 typedef struct CF_Coroutine { uint64_t id; } CF_Coroutine;
 // @end
@@ -38,7 +38,7 @@ typedef struct CF_Coroutine { uint64_t id; } CF_Coroutine;
  * @category coroutine
  * @brief    Entry point for a coroutine to start.
  * @param    co            The coroutine.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield
  */
 typedef void (CF_CoroutineFn)(CF_Coroutine co);
 
@@ -53,7 +53,7 @@ typedef void (CF_CoroutineFn)(CF_Coroutine co);
  *           coroutine with `cf_destroy_coroutine` when done. See `CF_Coroutine` for some more details. **IMPORTANT NOTE**: You should beef
  *           up the stack_size to 1 or 2 MB (you may use e.g. `CF_MB * 2`) if you wish to call into APIs such as DirectX. A variety of APIs
  *           and libraries out there have very deep or complex call stacks -- so the default size may cause stack overflows in such cases.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume
  */
 CF_API CF_Coroutine CF_CALL cf_make_coroutine(CF_CoroutineFn* fn, int stack_size, void* udata);
 
@@ -63,7 +63,7 @@ CF_API CF_Coroutine CF_CALL cf_make_coroutine(CF_CoroutineFn* fn, int stack_size
  * @brief    Destroys a coroutine created by `cf_make_coroutine`.
  * @param    co            The coroutine.
  * @remarks  All objects on the coroutine's stack will get automically cleaned up.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_make_coroutine cf_coroutine_state_to_string cf_coroutine_resume
  */
 CF_API void CF_CALL cf_destroy_coroutine(CF_Coroutine co);
 
@@ -71,8 +71,8 @@ CF_API void CF_CALL cf_destroy_coroutine(CF_Coroutine co);
  * @enum     CF_CoroutineState
  * @category coroutine
  * @brief    The states of a coroutine.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
- * @related  cf_make_app cf_destroy_app
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_make_coroutine
+ * @related  cf_destroy_app cf_make_app
  */
 #define CF_COROUTINE_STATE_DEFS \
 	/* @entry The coroutine has stopped running entirely. */                                           \
@@ -97,7 +97,7 @@ typedef enum CF_CoroutineState
  * @category coroutine
  * @brief    Converts a `CF_CoroutineState` to c-string.
  * @param    type          The state.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state cf_coroutine_space_remaining cf_coroutine_resume
  */
 CF_INLINE const char* cf_coroutine_state_to_string(CF_CoroutineState type)
 {
@@ -117,7 +117,7 @@ CF_INLINE const char* cf_coroutine_state_to_string(CF_CoroutineState type)
  * return    Returns info on any errors as `CF_Result`.
  * @remarks  Coroutines are functions that can be paused with `cf_coroutine_yield` and resumed with `cf_coroutine_resume`. See `CF_Coroutine`
  *           for more details.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_yield cf_coroutine_state
  */
 CF_API CF_Result CF_CALL cf_coroutine_resume(CF_Coroutine co);
 
@@ -129,7 +129,7 @@ CF_API CF_Result CF_CALL cf_coroutine_resume(CF_Coroutine co);
  * return    Returns info on any errors as `CF_Result`.
  * @remarks  Coroutines are functions that can be paused with `cf_coroutine_yield` and resumed with `cf_coroutine_resume`. See `CF_Coroutine`
  *           for more details.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_state
  */
 CF_API CF_Result CF_CALL cf_coroutine_yield(CF_Coroutine co);
 
@@ -138,7 +138,7 @@ CF_API CF_Result CF_CALL cf_coroutine_yield(CF_Coroutine co);
  * @category coroutine
  * @brief    Returns the current state of the coroutine.
  * @param    co            The coroutine.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_space_remaining cf_coroutine_resume
  */
 CF_API CF_CoroutineState CF_CALL cf_coroutine_state(CF_Coroutine co);
 
@@ -147,7 +147,7 @@ CF_API CF_CoroutineState CF_CALL cf_coroutine_state(CF_Coroutine co);
  * @category coroutine
  * @brief    Returns the `void* udata` from `cf_coroutine_create`.
  * @param    co            The coroutine.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield
  */
 CF_API void* CF_CALL cf_coroutine_get_udata(CF_Coroutine co);
 
@@ -161,7 +161,7 @@ CF_API void* CF_CALL cf_coroutine_get_udata(CF_Coroutine co);
  * return    Returns info on any errors as `CF_Result`.
  * @remarks  Each coroutine has an internal storage of 1k (1024) bytes. The purpose is to allow a formal communication/parameter passing
  *           in/out of coroutines via FIFO ordering. These storage are totally optional, and here merely for convenience.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_pop cf_coroutine_state_to_string cf_coroutine_resume
  */
 CF_API CF_Result CF_CALL cf_coroutine_push(CF_Coroutine co, const void* data, size_t size);
 
@@ -175,7 +175,7 @@ CF_API CF_Result CF_CALL cf_coroutine_push(CF_Coroutine co, const void* data, si
  * return    Returns info on any errors as `CF_Result`.
  * @remarks  Each coroutine has an internal storage of 1k (1024) bytes. The purpose is to allow a formal communication/parameter passing
  *           in/out of coroutines via FIFO ordering. These storage are totally optional, and here merely for convenience.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_push cf_coroutine_state_to_string cf_coroutine_resume
  */
 CF_API CF_Result CF_CALL cf_coroutine_pop(CF_Coroutine co, void* data, size_t size);
 
@@ -186,7 +186,7 @@ CF_API CF_Result CF_CALL cf_coroutine_pop(CF_Coroutine co, void* data, size_t si
  * @param    co            The coroutine.
  * @remarks  Each coroutine has an internal storage of 1k (1024) bytes. The purpose is to allow a formal communication/parameter passing
  *           in/out of coroutines via FIFO ordering. These storage are totally optional, and here merely for convenience.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield
  */
 CF_API size_t CF_CALL cf_coroutine_bytes_pushed(CF_Coroutine co);
 
@@ -197,7 +197,7 @@ CF_API size_t CF_CALL cf_coroutine_bytes_pushed(CF_Coroutine co);
  * @param    co            The coroutine.
  * @remarks  Each coroutine has an internal storage of 1k (1024) bytes. The purpose is to allow a formal communication/parameter passing
  *           in/out of coroutines via FIFO ordering. These storage are totally optional, and here merely for convenience.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_state cf_coroutine_resume
  */
 CF_API size_t CF_CALL cf_coroutine_space_remaining(CF_Coroutine co);
 
@@ -210,7 +210,7 @@ CF_API size_t CF_CALL cf_coroutine_space_remaining(CF_Coroutine co);
  *           For example, your coroutines may call into other functions -- instead of passing around a `co` pointer everywhere,
  *           your helper functions can simply fetch the `CF_Coroutine` pointer themselves on an as-needed basis by calling
  *           this function.
- * @related  CF_Coroutine CF_CoroutineFn CF_CoroutineState cf_make_coroutine cf_destroy_coroutine cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield cf_coroutine_state cf_coroutine_get_udata cf_coroutine_push cf_coroutine_pop cf_coroutine_bytes_pushed cf_coroutine_space_remaining cf_coroutine_currently_running
+ * @related  cf_coroutine_state_to_string cf_coroutine_resume cf_coroutine_yield
  */
 CF_API CF_Coroutine CF_CALL cf_coroutine_currently_running(void);
 

--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -197,7 +197,7 @@ extern "C" {
  * @param    message  An error message.
  * @param    file     Name of the file the assert came from.
  * @param    line     The line number the assert came from.
- * @related  cf_set_assert_handler cf_assert_fn
+ * @related  cf_set_assert_handler
  */
 typedef void (cf_assert_fn)(bool expr, const char* message, const char* file, int line);
 CF_API extern cf_assert_fn* g_assert_fn;
@@ -206,7 +206,7 @@ CF_API extern cf_assert_fn* g_assert_fn;
  * @function cf_set_assert_handler
  * @category app
  * @brief    Sets the application's default assert handler.
- * @related  cf_set_assert_handler cf_assert_fn
+ * @related  cf_assert_fn
  */
 CF_API void CF_CALL cf_set_assert_handler(cf_assert_fn* assert_fn);
 

--- a/include/cute_doubly_list.h
+++ b/include/cute_doubly_list.h
@@ -22,7 +22,7 @@ extern "C" {
  * @category list
  * @brief    A node in a circular doubly-linked list.
  * @remarks  This node is _intrusive_ and to be placed within your struct/object definitions as a member.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 typedef struct CF_ListNode
 {
@@ -38,7 +38,7 @@ typedef struct CF_ListNode
  * @struct   CF_List
  * @category list
  * @brief    A circular doubly-linked list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 typedef struct CF_List
 {
@@ -69,7 +69,7 @@ typedef struct CF_List
  *     
  *     // Do whatever is needed with the node.
  *     do_stuff(node);
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 #define CF_LIST_NODE(T, member, ptr) ((CF_ListNode*)((uintptr_t)ptr + CF_OFFSET_OF(T, member)))
 
@@ -95,7 +95,7 @@ typedef struct CF_List
  *     
  *     // Do whatever is needed with the host:
  *     do_stuff(my);
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 #define CF_LIST_HOST(T, member, ptr) ((T*)((uintptr_t)ptr - CF_OFFSET_OF(T, member)))
 
@@ -105,7 +105,7 @@ typedef struct CF_List
  * @brief    Intializes a node.
  * @param    node       The node.
  * @remarks  As this list is circular, each node is initialized to point to itself.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init cf_list_push_front cf_list_push_back
  */
 CF_INLINE void cf_list_init_node(CF_ListNode* node)
 {
@@ -120,7 +120,7 @@ CF_INLINE void cf_list_init_node(CF_ListNode* node)
  * @param    list       The list.
  * @remarks  As an optimization the list contains a dummy node inside of it. To traverse this list, use `cf_list_begin` and
  *           `cf_list_end` in a for loop. See `cf_list_begin` for an example.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_push_front cf_list_push_back
  */
 CF_INLINE void cf_list_init(CF_List* list)
 {
@@ -133,7 +133,7 @@ CF_INLINE void cf_list_init(CF_List* list)
  * @brief    Pushes a node onto the front of the list.
  * @param    list       The list.
  * @param    node       The node.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_push_back cf_list_pop_front cf_list_pop_back
  */
 CF_INLINE void cf_list_push_front(CF_List* list, CF_ListNode* node)
 {
@@ -149,7 +149,7 @@ CF_INLINE void cf_list_push_front(CF_List* list, CF_ListNode* node)
  * @brief    Pushes a node onto the back of the list.
  * @param    list       The list.
  * @param    node       The node.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_push_front cf_list_pop_front cf_list_pop_back
  */
 CF_INLINE void cf_list_push_back(CF_List* list, CF_ListNode* node)
 {
@@ -164,7 +164,7 @@ CF_INLINE void cf_list_push_back(CF_List* list, CF_ListNode* node)
  * @category list
  * @brief    Removes a node from the list.
  * @param    List       The list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 CF_INLINE void cf_list_remove(CF_ListNode* node)
 {
@@ -178,7 +178,7 @@ CF_INLINE void cf_list_remove(CF_ListNode* node)
  * @category list
  * @brief    Pops a node off the front of a list.
  * @param    List       The list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_pop_back cf_list_push_front cf_list_push_back
  */
 CF_INLINE CF_ListNode* cf_list_pop_front(CF_List* list)
 {
@@ -192,7 +192,7 @@ CF_INLINE CF_ListNode* cf_list_pop_front(CF_List* list)
  * @category list
  * @brief    Pops a node off the back of a list.
  * @param    List       The list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_pop_front cf_list_push_front cf_list_push_back
  */
 CF_INLINE CF_ListNode* cf_list_pop_back(CF_List* list)
 {
@@ -206,7 +206,7 @@ CF_INLINE CF_ListNode* cf_list_pop_back(CF_List* list)
  * @category list
  * @brief    Returns true if a list is empty.
  * @param    List       The list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_end cf_list_init_node cf_list_init
  */
 CF_INLINE bool cf_list_empty(CF_List* list)
 {
@@ -224,7 +224,7 @@ CF_INLINE bool cf_list_empty(CF_List* list)
  *     }
  * @remarks  Since the list is circular with a single dummy node it can be confusing to loop over. To help make this simpler, use
  *           `cf_list_begin` and `cf_list_end` to perform a loop over the list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_back cf_list_init_node cf_list_init
  */
 CF_INLINE CF_ListNode* cf_list_begin(CF_List* list)
 {
@@ -242,7 +242,7 @@ CF_INLINE CF_ListNode* cf_list_begin(CF_List* list)
  *     }
  * @remarks  Since the list is circular with a single dummy node it can be confusing to loop over. To help make this simpler, use
  *           `cf_list_begin` and `cf_list_end` to perform a loop over the list.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_empty cf_list_init_node cf_list_init
  */
 CF_INLINE CF_ListNode* cf_list_end(CF_List* list)
 {
@@ -255,7 +255,7 @@ CF_INLINE CF_ListNode* cf_list_end(CF_List* list)
  * @brief    Returns a pointer to the first element in the list.
  * @param    List       The list.
  * @remarks  Check to see if this is a valid node in the list with `node != cf_list_end(list)`.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_init_node cf_list_init cf_list_push_front
  */
 CF_INLINE CF_ListNode* cf_list_front(CF_List* list)
 {
@@ -268,7 +268,7 @@ CF_INLINE CF_ListNode* cf_list_front(CF_List* list)
  * @brief    Returns a pointer to the last element in the list.
  * @param    List       The list.
  * @remarks  Check to see if this is a valid node in the list with `node != cf_list_end(list)`.
- * @related  CF_ListNode CF_List CF_LIST_NODE CF_LIST_HOST cf_list_init_node cf_list_init cf_list_push_front cf_list_push_back cf_list_remove cf_list_pop_front cf_list_pop_back cf_list_empty cf_list_begin cf_list_end cf_list_front cf_list_back
+ * @related  cf_list_begin cf_list_init_node cf_list_init
  */
 CF_INLINE CF_ListNode* cf_list_back(CF_List* list)
 {

--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -26,7 +26,7 @@ extern "C" {
  * @category draw
  * @brief    Draws a sprite.
  * @param    sprite     The sprite.
- * @related  cf_draw_sprite cf_draw_quad draw_look_at cf_draw_to cf_app_draw_onto_screen
+ * @related  cf_draw_quad cf_draw_to cf_app_draw_onto_screen
  */
 CF_API void CF_CALL cf_draw_sprite(const CF_Sprite* sprite);
 
@@ -37,7 +37,7 @@ CF_API void CF_CALL cf_draw_sprite(const CF_Sprite* sprite);
  * @param    sprite     The sprite.
  * @remarks  This function ensures the sprite is fully loaded into memory without actually rendering anything.
  *           This is a good way to avoid disk io at inconvenient times.
- * @related  cf_draw_sprite cf_draw_quad draw_look_at cf_draw_to cf_app_draw_onto_screen
+ * @related  cf_draw_sprite cf_draw_quad cf_draw_to
  */
 CF_API void CF_CALL cf_draw_prefetch(const CF_Sprite* sprite);
 
@@ -48,7 +48,7 @@ CF_API void CF_CALL cf_draw_prefetch(const CF_Sprite* sprite);
  * @param    bb         The AABB (Axis-Aligned Bounding Box) to draw a quad over.
  * @param    thickness  The thickness of each line to draw.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
- * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad_fill cf_draw_quad_fill2 cf_draw_quad2
  */
 CF_API void CF_CALL cf_draw_quad(CF_Aabb bb, float thickness, float chubbiness);
 
@@ -63,7 +63,7 @@ CF_API void CF_CALL cf_draw_quad(CF_Aabb bb, float thickness, float chubbiness);
  * @param    thickness  The thickness of each line to draw.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
  * @remarks  All points `p0` through `p3` are encouraged to be in counter-clockwise order.
- * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad_fill cf_draw_quad_fill2
  */
 CF_API void CF_CALL cf_draw_quad2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float thickness, float chubbiness);
 
@@ -73,7 +73,7 @@ CF_API void CF_CALL cf_draw_quad2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float 
  * @brief    Draws a quad.
  * @param    bb         The AABB (Axis-Aligned Bounding Box) to draw a quad over.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
- * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad_fill2 cf_draw_quad cf_draw_quad2
  */
 CF_API void CF_CALL cf_draw_quad_fill(CF_Aabb bb, float chubbiness);
 
@@ -87,7 +87,7 @@ CF_API void CF_CALL cf_draw_quad_fill(CF_Aabb bb, float chubbiness);
  * @param    p3         A corner of the quad.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
  * @remarks  All points `p0` through `p3` are encouraged to be in counter-clockwise order.
- * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad_fill cf_draw_quad cf_draw_quad2
  */
 CF_API void CF_CALL cf_draw_quad_fill2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float chubbiness);
 
@@ -99,7 +99,7 @@ CF_API void CF_CALL cf_draw_quad_fill2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, f
 * @param    thickness  The thickness of each line to draw.
 * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
 * @remarks  This is an alias for `cf_draw_quad`
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_INLINE void cf_draw_box(CF_Aabb bb, float thickness, float chubbiness) { cf_draw_quad(bb, thickness, chubbiness); }
 
@@ -110,7 +110,7 @@ CF_INLINE void cf_draw_box(CF_Aabb bb, float thickness, float chubbiness) { cf_d
 * @param    bb         The AABB (Axis-Aligned Bounding Box) to draw a quad over.
 * @param    thickness  The thickness of each line to draw.
 * @param    radius     The radius to use for rounding.
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_API void CF_CALL cf_draw_box_rounded(CF_Aabb bb, float thickness, float radius);
 
@@ -125,7 +125,7 @@ CF_API void CF_CALL cf_draw_box_rounded(CF_Aabb bb, float thickness, float radiu
 * @param    thickness  The thickness of each line to draw.
 * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
 * @remarks  All points `p0` through `p3` are encouraged to be in counter-clockwise order. This is an alias for `cf_draw_quad2`
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_INLINE void cf_draw_box2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float thickness, float chubbiness) { cf_draw_quad2(p0, p1, p2, p3, thickness,  chubbiness); }
 
@@ -136,7 +136,7 @@ CF_INLINE void cf_draw_box2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float thickn
 * @param    bb         The AABB (Axis-Aligned Bounding Box) to draw a quad over.
 * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
 * @remarks  This is an alias for `cf_draw_quad_fill`
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_INLINE void cf_draw_box_fill(CF_Aabb bb, float chubbiness) { cf_draw_quad_fill(bb, chubbiness); }
 
@@ -150,7 +150,7 @@ CF_INLINE void cf_draw_box_fill(CF_Aabb bb, float chubbiness) { cf_draw_quad_fil
 * @param    p3         A corner of the quad.
 * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
 * @remarks  All points `p0` through `p3` are encouraged to be in counter-clockwise order. This is an alias for `cf_draw_quad_fill2`
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_INLINE void cf_draw_box_fill2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float chubbiness) { cf_draw_quad_fill2(p0, p1, p2, p3, chubbiness); }
 
@@ -160,7 +160,7 @@ CF_INLINE void cf_draw_box_fill2(CF_V2 p0, CF_V2 p1, CF_V2 p2, CF_V2 p3, float c
 * @brief    Draws a quad with rounded corners.
 * @param    bb         The AABB (Axis-Aligned Bounding Box) to draw a quad over.
 * @param    radius     The radius to use for rounding.
-* @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill cf_draw_quad_fill2
+ * @related  cf_draw_quad cf_draw_quad2 cf_draw_quad_fill
 */
 CF_API void CF_CALL cf_draw_box_rounded_fill(CF_Aabb bb, float radius);
 
@@ -170,7 +170,7 @@ CF_API void CF_CALL cf_draw_box_rounded_fill(CF_Aabb bb, float radius);
  * @brief    Draws a circle wireframe.
  * @param    circle     The circle.
  * @param    thickness  The thickness of each line to draw.
- * @related  cf_draw_circle cf_draw_circle2 cf_draw_circle_fill cf_draw_circle_fill2
+ * @related  cf_draw_circle_fill cf_draw_circle_fill2 cf_draw_circle2
  */
 CF_API void CF_CALL cf_draw_circle(CF_Circle circle, float thickness);
 
@@ -181,7 +181,7 @@ CF_API void CF_CALL cf_draw_circle(CF_Circle circle, float thickness);
  * @param    p          Center of the circle.
  * @param    r          Radius of the circle.
  * @param    thickness  The thickness of each line to draw.
- * @related  cf_draw_circle cf_draw_circle2 cf_draw_circle_fill cf_draw_circle_fill2
+ * @related  cf_draw_circle cf_draw_circle_fill cf_draw_circle_fill2
  */
 CF_API void CF_CALL cf_draw_circle2(CF_V2 p, float r, float thickness);
 
@@ -190,7 +190,7 @@ CF_API void CF_CALL cf_draw_circle2(CF_V2 p, float r, float thickness);
  * @category draw
  * @brief    Draws a circle.
  * @param    circle     The circle.
- * @related  cf_draw_circle cf_draw_circle2 cf_draw_circle_fill cf_draw_circle_fill2
+ * @related  cf_draw_circle_fill2 cf_draw_circle cf_draw_circle2
  */
 CF_API void CF_CALL cf_draw_circle_fill(CF_Circle circle);
 
@@ -200,7 +200,7 @@ CF_API void CF_CALL cf_draw_circle_fill(CF_Circle circle);
  * @brief    Draws a circle.
  * @param    p          Center of the circle.
  * @param    r          Radius of the circle.
- * @related  cf_draw_circle cf_draw_circle2 cf_draw_circle_fill cf_draw_circle_fill2
+ * @related  cf_draw_circle_fill cf_draw_circle cf_draw_circle2
  */
 CF_API void CF_CALL cf_draw_circle_fill2(CF_V2 p, float r);
 
@@ -210,7 +210,7 @@ CF_API void CF_CALL cf_draw_circle_fill2(CF_V2 p, float r);
  * @brief    Draws a capsule wireframe.
  * @param    capsule    The capsule.
  * @param    thickness  The thickness of each line to draw.
- * @related  cf_draw_capsule cf_draw_capsule2 cf_draw_capsule_fill cf_draw_capsule_fill2
+ * @related  cf_draw_capsule_fill cf_draw_capsule_fill2 cf_draw_capsule2
  */
 CF_API void CF_CALL cf_draw_capsule(CF_Capsule capsule, float thickness);
 
@@ -222,7 +222,7 @@ CF_API void CF_CALL cf_draw_capsule(CF_Capsule capsule, float thickness);
  * @param    p1         An endpoint of the interior line-segment of the capsule (the center of one end-cap).
  * @param    r          Radius of the capsule.
  * @param    thickness  The thickness of each line to draw.
- * @related  cf_draw_capsule cf_draw_capsule2 cf_draw_capsule_fill cf_draw_capsule_fill2
+ * @related  cf_draw_capsule cf_draw_capsule_fill cf_draw_capsule_fill2
  */
 CF_API void CF_CALL cf_draw_capsule2(CF_V2 p0, CF_V2 p1, float r, float thickness);
 
@@ -231,7 +231,7 @@ CF_API void CF_CALL cf_draw_capsule2(CF_V2 p0, CF_V2 p1, float r, float thicknes
  * @category draw
  * @brief    Draws a capsule.
  * @param    capsule    The capsule.
- * @related  cf_draw_capsule cf_draw_capsule2 cf_draw_capsule_fill cf_draw_capsule_fill2
+ * @related  cf_draw_capsule_fill2 cf_draw_capsule cf_draw_capsule2
  */
 CF_API void CF_CALL cf_draw_capsule_fill(CF_Capsule capsule);
 
@@ -242,7 +242,7 @@ CF_API void CF_CALL cf_draw_capsule_fill(CF_Capsule capsule);
  * @param    p0         An endpoint of the interior line-segment of the capsule (the center of one end-cap).
  * @param    p1         An endpoint of the interior line-segment of the capsule (the center of one end-cap).
  * @param    r          Radius of the capsule.
- * @related  cf_draw_capsule cf_draw_capsule2 cf_draw_capsule_fill cf_draw_capsule_fill2
+ * @related  cf_draw_capsule_fill cf_draw_capsule cf_draw_capsule2
  */
 CF_API void CF_CALL cf_draw_capsule_fill2(CF_V2 p0, CF_V2 p1, float r);
 
@@ -255,7 +255,7 @@ CF_API void CF_CALL cf_draw_capsule_fill2(CF_V2 p0, CF_V2 p1, float r);
  * @param    p2         A corner of the triangle.
  * @param    thickness  The thickness of each line to draw.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
- * @related  cf_draw_tri cf_draw_tri_fill
+ * @related  cf_draw_tri_fill
  */
 CF_API void CF_CALL cf_draw_tri(CF_V2 p0, CF_V2 p1, CF_V2 p2, float thickness, float chubbiness);
 
@@ -267,7 +267,7 @@ CF_API void CF_CALL cf_draw_tri(CF_V2 p0, CF_V2 p1, CF_V2 p2, float thickness, f
  * @param    p1         A corner of the triangle.
  * @param    p2         A corner of the triangle.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
- * @related  cf_draw_tri cf_draw_tri_fill
+ * @related  cf_draw_tri
  */
 CF_API void CF_CALL cf_draw_tri_fill(CF_V2 p0, CF_V2 p1, CF_V2 p2, float chubbiness);
 
@@ -278,7 +278,7 @@ CF_API void CF_CALL cf_draw_tri_fill(CF_V2 p0, CF_V2 p1, CF_V2 p2, float chubbin
  * @param    p0         An endpoint of the line.
  * @param    p1         An endpoint of the line.
  * @param    thickness  The thickness of the line to draw.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow cf_draw_polygon_fill
+ * @related  cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2
  */
 CF_API void CF_CALL cf_draw_line(CF_V2 p0, CF_V2 p1, float thickness);
 
@@ -291,7 +291,7 @@ CF_API void CF_CALL cf_draw_line(CF_V2 p0, CF_V2 p1, float thickness);
  * @param    thickness    The thickness of the line to draw.
  * @param    loop         True to connect the first and last point to form a loop. False otherwise.
  * @param    bevel_count  The number of edges used to smooth corners.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow cf_draw_polygon_fill
+ * @related  cf_draw_polygon_fill cf_draw_line cf_draw_bezier_line
  */
 CF_API void CF_CALL cf_draw_polyline(const CF_V2* points, int count, float thickness, bool loop);
 
@@ -303,7 +303,7 @@ CF_API void CF_CALL cf_draw_polyline(const CF_V2* points, int count, float thick
  * @param    count        The number of points in the polygon.
  * @param    chubbiness Inflates the shape, similar to corner-rounding. Makes the shape chubbier.
  * @remarks  This function has a hard-limit of up to 8 points.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow cf_draw_polygon_fill cf_draw_polygon_fill_simple
+ * @related  cf_draw_polygon_fill_simple cf_draw_polyline cf_draw_line
  */
 CF_API void CF_CALL cf_draw_polygon_fill(const CF_V2* points, int count, float chubbiness);
 
@@ -317,7 +317,7 @@ CF_API void CF_CALL cf_draw_polygon_fill(const CF_V2* points, int count, float c
  *           must be a _simple polygon_, meaning no self-intersections are allowed, no duplicate or overlapping vertices are
  *           allowed, and other features like chubbiness or antialias can not be applied. This function simply converts your
  *           polygon and renders a series of triangles under the hood. Please be sure to submit your vertices in CCW order.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow cf_draw_polygon_fill cf_draw_polygon_fill_simple
+ * @related  cf_draw_polygon_fill cf_draw_polyline cf_draw_line
  */
 CF_API void CF_CALL cf_draw_polygon_fill_simple(const CF_V2* points, int count);
 
@@ -330,7 +330,7 @@ CF_API void CF_CALL cf_draw_polygon_fill_simple(const CF_V2* points, int count);
  * @param    b          The end point.
  * @param    thickness  The thickness of the line to draw.
  * @param    iters      The number of lines used to draw the bezier spline.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow
+ * @related  cf_draw_bezier_line2 cf_draw_line cf_draw_polyline
  */
 CF_API void CF_CALL cf_draw_bezier_line(CF_V2 a, CF_V2 c0, CF_V2 b, int iters, float thickness);
 
@@ -344,7 +344,7 @@ CF_API void CF_CALL cf_draw_bezier_line(CF_V2 a, CF_V2 c0, CF_V2 b, int iters, f
  * @param    b          The end point.
  * @param    thickness  The thickness of the line to draw.
  * @param    iters      The number of lines used to draw the bezier spline.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow
+ * @related  cf_draw_bezier_line cf_draw_line cf_draw_polyline
  */
 CF_API void CF_CALL cf_draw_bezier_line2(CF_V2 a, CF_V2 c0, CF_V2 c1, CF_V2 b, int iters, float thickness);
 
@@ -359,7 +359,7 @@ CF_API void CF_CALL cf_draw_bezier_line2(CF_V2 a, CF_V2 c0, CF_V2 c1, CF_V2 b, i
  * @remarks  This function is intended only for debug purposes. It's implemented in naive way so the
  *           arrow shaft will overdraw atop the arrow head. This will become visible if the arrow is
  *           drawn with any transparency.
- * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line cf_draw_bezier_line2 cf_draw_arrow
+ * @related  cf_draw_line cf_draw_polyline cf_draw_bezier_line
  */
 CF_API void CF_CALL cf_draw_arrow(CF_V2 a, CF_V2 b, float thickness, float arrow_width);
 
@@ -370,7 +370,7 @@ CF_API void CF_CALL cf_draw_arrow(CF_V2 a, CF_V2 b, float thickness, float arrow
  * @param    layer      The layer.
  * @remarks  Draw layers are sorted before rendering. Lower numbers are rendered first, while larger numbers are rendered last.
  *           This can be used to pick which sprites/shapes should draw on top of each other.
- * @related  cf_draw_push_layer cf_draw_pop_layer cf_draw_peek_layer
+ * @related  cf_draw_pop_layer cf_draw_peek_layer
  */
 CF_API void CF_CALL cf_draw_push_layer(int layer);
 
@@ -380,7 +380,7 @@ CF_API void CF_CALL cf_draw_push_layer(int layer);
  * @brief    Pops and returns the last draw layer.
  * @remarks  Draw layers are sorted before rendering. Lower numbers are rendered first, while larger numbers are rendered last.
  *           This can be used to pick which sprites/shapes should draw on top of each other.
- * @related  cf_draw_push_layer cf_draw_pop_layer cf_draw_peek_layer
+ * @related  cf_draw_push_layer cf_draw_peek_layer
  */
 CF_API int CF_CALL cf_draw_pop_layer(void);
 
@@ -390,7 +390,7 @@ CF_API int CF_CALL cf_draw_pop_layer(void);
  * @brief    Returns the last draw layer.
  * @remarks  Draw layers are sorted before rendering. Lower numbers are rendered first, while larger numbers are rendered last.
  *           This can be used to pick which sprites/shapes should draw on top of each other.
- * @related  cf_draw_push_layer cf_draw_pop_layer cf_draw_peek_layer
+ * @related  cf_draw_push_layer cf_draw_pop_layer
  */
 CF_API int CF_CALL cf_draw_peek_layer(void);
 
@@ -400,7 +400,7 @@ CF_API int CF_CALL cf_draw_peek_layer(void);
  * @brief    Pushes a draw color.
  * @param    c          The color.
  * @remarks  Various draw functions do not specify a color. In these cases, the last color pushed will be used.
- * @related  cf_draw_push_color cf_draw_pop_color cf_draw_peek_color
+ * @related  cf_draw_pop_color cf_draw_peek_color
  */
 CF_API void CF_CALL cf_draw_push_color(CF_Color c);
 
@@ -409,7 +409,7 @@ CF_API void CF_CALL cf_draw_push_color(CF_Color c);
  * @category draw
  * @brief    Pops and returns the last draw color.
  * @remarks  Various draw functions do not specify a color. In these cases, the last color pushed will be used.
- * @related  cf_draw_push_color cf_draw_pop_color cf_draw_peek_color
+ * @related  cf_draw_push_color cf_draw_peek_color
  */
 CF_API CF_Color CF_CALL cf_draw_pop_color(void);
 
@@ -418,7 +418,7 @@ CF_API CF_Color CF_CALL cf_draw_pop_color(void);
  * @category draw
  * @brief    Returns the last draw color.
  * @remarks  Various draw functions do not specify a color. In these cases, the last color pushed will be used.
- * @related  cf_draw_push_color cf_draw_pop_color cf_draw_peek_color
+ * @related  cf_draw_push_color cf_draw_pop_color
  */
 CF_API CF_Color CF_CALL cf_draw_peek_color(void);
 
@@ -429,7 +429,7 @@ CF_API CF_Color CF_CALL cf_draw_peek_color(void);
  * @param    antialias  True to antialias, false otherwise.
  * @remarks  Various shape drawing functions can be drawn in antialiased mode, or in plain mode. Antialiasing is slightly slower,
  *           but looks much smoother.
- * @related  cf_draw_push_antialias cf_draw_pop_antialias cf_draw_peek_antialias
+ * @related  cf_draw_pop_antialias cf_draw_peek_antialias
  */
 CF_API void CF_CALL cf_draw_push_antialias(bool antialias);
 
@@ -439,7 +439,7 @@ CF_API void CF_CALL cf_draw_push_antialias(bool antialias);
  * @brief    Pops and returns the last antialias state.
  * @remarks  Various shape drawing functions can be drawn in antialiased mode, or in plain mode. Antialiasing is slightly slower,
  *           but looks much smoother.
- * @related  cf_draw_push_antialias cf_draw_pop_antialias cf_draw_peek_antialias
+ * @related  cf_draw_push_antialias cf_draw_peek_antialias
  */
 CF_API bool CF_CALL cf_draw_pop_antialias(void);
 
@@ -449,7 +449,7 @@ CF_API bool CF_CALL cf_draw_pop_antialias(void);
  * @brief    Returns the last antialias state.
  * @remarks  Various shape drawing functions can be drawn in antialiased mode, or in plain mode. Antialiasing is slightly slower,
  *           but looks much smoother.
- * @related  cf_draw_push_antialias cf_draw_pop_antialias cf_draw_peek_antialias
+ * @related  cf_draw_push_antialias cf_draw_pop_antialias
  */
 CF_API bool CF_CALL cf_draw_peek_antialias(void);
 
@@ -459,7 +459,7 @@ CF_API bool CF_CALL cf_draw_peek_antialias(void);
  * @brief    Returns the last antialias scale.
  * @remarks  Antialias scale controls how much antialiasing will be used. A larger number makes the borders of shapes blurry.
  *           The number must be greater than 0, but probably not more than 2 or 3 for most cases. The default is 1.5.
- * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
+ * @related  cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
  */
 CF_API void CF_CALL cf_draw_push_antialias_scale(float scale);
 
@@ -469,7 +469,7 @@ CF_API void CF_CALL cf_draw_push_antialias_scale(float scale);
  * @brief    Pops and returns the last antialias scale.
  * @remarks  Antialias scale controls how much antialiasing will be used. A larger number makes the borders of shapes blurry.
  *           The number must be greater than 0, but probably not more than 2 or 3 for most cases. The default is 1.5.
- * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
+ * @related  cf_draw_push_antialias_scale cf_draw_peek_antialias_scale
  */
 CF_API float CF_CALL cf_draw_pop_antialias_scale(void);
 
@@ -479,7 +479,7 @@ CF_API float CF_CALL cf_draw_pop_antialias_scale(void);
  * @brief    Returns the last antialias scale.
  * @remarks  Antialias scale controls how much antialiasing will be used. A larger number makes the borders of shapes blurry.
  *           The number must be greater than 0, but probably not more than 2 or 3 for most cases. The default is 1.5.
- * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale cf_draw_peek_antialias_scale
+ * @related  cf_draw_push_antialias_scale cf_draw_pop_antialias_scale
  */
 CF_API float CF_CALL cf_draw_peek_antialias_scale(void);
 
@@ -490,7 +490,7 @@ CF_API float CF_CALL cf_draw_peek_antialias_scale(void);
  * @remarks  Each attribute gets copied onto *all* the vertices for everything drawn thereafter. This is useful
  *           for custom shaders that want some extra bits of data sent to the fragment shader. If you want to
  *           customize individual vertices then check out `CF_Vertex`.
- * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
+ * @related  cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
  */
 CF_API void CF_CALL cf_draw_push_vertex_attributes(float r, float g, float b, float a);
 
@@ -501,7 +501,7 @@ CF_API void CF_CALL cf_draw_push_vertex_attributes(float r, float g, float b, fl
  * @remarks  Each attribute gets copied onto *all* the vertices for everything drawn thereafter. This is useful
  *           for custom shaders that want some extra bits of data sent to the fragment shader. If you want to
  *           customize individual vertices then check out `CF_Vertex`.
- * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
+ * @related  cf_draw_push_vertex_attributes cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
  */
 CF_API void CF_CALL cf_draw_push_vertex_attributes2(CF_Color attributes);
 
@@ -509,7 +509,7 @@ CF_API void CF_CALL cf_draw_push_vertex_attributes2(CF_Color attributes);
  * @function cf_draw_pop_vertex_attributes
  * @category draw
  * @brief    Pops the current vertex attribute state, restoring the previous state.
- * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
+ * @related  cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_peek_vertex_attributes
  */
 CF_API CF_Color CF_CALL cf_draw_pop_vertex_attributes(void);
 
@@ -517,7 +517,7 @@ CF_API CF_Color CF_CALL cf_draw_pop_vertex_attributes(void);
  * @function cf_draw_peek_vertex_attributes
  * @category draw
  * @brief    Returns the current vertex attribute state.
- * @related  CF_Vertex cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes cf_draw_peek_vertex_attributes
+ * @related  cf_draw_push_vertex_attributes cf_draw_push_vertex_attributes2 cf_draw_pop_vertex_attributes
  */
 CF_API CF_Color CF_CALL cf_draw_peek_vertex_attributes(void);
 
@@ -529,7 +529,7 @@ CF_API CF_Color CF_CALL cf_draw_peek_vertex_attributes(void);
  *           This is useful when you need to fill in unique `attributes` per-vertex, or modify any other
  *           bits of the vertex before rendering. This could be used to implement features like dynamically
  *           generated UV's for shape slicing, or complex lighting systems.
- * @related  CF_Vertex CF_VertexFn cf_set_vertex_callback
+ * @related  cf_set_vertex_callback CF_VertexFn
  */
 typedef struct CF_Vertex
 {
@@ -592,7 +592,7 @@ typedef struct CF_Vertex
  *           should probably redesign your feature to not require adjecancy information, or use your own custom
  *           rendering solution. With a custom solution you may use low-level graphics in cute_graphics.h, where
  *           any adjacency info can be controlled 100% by you a-priori.
- * @related  CF_Vertex CF_VertexFn cf_set_vertex_callback
+ * @related  cf_set_vertex_callback CF_Vertex
  */
 typedef void (CF_VertexFn)(CF_Vertex* verts, int count);
 
@@ -601,7 +601,7 @@ typedef void (CF_VertexFn)(CF_Vertex* verts, int count);
  * @category draw
  * @brief    An optional callback for modifying vertices before they are sent to the GPU.
  * @remarks  See `CF_VertexFn`.
- * @related  CF_Vertex CF_VertexFn cf_set_vertex_callback
+ * @related  CF_Vertex CF_VertexFn
  */
 CF_API void CF_CALL cf_set_vertex_callback(CF_VertexFn* vertex_fn);
 
@@ -615,7 +615,7 @@ CF_API void CF_CALL cf_set_vertex_callback(CF_VertexFn* vertex_fn);
  * @remarks  Memory is only consumed when you draw a certain glyph (text character). Just loading up the font initially is
  *           a low-cost operation. You may load up many fonts with low overhead. Please note that bold, italic, etc. are actually
  *           _different fonts_ and each must be loaded up individually.
- * @related  cf_make_font cf_make_font_from_memory cf_destroy_font cf_push_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_make_font_from_memory cf_destroy_font cf_push_font
  */
 CF_API CF_Result CF_CALL cf_make_font(const char* path, const char* font_name);
 
@@ -630,7 +630,7 @@ CF_API CF_Result CF_CALL cf_make_font(const char* path, const char* font_name);
  * @remarks  Memory is only consumed when you draw a certain glyph (text character). Just loading up the font initially is
  *           a low-cost operation. You may load up many fonts with low overhead. Please note that bold, italic, etc. are actually
  *           _different fonts_ and each must be loaded up individually.
- * @related  cf_make_font cf_make_font_from_memory cf_destroy_font cf_push_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_make_font cf_destroy_font cf_push_font
  */
 CF_API CF_Result CF_CALL cf_make_font_from_memory(void* data, int size, const char* font_name);
 
@@ -639,7 +639,7 @@ CF_API CF_Result CF_CALL cf_make_font_from_memory(void* data, int size, const ch
  * @category text
  * @brief    Destroys a font previously made by `cf_make_font` or `cf_make_font_from_memory`.
  * @param    font_name   The unique name for this font.
- * @related  cf_make_font cf_make_font_from_memory cf_destroy_font cf_push_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_draw_text cf_make_font cf_make_font_from_memory
  */
 CF_API void CF_CALL cf_destroy_font(const char* font_name);
 
@@ -648,7 +648,7 @@ CF_API void CF_CALL cf_destroy_font(const char* font_name);
  * @category text
  * @brief    Pushes a font to use for text drawing.
  * @param    font_name   The unique name for this font.
- * @related  cf_make_font cf_push_font cf_pop_font cf_peek_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font_size cf_push_font_blur cf_pop_font
  */
 CF_API void CF_CALL cf_push_font(const char* font);
 
@@ -656,7 +656,7 @@ CF_API void CF_CALL cf_push_font(const char* font);
  * @function cf_pop_font
  * @category text
  * @brief    Pops and returns the last font name used.
- * @related  cf_make_font cf_push_font cf_pop_font cf_peek_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font cf_peek_font cf_push_font_size
  */
 CF_API const char* CF_CALL cf_pop_font(void);
 
@@ -664,7 +664,7 @@ CF_API const char* CF_CALL cf_pop_font(void);
  * @function cf_peek_font
  * @category text
  * @brief    Returns the last font name used.
- * @related  cf_make_font cf_push_font cf_pop_font cf_peek_font cf_push_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font cf_pop_font cf_push_font_size
  */
 CF_API const char* CF_CALL cf_peek_font(void);
 
@@ -673,7 +673,7 @@ CF_API const char* CF_CALL cf_peek_font(void);
  * @category text
  * @brief    Pushes a font size to use for text drawing.
  * @param    size       The size to use for text drawing.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_pop_font_size cf_peek_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font_blur cf_push_font cf_pop_font_size
  */
 CF_API void CF_CALL cf_push_font_size(float size);
 
@@ -681,7 +681,7 @@ CF_API void CF_CALL cf_push_font_size(float size);
  * @function cf_pop_font_size
  * @category text
  * @brief    Pops and returns the last font size.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_pop_font_size cf_peek_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font cf_push_font_size cf_peek_font_size
  */
 CF_API float CF_CALL cf_pop_font_size(void);
 
@@ -689,7 +689,7 @@ CF_API float CF_CALL cf_pop_font_size(void);
  * @function cf_peek_font_size
  * @category text
  * @brief    Returns the last font size.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_pop_font_size cf_peek_font_size cf_push_font_blur cf_draw_text
+ * @related  cf_push_font cf_push_font_size cf_pop_font_size
  */
 CF_API float CF_CALL cf_peek_font_size(void);
 
@@ -698,7 +698,7 @@ CF_API float CF_CALL cf_peek_font_size(void);
  * @category text
  * @brief    Pushes a font blur to use for text drawing.
  * @param    blur       The blur to use for text drawing.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_push_font_blur cf_pop_font_blur cf_peek_font_blur cf_draw_text
+ * @related  cf_push_font_size cf_push_font cf_pop_font_blur
  */
 CF_API void CF_CALL cf_push_font_blur(int blur);
 
@@ -706,7 +706,7 @@ CF_API void CF_CALL cf_push_font_blur(int blur);
  * @function cf_pop_font_blur
  * @category text
  * @brief    Pops and returns the last font blur.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_push_font_blur cf_pop_font_blur cf_peek_font_blur cf_draw_text
+ * @related  cf_push_font cf_push_font_size cf_push_font_blur
  */
 CF_API int CF_CALL cf_pop_font_blur(void);
 
@@ -714,7 +714,7 @@ CF_API int CF_CALL cf_pop_font_blur(void);
  * @function cf_peek_font_blur
  * @category text
  * @brief    Returns the last font blur.
- * @related  cf_make_font cf_push_font cf_push_font_size cf_push_font_blur cf_pop_font_blur cf_peek_font_blur cf_draw_text
+ * @related  cf_push_font cf_push_font_size cf_push_font_blur
  */
 CF_API int CF_CALL cf_peek_font_blur(void);
 
@@ -723,7 +723,7 @@ CF_API int CF_CALL cf_peek_font_blur(void);
  * @category text
  * @brief    Pushes a text wrap width to use for text drawing.
  * @param    width      The text wrap width to use for text drawing.
- * @related  cf_make_font cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width cf_peek_text_wrap_width cf_push_text_clip_box cf_draw_text
+ * @related  cf_push_text_clip_box cf_push_font cf_pop_text_wrap_width
  */
 CF_API void CF_CALL cf_push_text_wrap_width(float width);
 
@@ -731,7 +731,7 @@ CF_API void CF_CALL cf_push_text_wrap_width(float width);
  * @function cf_pop_text_wrap_width
  * @category text
  * @brief    Pops and returns the last text wrap width.
- * @related  cf_make_font cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width cf_peek_text_wrap_width cf_push_text_clip_box cf_draw_text
+ * @related  cf_push_font cf_push_text_wrap_width cf_peek_text_wrap_width
  */
 CF_API float CF_CALL cf_pop_text_wrap_width(void);
 
@@ -739,7 +739,7 @@ CF_API float CF_CALL cf_pop_text_wrap_width(void);
  * @function cf_peek_text_wrap_width
  * @category text
  * @brief    Returns the last text wrap width.
- * @related  cf_make_font cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width cf_peek_text_wrap_width cf_push_text_clip_box cf_draw_text
+ * @related  cf_push_font cf_push_text_wrap_width cf_pop_text_wrap_width
  */
 CF_API float CF_CALL cf_peek_text_wrap_width(void);
 
@@ -748,7 +748,7 @@ CF_API float CF_CALL cf_peek_text_wrap_width(void);
  * @category text
  * @brief    Pushes a whether or not to layout text vertically (as opposed to the default or horizontally).
  * @param    layout_vertically  True to layout vertically, false otherwise.
- * @related  cf_make_font cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout cf_peek_text_vertical_layout cf_draw_text
+ * @related  cf_push_font cf_pop_text_vertical_layout cf_peek_text_vertical_layout
  */
 CF_API void CF_CALL cf_push_text_vertical_layout(bool layout_vertically);
 
@@ -756,7 +756,7 @@ CF_API void CF_CALL cf_push_text_vertical_layout(bool layout_vertically);
  * @function cf_pop_text_vertical_layout
  * @category text
  * @brief    Pops and returns the last vertical layout state.
- * @related  cf_make_font cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout cf_peek_text_vertical_layout cf_draw_text
+ * @related  cf_push_font cf_push_text_vertical_layout cf_peek_text_vertical_layout
  */
 CF_API bool CF_CALL cf_pop_text_vertical_layout(void);
 
@@ -764,7 +764,7 @@ CF_API bool CF_CALL cf_pop_text_vertical_layout(void);
  * @function cf_peek_text_vertical_layout
  * @category text
  * @brief    Returns the last vertical layout state.
- * @related  cf_make_font cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout cf_peek_text_vertical_layout cf_draw_text
+ * @related  cf_push_font cf_push_text_vertical_layout cf_pop_text_vertical_layout
  */
 CF_API bool CF_CALL cf_peek_text_vertical_layout(void);
 
@@ -774,7 +774,7 @@ CF_API bool CF_CALL cf_peek_text_vertical_layout(void);
  * @brief    Returns the width of a text given the currently pushed font.
  * @param    text      The text considered for rendering.
  * @param    num_chars_to_draw  The number of characters to draw `text`. Use -1 to draw the whole string.
- * @related  cf_make_font cf_text_width cf_text_height cf_draw_text cf_text_size
+ * @related  cf_text_height cf_text_size cf_make_font
  */
 CF_API float CF_CALL cf_text_width(const char* text, int num_chars_to_draw);
 
@@ -784,7 +784,7 @@ CF_API float CF_CALL cf_text_width(const char* text, int num_chars_to_draw);
  * @brief    Returns the height of a text given the currently pushed font.
  * @param    text      The text considered for rendering.
  * @param    num_chars_to_draw  The number of characters to draw `text`. Use -1 to draw the whole string.
- * @related  cf_make_font cf_text_width cf_text_height cf_draw_text cf_text_size
+ * @related  cf_text_width cf_text_size cf_make_font
  */
 CF_API float CF_CALL cf_text_height(const char* text, int num_chars_to_draw);
 
@@ -796,7 +796,7 @@ CF_API float CF_CALL cf_text_height(const char* text, int num_chars_to_draw);
  * @param    num_chars_to_draw  The number of characters to draw `text`. Use -1 to draw the whole string.
  * @remarks  This function is slightly superior to `cf_text_width` or `cf_text_height` if you need both width/height, as
  *           it will run the layout code only a single time.
- * @related  cf_make_font cf_text_width cf_text_height cf_draw_text cf_text_size
+ * @related  cf_text_width cf_text_height cf_make_font
  */
 CF_API CF_V2 CF_CALL cf_text_size(const char* text, int num_chars_to_draw);
 
@@ -808,7 +808,7 @@ CF_API CF_V2 CF_CALL cf_text_size(const char* text, int num_chars_to_draw);
  * @param    position           The top-left corner of the text.
  * @param    num_chars_to_draw  The number of characters to draw `text`. Use -1 to draw the whole string.
  * @remarks  `num_chars_to_draw` is a great way to control how many characters to draw for implementing a typewriter style effect.
- * @related  cf_make_font cf_draw_text cf_text_effect_register cf_draw_to cf_app_draw_onto_screen
+ * @related  cf_draw_to cf_make_font cf_text_effect_register
  */
 CF_API void CF_CALL cf_draw_text(const char* text, CF_V2 position, int num_chars_to_draw /*= -1*/);
 
@@ -834,7 +834,7 @@ CF_API void CF_CALL cf_push_text_id(uint64_t id);
  * @function cf_pop_text_id
  * @category text
  * @brief    Pops and returns the last text id.
- * @related  cf_push_text_id cf_draw_text cf_text_effect_register CF_TextEffect
+ * @related  cf_push_text_id cf_draw_text cf_text_effect_register
  */
 CF_API uint64_t CF_CALL cf_pop_text_id(void);
 
@@ -842,7 +842,7 @@ CF_API uint64_t CF_CALL cf_pop_text_id(void);
  * @function cf_peek_text_id
  * @category text
  * @brief    Returns the last text_id.
- * @related  cf_push_text_id cf_draw_text cf_text_effect_register CF_TextEffect
+ * @related  cf_push_text_id cf_draw_text cf_text_effect_register
  */
 CF_API uint64_t CF_CALL cf_peek_text_id(void);
 
@@ -857,7 +857,7 @@ CF_API uint64_t CF_CALL cf_peek_text_id(void);
  *           `cf_text_effect_register` on registering a custom-made text effect. See `cf_text_effect_register` for a big list of built-in text effects
  *           that work out-of-the-box. Members of this struct that can be mutated freely within a custom text effect are noted with "User-modifiable"
  *           in their description.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register
+ * @related  cf_text_effect_register CF_TextEffectFn
  */
 typedef struct CF_TextEffect
 {
@@ -938,7 +938,7 @@ typedef struct CF_TextEffect
  *           position, visibility, etc. You should use `cf_text_effect_get_number`, `cf_text_effect_get_color`, or
  *           `cf_text_effect_get_string` to fetch values from your codes. As a convenience, you can see if the current
  *           character is the first or last to render using `cf_text_effect_on_start` or `cf_text_effect_on_finish` respectively.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ * @related  cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color
  */
 typedef bool (CF_TextEffectFn)(CF_TextEffect* fx);
 
@@ -998,7 +998,7 @@ typedef bool (CF_TextEffectFn)(CF_TextEffect* fx);
  *           automatically. You only need to fetch them with the appropriate cf_text_effect_get*** function.
  *           Note: You can also setup parameters for markup as strings, not just numbers/colors. Example: `<color=#2c5ee8 metadata=\"Just some string.\">blue text</color>`,
  *           where the `color` markup contains a parameter called `metadata` and a strinf value of `"Just some string."`.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ * @related  cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
  */
 CF_API void CF_CALL cf_text_effect_register(const char* name, CF_TextEffectFn* fn);
 
@@ -1010,7 +1010,7 @@ CF_API void CF_CALL cf_text_effect_register(const char* name, CF_TextEffectFn* f
  * @param    key          The name of the text code parameter
  * @param    default_val  A default value for the text code parameter if doesn't exist in the text.
  * @return   Returns the value of the text code parameter.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ * @related  cf_text_effect_get_color cf_text_effect_get_string cf_text_effect_register
  */
 CF_API double CF_CALL cf_text_effect_get_number(const CF_TextEffect* fx, const char* key, double default_val);
 
@@ -1022,7 +1022,7 @@ CF_API double CF_CALL cf_text_effect_get_number(const CF_TextEffect* fx, const c
  * @param    key          The name of the text code parameter
  * @param    default_val  A default value for the text code parameter if doesn't exist in the text.
  * @return   Returns the value of the text code parameter.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ * @related  cf_text_effect_get_number cf_text_effect_get_string cf_text_effect_register
  */
 CF_API CF_Color CF_CALL cf_text_effect_get_color(const CF_TextEffect* fx, const char* key, CF_Color default_val);
 
@@ -1036,7 +1036,7 @@ CF_API CF_Color CF_CALL cf_text_effect_get_color(const CF_TextEffect* fx, const 
  * @return   Returns the value of the text code parameter.
  * @remarks  You may place a string inside of markups by wrapped quotes. Example: `<my_effect metadata=\"Here's the metadata.\">Hello world!</my_effect>`.
  *           This string can be fetched from within your `CF_TextEffectFn` callback by calling `cf_text_effect_get_string`.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ * @related  cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_register
  */
 CF_API const char* CF_CALL cf_text_effect_get_string(const CF_TextEffect* fx, const char* key, const char* default_val);
 
@@ -1045,7 +1045,7 @@ CF_API const char* CF_CALL cf_text_effect_get_string(const CF_TextEffect* fx, co
  * @category text
  * @brief    Info describing a markup inside of a string rendered with text effects.
  * @remarks  This struct describes the markup information for each text effect within a renderable string.
- * @related  CF_TextEffect CF_MarkupInfo cf_text_markup_info_fn cf_text_get_markup_info
+ * @related  cf_text_markup_info_fn cf_text_get_markup_info CF_TextEffect
  */
 typedef struct CF_MarkupInfo
 {
@@ -1075,7 +1075,7 @@ typedef struct CF_MarkupInfo
  * @param    fx          The `CF_TextEffect` instance used for rendering, containing markup metadata. See remarks for details.
  * @remarks  This callback is invoked once per markup within the renderable `text`. If you wish to fetch any of the markup metadata
  *           you may use `cf_text_effect_get_number`, `cf_text_effect_get_color`, or `cf_text_effect_get_string` by passing in the `fx` pointer to each.
- * @related  CF_TextEffect CF_MarkupInfo cf_text_markup_info_fn cf_text_get_markup_info
+ * @related  cf_text_get_markup_info CF_TextEffect CF_MarkupInfo
  */
 typedef void (cf_text_markup_info_fn)(const char* text, CF_MarkupInfo info, const CF_TextEffect* fx);
 
@@ -1089,7 +1089,7 @@ typedef void (cf_text_markup_info_fn)(const char* text, CF_MarkupInfo info, cons
  * @param    num_chars_to_draw  The number of characters to draw `text`. Use -1 to draw the whole string.
  * @remarks  The callback `fn` is invoked once per markup within the renderable `text`. If you wish to fetch any of the markup metadata
  *           you may use `cf_text_effect_get_number`, `cf_text_effect_get_color`, or `cf_text_effect_get_string` by passing in the `fx` pointer to each.
- * @related  CF_TextEffect CF_MarkupInfo cf_text_markup_info_fn cf_text_get_markup_info
+ * @related  cf_text_markup_info_fn CF_TextEffect CF_MarkupInfo
  */
 CF_API void CF_CALL cf_text_get_markup_info(cf_text_markup_info_fn* fn, const char* text, CF_V2 position, int num_chars_to_draw /*= -1*/);
 
@@ -1098,7 +1098,7 @@ CF_API void CF_CALL cf_text_get_markup_info(cf_text_markup_info_fn* fn, const ch
  * @category text
  * @brief    Turns on/off text effects.
  * @remarks  Text effects are on by default.
- * @related  cf_push_text_effect_active cf_pop_text_effect_active cf_peek_text_effect_active
+ * @related  cf_pop_text_effect_active cf_peek_text_effect_active
  */
 CF_API void CF_CALL cf_push_text_effect_active(bool effects_on);
 
@@ -1106,7 +1106,7 @@ CF_API void CF_CALL cf_push_text_effect_active(bool effects_on);
  * @function cf_pop_text_effect_active
  * @category text
  * @brief    Pops the previously pushed activated state for text effects. See `cf_push_text_effect_active`.
- * @related  cf_push_text_effect_active cf_pop_text_effect_active cf_peek_text_effect_active
+ * @related  cf_push_text_effect_active cf_peek_text_effect_active
  */
 CF_API bool CF_CALL cf_pop_text_effect_active(void);
 
@@ -1114,7 +1114,7 @@ CF_API bool CF_CALL cf_pop_text_effect_active(void);
  * @function cf_peek_text_effect_active
  * @category text
  * @brief    Returns the last text active state.
- * @related  cf_push_text_effect_active cf_pop_text_effect_active cf_peek_text_effect_active
+ * @related  cf_push_text_effect_active cf_pop_text_effect_active
  */
 CF_API bool CF_CALL cf_peek_text_effect_active(void);
 
@@ -1180,14 +1180,14 @@ CF_API void CF_CALL cf_draw_push_render_state(CF_RenderState render_state);
 /**
  * @function cf_draw_pop_render_state
  * @category draw
- * @brief    Pops and returns the last `CF_RenderState`.* @related  CF_RenderState cf_draw_filter cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state cf_draw_pop_render_state cf_draw_peek_render_state cf_render_to cf_app_draw_onto_screen
+ * @related  cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state
  */
 CF_API CF_RenderState CF_CALL cf_draw_pop_render_state(void);
 
 /**
  * @function cf_draw_peek_render_state
  * @category draw
- * @brief    Returns the last `CF_RenderState`.* @related  CF_RenderState cf_draw_filter cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state cf_draw_pop_render_state cf_draw_peek_render_state cf_render_to cf_app_draw_onto_screen
+ * @related  cf_draw_push_viewport cf_draw_push_scissor cf_draw_push_render_state
  */
 CF_API CF_RenderState CF_CALL cf_draw_peek_render_state(void);
 
@@ -1217,7 +1217,7 @@ CF_API void CF_CALL cf_draw_set_atlas_dimensions(int width_in_pixels, int height
  * @category draw
  * @brief    Bytecode for a draw shader.
  * @remarks  This can be created using the `cute-shaderc` compiler.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader cf_make_draw_shader_from_bytecode
+ * @related  cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
  */
 typedef struct CF_DrawShaderBytecode
 {
@@ -1234,7 +1234,7 @@ typedef struct CF_DrawShaderBytecode
  * @brief    Creates a custom draw shader.
  * @remarks  Your shader must be written in GLSL 450, and must follow some specific rules to be compatible with the draw API. For more in-depth explanations,
  *           see CF's docs on [Draw Shaders](https://randygaul.github.io/cute_framework/topics/drawing#shaders). Make sure to call `cf_shader_directory` first.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader cf_make_draw_shader_from_source
+ * @related  cf_make_draw_shader_from_source cf_draw_push_shader cf_draw_pop_shader
  */
 CF_API CF_Shader CF_CALL cf_make_draw_shader(const char* path);
 
@@ -1245,7 +1245,7 @@ CF_API CF_Shader CF_CALL cf_make_draw_shader(const char* path);
  * @remarks  Your shader must be written in GLSL 450, and must follow some specific rules to be compatible with the draw API. For more in-depth explanations,
  *           see CF's docs on [Draw Shaders](https://randygaul.github.io/cute_framework/topics/drawing#shaders). If you wish to include other files into
  *           your shader via `#include` make sure to call `cf_shader_directory` first.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
+ * @related  cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
  */
 CF_API CF_Shader CF_CALL cf_make_draw_shader_from_source(const char* src);
 
@@ -1255,7 +1255,7 @@ CF_API CF_Shader CF_CALL cf_make_draw_shader_from_source(const char* src);
  * @brief    Creates a custom draw shader from bytecode.
  * @remarks  Your shader must be written in GLSL 450, and must follow some specific rules to be compatible with the draw API. For more in-depth explanations,
  *           see CF's docs on [Draw Shaders](https://randygaul.github.io/cute_framework/topics/drawing#shaders).
- * @related  CF_Shader CF_DrawShaderBytecode cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
+ * @related  cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
  */
 CF_API CF_Shader CF_CALL cf_make_draw_shader_from_bytecode(CF_DrawShaderBytecode bytecode);
 
@@ -1263,7 +1263,7 @@ CF_API CF_Shader CF_CALL cf_make_draw_shader_from_bytecode(CF_DrawShaderBytecode
  * @function cf_draw_push_shader
  * @category draw
  * @brief    Pushes a custom shader.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
+ * @related  cf_draw_pop_shader cf_draw_peek_shader CF_Shader
  */
 CF_API void CF_CALL cf_draw_push_shader(CF_Shader shader);
 
@@ -1271,7 +1271,7 @@ CF_API void CF_CALL cf_draw_push_shader(CF_Shader shader);
  * @function cf_draw_pop_shader
  * @category draw
  * @brief    Pops the custom shader and restores the previous state.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
+ * @related  cf_draw_push_shader cf_draw_peek_shader CF_Shader
  */
 CF_API CF_Shader CF_CALL cf_draw_pop_shader(void);
 
@@ -1279,7 +1279,7 @@ CF_API CF_Shader CF_CALL cf_draw_pop_shader(void);
  * @function cf_draw_peek_shader
  * @category draw
  * @brief    Returns the current custom shader.
- * @related  CF_Shader cf_draw_push_shader cf_draw_pop_shader cf_draw_peek_shader
+ * @related  cf_draw_push_shader cf_draw_pop_shader CF_Shader
  */
 CF_API CF_Shader CF_CALL cf_draw_peek_shader(void);
 
@@ -1288,7 +1288,7 @@ CF_API CF_Shader CF_CALL cf_draw_peek_shader(void);
  * @category draw
  * @brief    Sets whether or not alpha discarding is enabled (on by default).
  * @remarks  Alpha discarding is useful to throw away pixels with zero alpha, for cutouts or as an optimization, or for certain blending techniques.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int
  */
 CF_API void CF_CALL cf_draw_push_alpha_discard(bool true_enable_alpha_discard);
 
@@ -1317,7 +1317,7 @@ CF_API bool CF_CALL cf_draw_peek_alpha_discard(void);
  * @param    name     The name of the uniform this texture will bind to.
  * @param    texture  The texture to bind.
  * @remarks  This is useful for custom shaders. See `cf_draw_push_shader`.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float
  */
 CF_API void CF_CALL cf_draw_set_texture(const char* name, CF_Texture texture);
 
@@ -1329,7 +1329,7 @@ CF_API void CF_CALL cf_draw_set_texture(const char* name, CF_Texture texture);
  * @param    data          A pointer to the data to send to the shader.
  * @param    type          The `CF_UniformType` of data to send.
  * @param    array_length  The number of elements of `CF_UniformType` to send.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2
  */
 CF_API void CF_CALL cf_draw_set_uniform(const char* name, void* data, CF_UniformType type, int array_length);
 
@@ -1337,7 +1337,7 @@ CF_API void CF_CALL cf_draw_set_uniform(const char* name, void* data, CF_Uniform
  * @function cf_draw_set_uniform_int
  * @category draw
  * @brief    Pushes an integer uniform by name.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
  */
 CF_API void CF_CALL cf_draw_set_uniform_int(const char* name, int val);
 
@@ -1345,7 +1345,7 @@ CF_API void CF_CALL cf_draw_set_uniform_int(const char* name, int val);
  * @function cf_draw_set_uniform_float
  * @category draw
  * @brief    Pushes a float uniform by name.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform_int cf_draw_set_uniform_v2 cf_draw_set_uniform_color
  */
 CF_API void CF_CALL cf_draw_set_uniform_float(const char* name, float val);
 
@@ -1353,7 +1353,7 @@ CF_API void CF_CALL cf_draw_set_uniform_float(const char* name, float val);
  * @function cf_draw_set_uniform_v2
  * @category draw
  * @brief    Pushes a vector uniform by name.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_color
  */
 CF_API void CF_CALL cf_draw_set_uniform_v2(const char* name, CF_V2 val);
 
@@ -1361,7 +1361,7 @@ CF_API void CF_CALL cf_draw_set_uniform_v2(const char* name, CF_V2 val);
  * @function cf_draw_set_uniform_color
  * @category draw
  * @brief    Pushes a color uniform by name.
- * @related  cf_draw_set_texture cf_draw_set_uniform cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2 cf_draw_set_uniform_color
+ * @related  cf_draw_set_uniform_int cf_draw_set_uniform_float cf_draw_set_uniform_v2
  */
 CF_API void CF_CALL cf_draw_set_uniform_color(const char* name, CF_Color val);
 
@@ -1379,7 +1379,7 @@ CF_API CF_V2 CF_CALL cf_draw_mul(CF_V2 p);
  * @category draw
  * @brief    Applies this transform to current coordinate system.
  * @param    m      The transform to apply.
- * @related  cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_translate cf_draw_TSR cf_draw_scale
  */
 CF_API void CF_CALL cf_draw_transform(CF_M3x2 m);
 
@@ -1389,7 +1389,7 @@ CF_API void CF_CALL cf_draw_transform(CF_M3x2 m);
  * @brief    Translates the current coordinate system.
  * @param    x      The x position to translate by.
  * @param    y      The y position to translate by.
- * @related  cf_draw_translate_v2 cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_translate_v2 cf_draw_transform cf_draw_TSR
  */
 CF_API void CF_CALL cf_draw_translate(float x, float y);
 
@@ -1398,7 +1398,7 @@ CF_API void CF_CALL cf_draw_translate(float x, float y);
  * @category draw
  * @brief    Translates the current coordinate system.
  * @param    position   The position to translate by.
- * @related  cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_translate cf_draw_transform cf_draw_TSR
  */
 CF_API void CF_CALL cf_draw_translate_v2(CF_V2 position);
 
@@ -1408,7 +1408,7 @@ CF_API void CF_CALL cf_draw_translate_v2(CF_V2 position);
  * @brief    Scales the current coordinate system.
  * @param    w      The width to scale the x-axis by.
  * @param    h      The height to scale the y-axis by.
- * @related  cf_draw_scale_v2 cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_scale_v2 cf_draw_translate cf_draw_transform
  */
 CF_API void CF_CALL cf_draw_scale(float w, float h);
 
@@ -1416,7 +1416,7 @@ CF_API void CF_CALL cf_draw_scale(float w, float h);
  * @function cf_draw_scale_v2
  * @category draw
  * @brief    Scales the current coordinate system.
- * @related  cf_draw_scale cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_scale cf_draw_translate cf_draw_transform
  */
 CF_API void CF_CALL cf_draw_scale_v2(CF_V2 scale);
 
@@ -1425,7 +1425,7 @@ CF_API void CF_CALL cf_draw_scale_v2(CF_V2 scale);
  * @category draw
  * @brief    Rotates the current coordinate system.
  * @param    radians    The angle to rotate by.
- * @related  cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_translate cf_draw_transform cf_draw_scale
  */
 CF_API void CF_CALL cf_draw_rotate(float radians);
 
@@ -1433,7 +1433,7 @@ CF_API void CF_CALL cf_draw_rotate(float radians);
  * @function cf_draw_TSR
  * @category draw
  * @brief    Transforms the current coordinate system by a rotation, then a scale, then a translation.
- * @related  cf_draw_TSR_absolute cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_TSR_absolute cf_draw_translate cf_draw_transform
  */
 CF_API void CF_CALL cf_draw_TSR(CF_V2 position, CF_V2 scale, float radians);
 
@@ -1441,7 +1441,7 @@ CF_API void CF_CALL cf_draw_TSR(CF_V2 position, CF_V2 scale, float radians);
  * @function cf_draw_TSR_absolute
  * @category draw
  * @brief    Sets the current coordinate system.
- * @related  cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR cf_draw_push cf_draw_pop
+ * @related  cf_draw_TSR cf_draw_translate cf_draw_transform
  */
 CF_API void CF_CALL cf_draw_TSR_absolute(CF_V2 position, CF_V2 scale, float radians);
 
@@ -1459,7 +1459,7 @@ CF_API void CF_CALL cf_draw_TSR_absolute(CF_V2 position, CF_V2 scale, float radi
  *           cf_draw_line(a, b); // Draw using the previous translate then rotate.
  *           cf_draw_pop(); // Restore the prior coordinate system.
  *           ```
- * @related  cf_draw_push cf_draw_pop cf_draw_peek cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR
+ * @related  cf_draw_pop cf_draw_peek cf_draw_translate
  */
 CF_API void CF_CALL cf_draw_push(void);
 
@@ -1469,7 +1469,7 @@ CF_API void CF_CALL cf_draw_push(void);
  * @brief    Restores the previous coordinate system.
  * @remarks  This function is essential for drawing things locally without affecting the coordinate
  *           system of anything else that needs to draw. See `cf_draw_push` for details.
- * @related  cf_draw_push cf_draw_pop cf_draw_peek cf_draw_translate cf_draw_transform cf_draw_translate cf_draw_scale cf_draw_rotate cf_draw_TSR
+ * @related  cf_draw_push cf_draw_peek cf_draw_translate
  */
 CF_API void CF_CALL cf_draw_pop(void);
 
@@ -1500,7 +1500,7 @@ CF_API void CF_CALL cf_draw_projection(CF_M3x2 projection);
  * @brief    Converts a coordinate from world space into screen space.
  * @remarks  Screen space has the origin at the top-left of the screen with the y-axis pointing down. This
  *           matches the coordinate space mouse coordinates are given.
- * @related  cf_world_to_screen cf_screen_to_world cf_screen_bounds_to_world
+ * @related  cf_screen_to_world cf_screen_bounds_to_world
  */
 CF_API CF_V2 CF_CALL cf_world_to_screen(CF_V2 point);
 
@@ -1514,7 +1514,7 @@ CF_API CF_V2 CF_CALL cf_world_to_screen(CF_V2 point);
  *           CF_V2 p = cf_v2((float)mouse_x(), (float)mouse_y());
  *           p = cf_screen_to_world(p);
  *           ```
- * @related  cf_world_to_screen cf_screen_to_world cf_screen_bounds_to_world
+ * @related  cf_screen_bounds_to_world cf_world_to_screen
  */
 CF_API CF_V2 CF_CALL cf_screen_to_world(CF_V2 point);
 
@@ -1523,7 +1523,7 @@ CF_API CF_V2 CF_CALL cf_screen_to_world(CF_V2 point);
  * @category draw
  * @brief    Returns a `CF_Aabb` of the screen bounds in world space.
  * @remarks  This can be useful for colliding against the screen, or implementing occlusion culling.
- * @related  cf_world_to_screen cf_screen_to_world cf_screen_bounds_to_world
+ * @related  cf_screen_to_world cf_world_to_screen
  */
 CF_API CF_Aabb CF_CALL cf_screen_bounds_to_world(void);
 
@@ -1538,7 +1538,7 @@ CF_API CF_Aabb CF_CALL cf_screen_bounds_to_world(void);
  *           function, so be sure to use it sparingly. If you apply a custom shader you may read pixels from the
  *           canvas as it's draw by `texture(u_image, v_uv)`. Feel free to copy `v_uv` into your own `vec2 uv = v_uv;`
  *           and sample from the canvas as-needed.
- * @related  cf_app_draw_onto_screen cf_render_to cf_draw_canvas
+ * @related  cf_app_draw_onto_screen cf_render_to
  */
 CF_API void CF_CALL cf_draw_canvas(CF_Canvas canvas, CF_V2 position, CF_V2 scale);
 
@@ -1550,7 +1550,7 @@ CF_API void CF_CALL cf_draw_canvas(CF_Canvas canvas, CF_V2 position, CF_V2 scale
  * @remarks  This is advanced function. It's useful for off-screen rendering for certain rendering effects, such as multi-pass
  *           effects like reflections, or advanced lighting techniques. By default, everything will get renderered to the app's
  *           canvas, so this function is not necessary to call at all. Instead, calling `cf_app_draw_onto_screen` should be the go-to.
- * @related  cf_draw_scale cf_draw_translate cf_draw_rotate cf_draw_push cf_draw_pop cf_app_draw_onto_screen cf_render_to cf_draw_canvas
+ * @related  cf_draw_scale cf_draw_translate cf_draw_rotate
  */
 CF_API void CF_CALL cf_render_to(CF_Canvas canvas, bool clear);
 
@@ -1564,7 +1564,7 @@ CF_API void CF_CALL cf_render_to(CF_Canvas canvas, bool clear);
  * @param    clear      If true the canvas gets cleared before rendering.
  * @remarks  Renders a range of layers to a canvas. All `draw_***` functions called on other layers will not be executed. Everything queued up between
  *           `layer_lo` and `layer_hi` will get processed and rendered to the canvas, and then removed from the internal command queue (won't be rendered again later).
- * @related  cf_draw_scale cf_draw_translate cf_draw_rotate cf_draw_push cf_draw_pop cf_app_draw_onto_screen cf_render_to cf_draw_canvas
+ * @related  cf_render_to cf_draw_scale cf_draw_translate
  */
 CF_API void CF_CALL cf_render_layers_to(CF_Canvas canvas, int layer_lo, int layer_hi, bool clear);
 
@@ -1574,7 +1574,7 @@ CF_API void CF_CALL cf_render_layers_to(CF_Canvas canvas, int layer_lo, int laye
  * @brief    Returns temporal information about a sprite's rendering internals.
  * @remarks  Useful to render a sprite in an external system, e.g. Dear ImGui. This struct is only valid until the next time `cf_render_to` or
  *           `cf_app_draw_onto_screen` is called.
- * @related  CF_TemporaryImage cf_fetch_image
+ * @related  cf_fetch_image
  */
 typedef struct CF_TemporaryImage
 {
@@ -1602,7 +1602,7 @@ typedef struct CF_TemporaryImage
  * @param    sprite     The sprite.
  * @remarks  Useful to render a sprite in an external system, e.g. Dear ImGui. This struct is only valid until the next time
  *           `cf_app_draw_onto_screen` is called. This function can have a negative impact on rendering perf.
- * @related  CF_TemporaryImage cf_fetch_image
+ * @related  CF_TemporaryImage
  */
 CF_API CF_TemporaryImage CF_CALL cf_fetch_image(const CF_Sprite* sprite);
 
@@ -1610,7 +1610,7 @@ CF_API CF_TemporaryImage CF_CALL cf_fetch_image(const CF_Sprite* sprite);
  * @struct   CF_AtlasSubImage
  * @category draw
  * @brief    Represents a single sub-image within an atlas, defined by a uv coordinate pair.
- * @related  CF_AtlasSubImage cf_register_premade_atlas cf_make_premade_sprite
+ * @related  cf_register_premade_atlas cf_make_premade_sprite
  */
 typedef struct CF_AtlasSubImage
 {
@@ -1638,7 +1638,7 @@ typedef struct CF_AtlasSubImage
  *           for convenience.
  *
  *           Call `cf_destroy_texture` on the return value when done.
- * @related  CF_AtlasSubImage cf_register_premade_atlas cf_make_premade_sprite cf_destroy_premade_atlas
+ * @related  cf_make_premade_sprite cf_destroy_premade_atlas CF_AtlasSubImage
  */
 CF_API CF_Texture CF_CALL cf_register_premade_atlas(const char* png_path, int sub_image_count, CF_AtlasSubImage* sub_images);
 
@@ -1647,7 +1647,7 @@ CF_API CF_Texture CF_CALL cf_register_premade_atlas(const char* png_path, int su
  * @category draw
  * @brief    Initializes a single-frame drawable sprite from a premade atlas `image_id`.
  * @param    image_id   The id from `cf_register_premade_atlas`.
- * @related  CF_AtlasSubImage cf_register_premade_atlas cf_make_premade_sprite cf_destroy_premade_atlas
+ * @related  cf_register_premade_atlas cf_destroy_premade_atlas CF_AtlasSubImage
  */
 CF_API CF_Sprite CF_CALL cf_make_premade_sprite(uint64_t image_id);
 

--- a/include/cute_file_system.h
+++ b/include/cute_file_system.h
@@ -34,7 +34,7 @@ extern "C" {
  *     printf("%s\n", filename);
  *     // Prints: big_gem.txt
  * @remarks  Call `sfree` on the return value when done. `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname_no_ext spext spext_equ
  */
 #define spfname(s) cf_path_get_filename(s)
 
@@ -48,7 +48,7 @@ extern "C" {
  *     printf("%s\n", filename);
  *     // Prints: big_gem
  * @remarks  Call `sfree` on the return value when done. `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname spext spext_equ
  */
 #define spfname_no_ext(s) cf_path_get_filename_no_ext(s)
 
@@ -62,7 +62,7 @@ extern "C" {
  *     printf("%s\n", ext);
  *     // Prints: .txt
  * @remarks  Call `sfree` on the return value when done. `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spext_equ spfname spfname_no_ext
  */
 #define spext(s) cf_path_get_ext(s)
 
@@ -73,7 +73,7 @@ extern "C" {
  * @param    s          The path string.
  * @param    ext        The file extension.
  * @remarks  `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spext spfname spfname_no_ext
  */
 #define spext_equ(s, ext) cf_path_ext_equ(s, ext)
 
@@ -85,7 +85,7 @@ extern "C" {
  * @return   If the string is not a dynamic string from CF's string API, a new string is returned. Otherwise the
  *           string is modified in-place. You must call `sfree` if a new dynamic string is returned, when done.
  * @remarks  `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  sppopn spfname spfname_no_ext
  */
 #define sppop(s) cf_path_pop(s)
 
@@ -98,7 +98,7 @@ extern "C" {
  * @return   If the string is not a dynamic string from CF's string API, a new string is returned. Otherwise the
  *           string is modified in-place. You must call `sfree` if a new dynamic string is returned, when done.
  * @remarks  `sp` stands for "sting path".
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  sppop spfname spfname_no_ext
  */
 #define sppopn(s, n) cf_path_pop_n(s, n)
 
@@ -112,7 +112,7 @@ extern "C" {
  *           string is modified in-place. You must call `sfree` if a new dynamic string is returned, when done.
  * @remarks  This will insert ellipses "..." into the path as necessary. This function is useful for displaying paths
  *           and visualizing them in small boxes or windows. n includes the nul-byte. Returns a new string.
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname spfname_no_ext spext
  */
 #define spcompact(s, n) cf_path_compact(s, n)
 
@@ -126,7 +126,7 @@ extern "C" {
  *     printf("%s\n", filename);
  *     // Prints: /rare
  * @remarks  `sp` stands for "sting path". Call `sfree` on the return value when done.
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname spfname_no_ext spext
  */
 #define spdir_of(s) cf_path_directory_of(s)
 
@@ -140,7 +140,7 @@ extern "C" {
  *     printf("%s\n", filename);
  *     // Prints: /data
  * @remarks  `sp` stands for "sting path". Call `sfree` on the return value when done.
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname spfname_no_ext spext
  */
 #define sptop_of(s) cf_path_top_directory(s)
 
@@ -158,7 +158,7 @@ extern "C" {
  *           ```
  *           spnorm("C:\\Users\\Randy\\Documents") -> "C:/Users/Randy/Documents"
  *           ```
- * @related  spfname spfname_no_ext spext spext_equ sppop sppopn spcompact spdir_of sptop_of spnorm
+ * @related  spfname spfname_no_ext spext
  */
 #define spnorm(s) cf_path_normalize(s)
 
@@ -251,7 +251,7 @@ CF_API char* CF_CALL cf_path_normalize(const char* path);
  * @category file
  * @brief    An opaque pointer for representing a file.
  * @remarks  [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system)
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read
  */
 typedef struct CF_File CF_File;
 // @end
@@ -260,7 +260,7 @@ typedef struct CF_File CF_File;
  * @enum     File Types
  * @category file
  * @brief    The various kinds of files that can be opened.
- * @related  CF_File CF_Stat cf_file_type_to_string
+ * @related  cf_file_type_to_string CF_File CF_Stat
  */
 #define CF_FILE_TYPE_DEFS \
 	/* @entry A reguler file, such as a .txt or .pdf file. */ \
@@ -284,7 +284,7 @@ typedef enum CF_FileType
  * @function cf_file_type_to_string
  * @category file
  * @brief    Returns a `CF_FileType` converted to a c-string.
- * @related  CF_File CF_Stat cf_file_type_to_string
+ * @related  CF_File CF_Stat
  */
 CF_INLINE const char* cf_file_type_to_string(CF_FileType type)
 {
@@ -300,7 +300,7 @@ CF_INLINE const char* cf_file_type_to_string(CF_FileType type)
  * @struct   CF_Stat
  * @category file
  * @brief    A structure containing information about a file.
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read
  */
 typedef struct CF_Stat
 {
@@ -330,7 +330,7 @@ typedef struct CF_Stat
  * @brief    Returns the path of the base directory.
  * @remarks  This is not a virtual path, but the actual OS-path where the executable was run from. This might not be the working directory,
  *           but probably is. You should probably mount the base directory with `cf_fs_mount`. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system) for an overview.
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount cf_fs_get_working_directory
+ * @related  cf_fs_get_user_directory cf_fs_get_working_directory cf_fs_set_write_directory
  */
 CF_API const char* CF_CALL cf_fs_get_base_directory(void);
 
@@ -339,7 +339,7 @@ CF_API const char* CF_CALL cf_fs_get_base_directory(void);
  * @category file
  * @brief    Returns the current working directory in platform-dependent notation.
  * @remarks  Not all platforms have the concept of a working directory, but this function will sill try to return something sane in these cases.
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount cf_fs_get_working_directory
+ * @related  cf_fs_get_base_directory cf_fs_get_user_directory cf_fs_set_write_directory
  */
 CF_API const char* CF_CALL cf_fs_get_working_directory(void);
 
@@ -353,7 +353,7 @@ CF_API const char* CF_CALL cf_fs_get_working_directory(void);
  * @remarks  The path is in platform-dependent notation. It's highly recommend to use `cf_fs_get_user_directory` and pass it into this function
  *           when shipping your game. This function will fail if any files are from the write directory are currently open.
  *           See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system) for an overview.
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount
+ * @related  cf_fs_get_base_directory cf_fs_get_user_directory cf_fs_mount
  */
 CF_API CF_Result CF_CALL cf_fs_set_write_directory(const char* platform_dependent_directory);
 
@@ -377,7 +377,7 @@ CF_API CF_Result CF_CALL cf_fs_set_write_directory(const char* platform_dependen
  *           "/Users/OS_user_name/Library/Application Support/my_game"
  *           ```
  *           You should assume this directory is the only safe place to write files. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount
+ * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_mount
  */
 CF_API const char* CF_CALL cf_fs_get_user_directory(const char* company_name, const char* game_name);
 
@@ -401,7 +401,7 @@ CF_API const char* CF_CALL cf_fs_get_user_directory(const char* company_name, co
  *           
  *           By default CF mounts the base directory when you call `cf_make_app`. This can be disabled by
  *           passing the `CF_APP_OPTIONS_FILE_SYSTEM_DONT_DEFAULT_MOUNT` flag to `cf_make_app`. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount
+ * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory
  */
 CF_API CF_Result CF_CALL cf_fs_mount(const char* archive, const char* mount_point, bool append_to_path);
 
@@ -411,7 +411,7 @@ CF_API CF_Result CF_CALL cf_fs_mount(const char* archive, const char* mount_poin
  * @brief    Removes an archive from the path specified in platform-dependent notation.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  This function does not remove a `mount_point` from the virtual file system, but only the actual archive that was previously mounted. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory cf_fs_mount cf_fs_dismount
+ * @related  cf_fs_get_base_directory cf_fs_set_write_directory cf_fs_get_user_directory
  */
 CF_API CF_Result CF_CALL cf_fs_dismount(const char* archive);
 
@@ -421,7 +421,7 @@ CF_API CF_Result CF_CALL cf_fs_dismount(const char* archive);
  * @brief    Returns file information at the given virtual path, such as file size or creation time.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  This doesn't open the file itself, and is a fairly light-weight operation in comparison. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read
  */
 CF_API CF_Result CF_CALL cf_fs_stat(const char* virtual_path, CF_Stat* stat);
 
@@ -431,7 +431,7 @@ CF_API CF_Result CF_CALL cf_fs_stat(const char* virtual_path, CF_Stat* stat);
  * @brief    Opens a file for writing relative to the write directory.
  * @return   Returns a `CF_File` pointer representing the file.
  * @remarks  The write directory is specified by you when calling `cf_fs_set_write_directory`. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_close cf_fs_open_file_for_write cf_fs_open_file_for_read
  */
 CF_API CF_File* CF_CALL cf_fs_create_file(const char* virtual_path);
 
@@ -441,7 +441,7 @@ CF_API CF_File* CF_CALL cf_fs_create_file(const char* virtual_path);
  * @brief    Opens a file for writing relative to the write directory.
  * @return   Returns a `CF_File` pointer representing the file.
  * @remarks  The write directory is specified by you when calling `cf_fs_set_write_directory`. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_open_file_for_read cf_fs_create_file cf_fs_close
  */
 CF_API CF_File* CF_CALL cf_fs_open_file_for_write(const char* virtual_path);
 
@@ -451,7 +451,7 @@ CF_API CF_File* CF_CALL cf_fs_open_file_for_write(const char* virtual_path);
  * @brief    Opens a file for appending relative to the write directory.
  * @return   Returns a `CF_File` pointer representing the file.
  * @remarks  The write directory is specified by you when calling `cf_fs_set_write_directory`. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_create_file
  */
 CF_API CF_File* CF_CALL cf_fs_open_file_for_append(const char* virtual_path);
 
@@ -462,7 +462,7 @@ CF_API CF_File* CF_CALL cf_fs_open_file_for_append(const char* virtual_path);
  * @param    virtual_path  The virtual path to the file.
  * @return   Returns a `CF_File` pointer representing the file.
  * @remarks  If you just want some basic information about the file (such as it's size or when it was created), you can use `cf_fs_stat` instead. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_open_file_for_write cf_fs_create_file cf_fs_close
  */
 CF_API CF_File* CF_CALL cf_fs_open_file_for_read(const char* virtual_path);
 
@@ -472,7 +472,7 @@ CF_API CF_File* CF_CALL cf_fs_open_file_for_read(const char* virtual_path);
  * @brief    Closes a file.
  * @param    file        The file.
  * @return   Returns any errors as a `CF_Result`.
- * @related  CF_File CF_Stat cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read cf_fs_close
+ * @related  cf_fs_create_file cf_fs_open_file_for_write cf_fs_open_file_for_read
  */
 CF_API CF_Result CF_CALL cf_fs_close(CF_File* file);
 
@@ -483,7 +483,7 @@ CF_API CF_Result CF_CALL cf_fs_close(CF_File* file);
  * @param    virtual_path  The virtual path to the file or directory.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory cf_fs_free_enumerated_directory
+ * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory
  */
 CF_API CF_Result CF_CALL cf_fs_remove(const char* virtual_path);
 
@@ -494,7 +494,7 @@ CF_API CF_Result CF_CALL cf_fs_remove(const char* virtual_path);
  * @param    virtual_path  The virtual path to the directory.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  All missing directories are also created. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory cf_fs_free_enumerated_directory
+ * @related  cf_fs_remove_directory cf_fs_enumerate_directory cf_fs_free_enumerated_directory
  */
 CF_API CF_Result CF_CALL cf_fs_create_directory(const char* virtual_path);
 
@@ -513,7 +513,7 @@ CF_API CF_Result CF_CALL cf_fs_create_directory(const char* virtual_path);
  * @remarks  Results are collected by visiting the search path for all real directories mounted on `virtual_path`. No duplicate file
  *           names will be reported. The list itself is sorted alphabetically, though you can further sort it however you like. Free
  *           the list up with `cf_fs_free_enumerated_directory` when done. The final element of the list is NULL. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory cf_fs_free_enumerated_directory
+ * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_free_enumerated_directory
  */
 CF_API const char** CF_CALL cf_fs_enumerate_directory(const char* virtual_path);
 
@@ -522,7 +522,7 @@ CF_API const char** CF_CALL cf_fs_enumerate_directory(const char* virtual_path);
  * @category file
  * @brief    Frees a file list from `cf_fs_create_directory`.
  * @param    directory_list  The directory list returned from `cf_fs_create_directory`.
- * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory cf_fs_free_enumerated_directory
+ * @related  cf_fs_remove_directory cf_fs_create_directory cf_fs_enumerate_directory
  */
 CF_API void CF_CALL cf_fs_free_enumerated_directory(const char** directory_list);
 
@@ -532,7 +532,7 @@ CF_API void CF_CALL cf_fs_free_enumerated_directory(const char** directory_list)
  * @brief    Returns true if a file exists, false otherwise.
  * @param    virtual_path  A path to the file.
  * @remarks  [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_read cf_fs_write cf_fs_eof
  */
 CF_API bool CF_CALL cf_fs_file_exists(const char* virtual_path);
 
@@ -545,7 +545,7 @@ CF_API bool CF_CALL cf_fs_file_exists(const char* virtual_path);
  * @param    size       The size in bytes of `buffer`.
  * @remarks  The file must be opened in read mode with `cf_fs_open_file_for_read`. Returns the number of bytes read. Returns -1 on
  *           failure. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_file_exists cf_fs_write cf_fs_eof
  */
 CF_API size_t CF_CALL cf_fs_read(CF_File* file, void* buffer, size_t size);
 
@@ -558,7 +558,7 @@ CF_API size_t CF_CALL cf_fs_read(CF_File* file, void* buffer, size_t size);
  * @param    size       The size in bytes of `buffer`.
  * @remarks  The file must be opened in write mode with `cf_fs_open_file_for_write`. Returns the number of bytes written. Returns -1 on
  *           failure. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_file_exists cf_fs_read cf_fs_eof
  */
 CF_API size_t CF_CALL cf_fs_write(CF_File* file, const void* buffer, size_t size);
 
@@ -568,7 +568,7 @@ CF_API size_t CF_CALL cf_fs_write(CF_File* file, const void* buffer, size_t size
  * @brief    Check to see if the eof has been found after reading a file opened in read mode.
  * @param    CF_File    The file.
  * @remarks  [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_file_exists cf_fs_read cf_fs_write
  */
 CF_API CF_Result CF_CALL cf_fs_eof(CF_File* file);
 
@@ -578,7 +578,7 @@ CF_API CF_Result CF_CALL cf_fs_eof(CF_File* file);
  * @brief    Returns the current position within the file.
  * @param    CF_File    The file.
  * @remarks  This is an offset from the beginning of the file. Returns -1 on failure. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_file_exists cf_fs_read cf_fs_write
  */
 CF_API size_t CF_CALL cf_fs_tell(CF_File* file);
 
@@ -590,7 +590,7 @@ CF_API size_t CF_CALL cf_fs_tell(CF_File* file);
  * @param    position   The read/write position.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  This is an offset from the beginning of the file. The next read or write will happen at this position. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_size cf_fs_file_exists cf_fs_read
  */
 CF_API CF_Result CF_CALL cf_fs_seek(CF_File* file, size_t position);
 
@@ -600,7 +600,7 @@ CF_API CF_Result CF_CALL cf_fs_seek(CF_File* file, size_t position);
  * @brief    Returns the size of a file in bytes.
  * @param    CF_File    The file.
  * @remarks  You might want to use `cf_fs_stat` instead to avoid needing to fully open the file first. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_File cf_fs_file_exists cf_fs_read cf_fs_write cf_fs_eof cf_fs_tell cf_fs_seek cf_fs_size
+ * @related  cf_fs_seek cf_fs_file_exists cf_fs_read
  */
 CF_API size_t CF_CALL cf_fs_size(CF_File* file);
 
@@ -611,7 +611,7 @@ CF_API size_t CF_CALL cf_fs_size(CF_File* file);
  * @param    virtual_path  A path to the file.
  * @param    size          If the file exists the size of the file is stored here.
  * @remarks  Call `cf_free` on it when done. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_read_entire_file_to_memory cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file
+ * @related  cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file
  */
 CF_API void* CF_CALL cf_fs_read_entire_file_to_memory(const char* virtual_path, size_t* size);
 
@@ -622,7 +622,7 @@ CF_API void* CF_CALL cf_fs_read_entire_file_to_memory(const char* virtual_path, 
  * @param    virtual_path  A path to the file.
  * @param    size          If the file exists the size of the file is stored here.
  * @remarks  Call `cf_free` on it when done. [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_fs_read_entire_file_to_memory cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file
+ * @related  cf_fs_read_entire_file_to_memory cf_fs_write_entire_buffer_to_file cf_fs_write_string_file
  */
 CF_API char* CF_CALL cf_fs_read_entire_file_to_memory_and_nul_terminate(const char* virtual_path, size_t* size);
 
@@ -633,7 +633,7 @@ CF_API char* CF_CALL cf_fs_read_entire_file_to_memory_and_nul_terminate(const ch
  * @param    virtual_path  A path to the file.
  * @param    data          A pointer to the data to write to the file.
  * @param    size          The size in bytes of `data`.
- * @related  cf_fs_read_entire_file_to_memory cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file cf_fs_write_string_range_to_file
+ * @related  cf_fs_write_string_file cf_fs_write_string_range_to_file cf_fs_read_entire_file_to_memory
  */
 CF_API CF_Result CF_CALL cf_fs_write_entire_buffer_to_file(const char* virtual_path, const void* data, size_t size);
 
@@ -643,7 +643,7 @@ CF_API CF_Result CF_CALL cf_fs_write_entire_buffer_to_file(const char* virtual_p
  * @brief    Writes a string to a file.
  * @param    virtual_path  A path to the file.
  * @param    string        A string to write.
- * @related  cf_fs_read_entire_file_to_memory cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file cf_fs_write_string_range_to_file
+ * @related  cf_fs_write_string_file cf_fs_write_string_range_to_file cf_fs_write_entire_buffer_to_file
  */
 CF_API CF_Result CF_CALL cf_fs_write_string_to_file(const char* virtual_path, const char* string);
 
@@ -654,7 +654,7 @@ CF_API CF_Result CF_CALL cf_fs_write_string_to_file(const char* virtual_path, co
  * @param    virtual_path  A path to the file.
  * @param    begin         Beginning of the string.
  * @param    end           Pointer to one passed the end of the string's contents.
- * @related  cf_fs_read_entire_file_to_memory cf_fs_read_entire_file_to_memory_and_nul_terminate cf_fs_write_entire_buffer_to_file cf_fs_write_string_file cf_fs_write_string_range_to_file
+ * @related  cf_fs_write_string_file cf_fs_write_entire_buffer_to_file cf_fs_read_entire_file_to_memory
  */
 CF_API CF_Result CF_CALL cf_fs_write_string_range_to_file(const char* virtual_path, const char* begin, const char* end);
 
@@ -689,7 +689,7 @@ CF_API const char* CF_CALL cf_fs_get_actual_path(const char* virtual_path);
  *           need to call this function. However, sometimes it's convenient to make tools that crawl
  *           over files without the need for a full application window. In this case simply call this
  *           function to enable all the `cf_fs_***` functions.
- * @related  cf_fs_init cf_fs_destroy
+ * @related  cf_fs_destroy
  */
 CF_API CF_Result CF_CALL cf_fs_init(const char* argv0);
 
@@ -700,7 +700,7 @@ CF_API CF_Result CF_CALL cf_fs_init(const char* argv0);
  * @param    argv0       The first command-line argument passed into your `main` function.
  * @remarks  Cleans up all static memory used by `cf_fs_init`. You probably don't need to call this function,
  *           as `cf_app_destroy` already does this for you.
- * @related  cf_fs_init cf_fs_destroy
+ * @related  cf_fs_init
  */
 CF_API void CF_CALL cf_fs_destroy(void);
 

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -62,7 +62,7 @@ extern "C" {
  * @category graphics
  * @brief    An opaque handle representing a texture.
  * @remarks  A texture is a buffer of data sent to the GPU for random access. Usually textures are used to store image data.
- * @related  CF_Texture CF_Canvas CF_Material CF_Shader CF_TextureParams cf_texture_defaults cf_make_texture cf_destroy_texture cf_texture_update cf_material_set_texture_vs cf_material_set_texture_fs
+ * @related  cf_texture_defaults cf_texture_update cf_make_texture
  */
 typedef struct CF_Texture { uint64_t id; } CF_Texture;
 // @end
@@ -71,7 +71,7 @@ typedef struct CF_Texture { uint64_t id; } CF_Texture;
  * @struct   CF_Canvas
  * @category graphics
  * @brief    An opaque handle representing a canvas.
- * @related  CF_Texture CF_Canvas CF_Material CF_Shader CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas
+ * @related  cf_canvas_defaults cf_make_canvas cf_destroy_canvas
  */
 typedef struct CF_Canvas { uint64_t id; } CF_Canvas;
 // @end
@@ -83,7 +83,7 @@ typedef struct CF_Canvas { uint64_t id; } CF_Canvas;
  * @remarks  A mesh is a container of triangles, along with optional indices. After a mesh
  *           is created the layout of the vertices in memory must be described. We use an array of
  *           `CF_VertexAttribute` to define how the GPU will interpret the vertices we send it.
- * @related  CF_Texture CF_Canvas CF_Material CF_Shader cf_make_mesh cf_destroy_mesh cf_mesh_update_vertex_data cf_apply_mesh
+ * @related  cf_mesh_update_vertex_data cf_make_mesh cf_destroy_mesh
  */
 typedef struct CF_Mesh { uint64_t id; } CF_Mesh;
 // @end
@@ -96,7 +96,7 @@ typedef struct CF_Mesh { uint64_t id; } CF_Mesh;
  *           variables inside of a shader stage (either the vertex or fragment shaders). For efficiency, all
  *           uniforms are packed into a "uniform buffer", a contiguous chunk of memory on the GPU. We must
  *           specify which uniform buffer each uniform belongs to.
- * @related  CF_Texture CF_Canvas CF_Material CF_Shader cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs cf_apply_shader
+ * @related  cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs
  */
 typedef struct CF_Material { uint64_t id; } CF_Material;
 // @end
@@ -106,7 +106,7 @@ typedef struct CF_Material { uint64_t id; } CF_Material;
  * @category graphics
  * @brief    An opaque handle representing a shader.
  * @remarks  A shader is a small program that runs on the GPU. They come in the form of vertex and fragment shaders.
- * @related  CF_Texture CF_Canvas CF_Material CF_Shader cf_make_shader cf_destroy_shader cf_apply_shader
+ * @related  cf_make_shader cf_destroy_shader cf_apply_shader
  */
 typedef struct CF_Shader { uint64_t id; } CF_Shader;
 // @end
@@ -118,7 +118,7 @@ typedef struct CF_Shader { uint64_t id; } CF_Shader;
  * @enum     CF_BackendType
  * @category graphics
  * @brief    The various supported graphics backends.
- * @related  CF_BackendType cf_backend_type_to_string cf_query_backend
+ * @related  cf_backend_type_to_string cf_query_backend
  */
 #define CF_BACKEND_TYPE_DEFS \
 	/* @entry Invalid backend type (unitialized or failed to create). */           \
@@ -148,7 +148,7 @@ typedef enum CF_BackendType
  * @function cf_backend_type_to_string
  * @category graphics
  * @brief    Returns a `CF_BackendType` converted to a string.
- * @related  CF_BackendType cf_backend_type_to_string cf_query_backend
+ * @related  cf_query_backend CF_BackendType
  */
 CF_INLINE const char* cf_backend_type_to_string(CF_BackendType type) {
 	switch (type) {
@@ -163,7 +163,7 @@ CF_INLINE const char* cf_backend_type_to_string(CF_BackendType type) {
  * @function cf_query_backend
  * @category graphics
  * @brief    Returns which `CF_BackendType` is currently active.
- * @related  CF_BackendType cf_backend_type_to_string cf_query_backend
+ * @related  cf_backend_type_to_string CF_BackendType
  */
 CF_API CF_BackendType CF_CALL cf_query_backend(void);
 
@@ -173,7 +173,7 @@ CF_API CF_BackendType CF_CALL cf_query_backend(void);
  * @brief    The various supported pixel formats for GPU.
  * @remarks  Pixel format support varies depending on driver, hardware, and usage flags.
  *           The `PIXEL_FORMAT_R8G8B8A8_UNORM` represents a safe default format.
- * @related  CF_PixelFormat cf_pixel_format_to_string CF_PixelFormatOp
+ * @related  cf_pixel_format_to_string CF_PixelFormatOp
  */
 #define CF_PIXEL_FORMAT_DEFS \
 	/* @entry Invalid pixel format. */                                                         \
@@ -303,7 +303,7 @@ typedef enum CF_PixelFormat
  * @function cf_pixel_format_to_string
  * @category graphics
  * @brief    Returns a `CF_PixelFormat` converted to a C string.
- * @related  CF_PixelFormat cf_pixel_format_to_string CF_PixelFormatOp
+ * @related  CF_PixelFormat CF_PixelFormatOp
  */
 CF_INLINE const char* cf_pixel_format_to_string(CF_PixelFormat format) {
 	switch (format) {
@@ -320,7 +320,7 @@ CF_INLINE const char* cf_pixel_format_to_string(CF_PixelFormat format) {
  * @brief    The various supported operations a pixel format can perform.
  * @remarks  Not all types are supported on each backend. Be sure to check with `cf_query_pixel_format` if a particular pixel format
  *           is available for your use-case.
- * @related  CF_PixelFormat cf_pixel_format_op_to_string CF_PixelFormatOp
+ * @related  cf_pixel_format_op_to_string CF_PixelFormat
  */
 #define CF_PIXELFORMAT_OP_DEFS \
 	/* @entry Nearest-neighbor filtering. Good for pixel art. */          \
@@ -348,7 +348,7 @@ typedef enum CF_PixelFormatOp
  * @function cf_pixel_format_op_to_string
  * @category graphics
  * @brief    Returns a `CF_PixelFormatOp` converted to a C string.
- * @related  CF_PixelFormat cf_pixel_format_op_to_string CF_PixelFormatOp
+ * @related  CF_PixelFormat CF_PixelFormatOp
  */
 CF_INLINE const char* cf_pixel_format_op_to_string(CF_PixelFormatOp op) {
 switch (op) {
@@ -366,7 +366,7 @@ default: return NULL;
  * @param    format  The `CF_PixelFormat` to query.
  * @param    op      The operation to test, see `CF_PixelFormatOp`.
  * @return   True if the operation is supported for the format, otherwise false.
- * @related  CF_PixelFormat CF_PixelFormatOp cf_texture_supports_format
+ * @related  cf_texture_supports_format CF_PixelFormat CF_PixelFormatOp
  */
 CF_API bool CF_CALL cf_query_pixel_format(CF_PixelFormat format, CF_PixelFormatOp op);
 
@@ -379,7 +379,7 @@ CF_API bool CF_CALL cf_query_pixel_format(CF_PixelFormat format, CF_PixelFormatO
  * @brief    Bitmask flags that indicate the intended usage of a texture.
  * @remarks  These flags define how a texture will be utilized in graphics and compute pipelines.
  *           Multiple flags can be combined using a bitwise OR operation.
- * @related  CF_TextureUsageFlagBits CF_TextureUsageFlags
+ * @related  CF_TextureUsageFlags
  */
 #define CF_TEXTURE_USAGE_DEFS \
 	/* @entry The texture will be used as a sampler in shaders. */                    \
@@ -409,7 +409,7 @@ typedef enum CF_TextureUsageBits
  * @enum     CF_Filter
  * @category graphics
  * @brief    Filtering options for how to access `CF_Texture` data on the GPU.
- * @related  CF_Filter cf_filter_to_string CF_TextureParams
+ * @related  cf_filter_to_string CF_TextureParams
  */
 #define CF_FILTER_DEFS \
 	/* @entry Nearest-neighbor filtering. Good for pixel art. */             \
@@ -429,7 +429,7 @@ typedef enum CF_Filter
  * @function cf_filter_to_string
  * @category graphics
  * @brief    Returns a `CF_Filter` converted to a C string.
- * @related  CF_Filter cf_filter_to_string CF_TextureParams
+ * @related  CF_Filter CF_TextureParams
  */
 CF_INLINE const char* cf_filter_to_string(CF_Filter filter) {
 	switch (filter) {
@@ -444,7 +444,7 @@ CF_INLINE const char* cf_filter_to_string(CF_Filter filter) {
  * @enum     CF_MipFilter
  * @category graphics
  * @brief    Describes how the GPU samples between mipmap levels.
- * @related  CF_MipFilter cf_mip_filter_to_string CF_TextureParams
+ * @related  cf_mip_filter_to_string CF_TextureParams
  */
 #define CF_MIP_FILTER_DEFS                                                  \
 	/* @entry Samples the nearest mip level without blending. */            \
@@ -464,7 +464,7 @@ typedef enum CF_MipFilter
  * @function cf_mip_filter_to_string
  * @category graphics
  * @brief    Returns a `CF_MipFilter` converted to a C string.
- * @related  CF_MipFilter cf_mip_filter_to_string CF_TextureParams
+ * @related  CF_MipFilter CF_TextureParams
  */
 CF_INLINE const char* cf_mip_filter_to_string(CF_MipFilter filter) {
 	switch (filter) {
@@ -479,7 +479,7 @@ CF_INLINE const char* cf_mip_filter_to_string(CF_MipFilter filter) {
  * @enum     CF_WrapMode
  * @category graphics
  * @brief    Wrap modes to define behavior when addressing a texture beyond the [0,1] range.
- * @related  CF_WrapMode cf_wrap_mode_string CF_TextureParams
+ * @related  cf_wrap_mode_string CF_TextureParams
  */
 #define CF_WRAP_MODE_DEFS \
 	/* @entry Repeats the image. */                                            \
@@ -501,7 +501,7 @@ typedef enum CF_WrapMode
  * @function cf_wrap_mode_string
  * @category graphics
  * @brief    Returns a `CF_WrapMode` converted to a C string.
- * @related  CF_WrapMode cf_wrap_mode_string CF_TextureParams
+ * @related  CF_WrapMode CF_TextureParams
  */
 CF_INLINE const char* cf_wrap_mode_string(CF_WrapMode mode) {
 	switch (mode) {
@@ -517,7 +517,7 @@ CF_INLINE const char* cf_wrap_mode_string(CF_WrapMode mode) {
  * @category graphics
  * @brief    A collection of parameters to create a `CF_Texture` with `cf_make_texture`.
  * @remarks  You may get a set of good default values by calling `cf_texture_defaults`.
- * @related  CF_TextureParams cf_texture_defaults CF_Texture cf_make_texture cf_destroy_texture cf_texture_update
+ * @related  cf_texture_defaults cf_make_texture cf_destroy_texture
  */
 typedef struct CF_TextureParams
 {
@@ -566,7 +566,7 @@ typedef struct CF_TextureParams
  * @function cf_texture_defaults
  * @category graphics
  * @brief    Returns a good set of default values for `CF_TextureParams` to call `cf_make_texture`.
- * @related  CF_TextureParams CF_Texture cf_make_texture
+ * @related  cf_make_texture CF_TextureParams CF_Texture
  */
 CF_API CF_TextureParams CF_CALL cf_texture_defaults(int w, int h);
 
@@ -576,7 +576,7 @@ CF_API CF_TextureParams CF_CALL cf_texture_defaults(int w, int h);
  * @brief    Returns a new `CF_Texture`.
  * @param    texture_params  The texture parameters as a `CF_TextureParams`.
  * @return   Free it up with `cf_destroy_texture` when done.
- * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update
+ * @related  cf_destroy_texture cf_texture_update CF_TextureParams
  */
 CF_API CF_Texture CF_CALL cf_make_texture(CF_TextureParams texture_params);
 
@@ -585,7 +585,7 @@ CF_API CF_Texture CF_CALL cf_make_texture(CF_TextureParams texture_params);
  * @category graphics
  * @brief    Destroys a `CF_Texture` created by `cf_make_texture`.
  * @param    texture   The texture.
- * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update
+ * @related  cf_make_texture cf_texture_update CF_TextureParams
  */
 CF_API void CF_CALL cf_destroy_texture(CF_Texture texture);
 
@@ -598,7 +598,7 @@ CF_API void CF_CALL cf_destroy_texture(CF_Texture texture);
  * @param    size       The size in bytes of `data`.
  * @remarks  If you plan to frequently update the texture once per frame, it's recommended to set `stream` to
  *           true in the creation params `CF_TextureParams`.
- * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update cf_texture_update_mip cf_generate_mipmaps
+ * @related  cf_texture_update_mip cf_make_texture cf_destroy_texture
  */
 CF_API void CF_CALL cf_texture_update(CF_Texture texture, void* data, int size);
 
@@ -612,7 +612,7 @@ CF_API void CF_CALL cf_texture_update(CF_Texture texture, void* data, int size);
  * @param    mip_level  The mipmap level to update (0 = base level).
  * @remarks  If you update the texture frequently (e.g., once per frame), it's recommended to set `stream = true`
  *           when creating the texture using `CF_TextureParams`.
- * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update cf_texture_update_mip cf_generate_mipmaps
+ * @related  cf_texture_update cf_make_texture cf_destroy_texture
  */
 CF_API void CF_CALL cf_texture_update_mip(CF_Texture texture, void* data, int size, int mip_level);
 
@@ -623,7 +623,7 @@ CF_API void CF_CALL cf_texture_update_mip(CF_Texture texture, void* data, int si
  * @param    texture    The texture to generate mipmaps for.
  * @remarks  This is useful when the base level has been updated manually (e.g., for dynamic or render target textures)
  *           and you want to downsample to fill in the full mip chain.
- * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update cf_texture_update_mip cf_generate_mipmaps
+ * @related  cf_make_texture cf_destroy_texture cf_texture_update
  */
 CF_API void CF_CALL cf_generate_mipmaps(CF_Texture texture);
 
@@ -632,7 +632,7 @@ CF_API void CF_CALL cf_generate_mipmaps(CF_Texture texture);
  * @category graphics
  * @brief    Returns an SDL_GPUTexture* casted to a `uint64_t`.
  * @remarks  This is useful for e.g. rendering textures in an external system like Dear ImGui.
- * @related  CF_TextureParams CF_Texture cf_make_texture
+ * @related  cf_make_texture CF_TextureParams CF_Texture
  */
 CF_API uint64_t CF_CALL cf_texture_handle(CF_Texture texture);
 
@@ -641,7 +641,7 @@ CF_API uint64_t CF_CALL cf_texture_handle(CF_Texture texture);
  * @category graphics
  * @brief    Returns an SDL_GPUTextureSamplerBinding* casted to a `uint64_t`.
  * @remarks  This is useful for e.g. rendering textures in an external system like Dear ImGui.
- * @related  CF_TextureParams CF_Texture cf_make_texture
+ * @related  cf_make_texture CF_TextureParams CF_Texture
  */
 CF_API uint64_t CF_CALL cf_texture_binding_handle(CF_Texture texture);
 
@@ -652,7 +652,7 @@ CF_API uint64_t CF_CALL cf_texture_binding_handle(CF_Texture texture);
  * @enum     CF_ShaderStage
  * @category graphics
  * @brief    Distinction between vertex and fragment shaders.
- * @related  CF_Shader cf_shader_directory cf_make_shader
+ * @related  cf_shader_directory cf_make_shader CF_Shader
  */
 #define CF_SHADER_STAGE_DEFS \
 	/* @entry */                      \
@@ -677,7 +677,7 @@ typedef enum CF_ShaderStage
  *           may also be watched via `cf_shader_on_changed` to support shader reloading during development. If you call `cf_shader_directory` with
  *           the path `"/assets/shaders"`, you should then supply paths to `cf_make_shader` relative to the shader directory, and
  *           simply pass in paths such as `"/shader.vert`" or `"shader.frag"`. This also applies to `#include` between shaders.
- * @related  CF_Shader cf_make_shader cf_destroy_shader cf_apply_shader CF_Material
+ * @related  cf_make_shader cf_destroy_shader cf_apply_shader
  */
 CF_API void CF_CALL cf_shader_directory(const char* path);
 
@@ -689,7 +689,7 @@ CF_API void CF_CALL cf_shader_directory(const char* path);
  * @param    udata           An optional `void*` passed back to you whenever `on_changed_fn` is called.
  * @remarks  This is an optional function intended to help facilitate runtime shader reloading during development.
  *           Callbacks are issued when `cf_app_update` is called.
- * @related  CF_Shader cf_make_shader cf_destroy_shader cf_apply_shader CF_Material
+ * @related  cf_make_shader cf_destroy_shader cf_apply_shader
  */
 CF_API void CF_CALL cf_shader_on_changed(void (*on_changed_fn)(const char* path, void* udata), void* udata);
 
@@ -744,7 +744,7 @@ CF_API void CF_CALL cf_shader_on_changed(void (*on_changed_fn)(const char* path,
  *           quite exactly like a C/C++ include, it's very similar -- each shader may be included into another
  *           shader *only once*. If you try to include a file multiple times (such as circular dependencies,
  *           or if two files try to include the same file) subsequent includes will be ignored.
- * @related  CF_Shader cf_make_shader cf_shader_directory cf_apply_shader CF_Material
+ * @related  cf_shader_directory cf_apply_shader CF_Material
  */
 CF_API CF_Shader CF_CALL cf_make_shader(const char* vertex_path, const char* fragment_path);
 
@@ -754,7 +754,7 @@ CF_API CF_Shader CF_CALL cf_make_shader(const char* vertex_path, const char* fra
  * @brief    Creates a shader from strings containing glsl source code.
  * @param    vertex_src    The vertex shader source as C-string.
  * @param    fragment_src  The fragment shader source as C-string.
- * @related  CF_Shader cf_make_shader cf_shader_directory cf_apply_shader CF_Material
+ * @related  cf_make_shader cf_shader_directory cf_apply_shader
  */
 CF_API CF_Shader CF_CALL cf_make_shader_from_source(const char* vertex_src, const char* fragment_src);
 
@@ -768,7 +768,7 @@ CF_API CF_Shader CF_CALL cf_make_shader_from_source(const char* vertex_src, cons
  *           startup times. SPIR-V blobs can be saved straight to disk and shipped with your game. Load
  *           the bytecode blob pair (vertex + fragment shader blobs) into a `CF_Shader` via `cf_make_shader_from_bytecode`.
  *           The value returned from this function should be passed to `cf_free_shader_bytecode` when it is no longer needed.
- * @related  CF_Shader CF_ShaderBytecode cf_make_shader_from_bytecode cf_free_shader_bytecode
+ * @related  cf_make_shader_from_bytecode cf_free_shader_bytecode CF_Shader
  */
 CF_API CF_ShaderBytecode CF_CALL cf_compile_shader_to_bytecode(const char* shader_src, CF_ShaderStage stage);
 
@@ -791,7 +791,7 @@ CF_API void CF_CALL cf_free_shader_bytecode(CF_ShaderBytecode bytecode);
  * @remarks  This function is good for precompiling shaders from bytecode, which can help speed up app
  *           startup times. SPIR-V blobs can be saved straight to disk and shipped with your game. Create the
  *           bytecode blob with `cf_make_shader_from_bytecode`.
- * @related  CF_Shader cf_make_shader_from_bytecode cf_make_shader_from_bytecode
+ * @related  CF_Shader
  */
 CF_API CF_Shader CF_CALL cf_make_shader_from_bytecode(CF_ShaderBytecode vertex_bytecode, CF_ShaderBytecode fragment_bytecode);
 
@@ -800,7 +800,7 @@ CF_API CF_Shader CF_CALL cf_make_shader_from_bytecode(CF_ShaderBytecode vertex_b
  * @category graphics
  * @brief    Frees up a `CF_Shader` created by `cf_make_shader`.
  * @param    shader     A shader.
- * @related  CF_Shader cf_make_shader cf_destroy_shader cf_apply_shader CF_Material
+ * @related  cf_make_shader cf_apply_shader CF_Shader
  */
 CF_API void CF_CALL cf_destroy_shader(CF_Shader shader);
 
@@ -813,7 +813,7 @@ CF_API void CF_CALL cf_destroy_shader(CF_Shader shader);
  * @brief    Multisample count used for MSAA render targets.
  * @remarks  Turning this on will attempt to use hardware to blur everything you render.
  *           You may not sample from canvas textures with sample counts greater than 1.
- * @related  CF_SampleCount cf_sample_count_string CF_TextureParams
+ * @related  cf_sample_count_string CF_TextureParams
  */
 #define CF_SAMPLE_COUNT_DEFS \
 	/* @entry No multisampling. */                          \
@@ -856,7 +856,7 @@ CF_INLINE const char* cf_samplecount_string(CF_SampleCount count) {
  *           by calling `cf_clear_color`. Usually you will not need to create a canvas at all, as it's an advanced feature for
  *           users who want to draw to an off-screen buffer. Use cases can include rendering reflections, advanced lighting
  *           techniques, or other kinds of multi-pass effects.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_canvas_defaults cf_make_canvas cf_destroy_canvas
  */
 typedef struct CF_CanvasParams
 {
@@ -881,7 +881,7 @@ typedef struct CF_CanvasParams
  * @function cf_canvas_defaults
  * @category graphics
  * @brief    Returns a good set of default values for a `CF_CanvasParams` to call `cf_make_canvas`.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_clear_color cf_make_canvas cf_destroy_canvas
  */
 CF_API CF_CanvasParams CF_CALL cf_canvas_defaults(int w, int h);
 
@@ -889,7 +889,7 @@ CF_API CF_CanvasParams CF_CALL cf_canvas_defaults(int w, int h);
  * @function cf_make_canvas
  * @category graphics
  * @brief    Returns a new `CF_Canvas` for offscreen rendering.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_canvas_defaults cf_destroy_canvas cf_apply_canvas
  */
 CF_API CF_Canvas CF_CALL cf_make_canvas(CF_CanvasParams canvas_params);
 
@@ -897,7 +897,7 @@ CF_API CF_Canvas CF_CALL cf_make_canvas(CF_CanvasParams canvas_params);
  * @function cf_destroy_canvas
  * @category graphics
  * @brief    Frees up a `CF_Canvas` created by `cf_make_canvas`.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_canvas_defaults cf_make_canvas cf_apply_canvas
  */
 CF_API void CF_CALL cf_destroy_canvas(CF_Canvas canvas);
 
@@ -906,7 +906,7 @@ CF_API void CF_CALL cf_destroy_canvas(CF_Canvas canvas);
  * @category graphics
  * @brief    Returns the `target` texture the canvas renders upon.
  * @remarks  If you turn on MSAA you may not sample from this texture.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_canvas_defaults cf_clear_color cf_make_canvas
  */
 CF_API CF_Texture CF_CALL cf_canvas_get_target(CF_Canvas canvas);
 
@@ -914,7 +914,7 @@ CF_API CF_Texture CF_CALL cf_canvas_get_target(CF_Canvas canvas);
  * @function cf_canvas_get_depth_stencil_target
  * @category graphics
  * @brief    Returns the `depth_stencil_target` texture the canvas renders upon.
- * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
+ * @related  cf_canvas_defaults cf_clear_color cf_make_canvas
  */
 CF_API CF_Texture CF_CALL cf_canvas_get_depth_stencil_target(CF_Canvas canvas);
 
@@ -925,7 +925,7 @@ CF_API CF_Texture CF_CALL cf_canvas_get_depth_stencil_target(CF_Canvas canvas);
  * @param    canvas  The canvas to clear.
  * @remarks  This clears the canvas to its configured clear color and clears depth to 1.0 (furthest depth).
  *           If the canvas has no depth-stencil target, only the color target will be cleared.
- * @related  cf_make_canvas cf_clear_color cf_clear_depth_stencil
+ * @related  cf_clear_color cf_clear_depth_stencil cf_make_canvas
  */
 CF_API void CF_CALL cf_clear_canvas(CF_Canvas canvas);
 
@@ -937,7 +937,7 @@ CF_API void CF_CALL cf_clear_canvas(CF_Canvas canvas);
  * @category graphics
  * @brief    The various supported vertex formats.
  * @remarks  Vertex formats define the type and size of vertex attributes in a vertex buffer.
- * @related  CF_VertexFormat cf_vertex_format_to_string CF_VertexFormatOp cf_query_vertex_format
+ * @related  cf_vertex_format_to_string cf_query_vertex_format
  */
 #define CF_VERTEX_FORMAT_DEFS \
 	/* @entry 32-bit signed integer. */                     \
@@ -1014,7 +1014,7 @@ typedef enum CF_VertexFormat
  * @function cf_vertex_format_string
  * @category graphics
  * @brief    Frees up a `CF_Canvas` created by `cf_make_canvas`.
- * @related  CF_VertexFormat cf_vertex_format_string CF_VertexAttribute cf_mesh_set_attributes
+ * @related  cf_mesh_set_attributes CF_VertexFormat CF_VertexAttribute
  */
 CF_INLINE const char* cf_vertex_format_string(CF_VertexFormat format) {
 	switch (format) {
@@ -1031,7 +1031,7 @@ CF_INLINE const char* cf_vertex_format_string(CF_VertexFormat format) {
  * @brief    Describes the memory layout of vertex attributes.
  * @remarks  An attribute is a component of a vertex, usually one, two, three or four floats/integers. A vertex is an input
  *           to a vertex shader. A `CF_Mesh` is a collection of vertices and attribute layout definitions.
- * @related  CF_VertexAttribute cf_mesh_set_attributes
+ * @related  cf_mesh_set_attributes
  */
 typedef struct CF_VertexAttribute
 {
@@ -1061,7 +1061,7 @@ typedef struct CF_VertexAttribute
  * @param    attribute_count              Number of attributes in `attributes`.
  * @param    vertex_stride                Number of bytes between each vertex.
  * @remarks  The max number of attributes is `CF_MESH_MAX_VERTEX_ATTRIBUTES` (32). Any more attributes beyond 32 will be ignored.
- * @related  CF_Mesh cf_make_mesh cf_destroy_mesh cf_mesh_update_vertex_data cf_mesh_set_index_buffer cf_mesh_set_instance_buffer
+ * @related  cf_mesh_update_vertex_data cf_mesh_set_index_buffer cf_mesh_set_instance_buffer
  */
 CF_API CF_Mesh CF_CALL cf_make_mesh(int vertex_buffer_size_in_bytes, const CF_VertexAttribute* attributes, int attribute_count, int vertex_stride);
 
@@ -1072,7 +1072,7 @@ CF_API CF_Mesh CF_CALL cf_make_mesh(int vertex_buffer_size_in_bytes, const CF_Ve
  * @param    mesh                         The mesh.
  * @param    index_buffer_size_in_bytes   The size of the mesh's index buffer.
  * @param    index_bit_count              The number of bits to use for indices, must be either 16 or 32.
- * @related  CF_Mesh cf_make_mesh cf_mesh_update_index_data
+ * @related  cf_mesh_update_index_data cf_make_mesh CF_Mesh
  */
 CF_API void CF_CALL cf_mesh_set_index_buffer(CF_Mesh mesh, int index_buffer_size_in_bytes, int index_bit_count);
 
@@ -1083,7 +1083,7 @@ CF_API void CF_CALL cf_mesh_set_index_buffer(CF_Mesh mesh, int index_buffer_size
  * @param    mesh                         The mesh.
  * @param    instance_buffer_size_in_bytes  The size of the mesh's index buffer.
  * @param    instance_stride                The number of bytes for each instance data.
- * @related  CF_Mesh cf_make_mesh cf_mesh_update_instance_data
+ * @related  cf_mesh_update_instance_data cf_make_mesh CF_Mesh
  */
 CF_API void CF_CALL cf_mesh_set_instance_buffer(CF_Mesh mesh, int instance_buffer_size_in_bytes, int instance_stride);
 
@@ -1092,7 +1092,7 @@ CF_API void CF_CALL cf_mesh_set_instance_buffer(CF_Mesh mesh, int instance_buffe
  * @category graphics
  * @brief    Frees up a `CF_Mesh` previously created with `cf_make_mesh`.
  * @param    mesh       The mesh.
- * @related  CF_Mesh cf_make_mesh cf_destroy_mesh cf_mesh_update_vertex_data
+ * @related  cf_make_mesh cf_mesh_update_vertex_data CF_Mesh
  */
 CF_API void CF_CALL cf_destroy_mesh(CF_Mesh mesh);
 
@@ -1103,7 +1103,7 @@ CF_API void CF_CALL cf_destroy_mesh(CF_Mesh mesh);
  * @param    mesh       The mesh.
  * @param    data       A pointer to vertex data.
  * @param    count      Number of vertices in `data`.
- * @related  CF_Mesh cf_make_mesh cf_destroy_mesh cf_mesh_update_vertex_data
+ * @related  cf_make_mesh cf_destroy_mesh CF_Mesh
  */
 CF_API void CF_CALL cf_mesh_update_vertex_data(CF_Mesh mesh, void* data, int count);
 
@@ -1114,7 +1114,7 @@ CF_API void CF_CALL cf_mesh_update_vertex_data(CF_Mesh mesh, void* data, int cou
  * @param    mesh       The mesh.
  * @param    data       A pointer to index data.
  * @param    count      Number of indices in `data`.
- * @related  CF_Mesh cf_make_mesh cf_destroy_mesh cf_mesh_set_index_buffer
+ * @related  cf_mesh_set_index_buffer cf_make_mesh cf_destroy_mesh
  */
 CF_API void CF_CALL cf_mesh_update_index_data(CF_Mesh mesh, void* data, int count);
 
@@ -1125,7 +1125,7 @@ CF_API void CF_CALL cf_mesh_update_index_data(CF_Mesh mesh, void* data, int coun
  * @param    mesh       The mesh.
  * @param    data       A pointer to instance data.
  * @param    count      Number of isntances in `data`.
- * @related  CF_Mesh cf_make_mesh cf_destroy_mesh cf_mesh_set_instance_buffer
+ * @related  cf_mesh_set_instance_buffer cf_make_mesh cf_destroy_mesh
  */
 CF_API void CF_CALL cf_mesh_update_instance_data(CF_Mesh mesh, void* data, int count);
 
@@ -1136,7 +1136,7 @@ CF_API void CF_CALL cf_mesh_update_instance_data(CF_Mesh mesh, void* data, int c
  * @enum     CF_CullMode
  * @category graphics
  * @brief    Settings to control if triangles are culled in clockwise order, counter-clockwise order, or not at all.
- * @related  CF_CullMode cf_cull_mode_string CF_RenderState
+ * @related  cf_cull_mode_string CF_RenderState
  */
 #define CF_CULL_MODE_DEFS \
 	/* @entry No culling at all. */                        \
@@ -1158,7 +1158,7 @@ typedef enum CF_CullMode
  * @function cf_cull_mode_string
  * @category graphics
  * @brief    Returns a `CF_CullMode` converted to a C string.
- * @related  CF_CullMode cf_cull_mode_string CF_RenderState
+ * @related  CF_CullMode CF_RenderState
  */
 CF_INLINE const char* cf_cull_mode_string(CF_CullMode mode) {
 	switch (mode) {
@@ -1173,7 +1173,7 @@ CF_INLINE const char* cf_cull_mode_string(CF_CullMode mode) {
  * @enum     CF_CompareFunction
  * @category graphics
  * @brief    Compare operations available for depth/stencil.
- * @related  CF_CompareFunction cf_compare_function_string CF_StencilOp CF_StencilFunction
+ * @related  cf_compare_function_string CF_StencilOp
  */
 #define CF_COMPARE_FUNCTION_DEFS \
 	/* @entry Always perform the operation. */         \
@@ -1205,7 +1205,7 @@ typedef enum CF_CompareFunction
  * @function cf_compare_function_string
  * @category graphics
  * @brief    Returns a `CF_CompareFunction` converted to a C string.
- * @related  CF_CompareFunction cf_compare_function_string CF_StencilOp CF_StencilFunction
+ * @related  CF_CompareFunction CF_StencilOp CF_StencilFunction
  */
 CF_INLINE const char* cf_compare_function_string(CF_CompareFunction compare) {
 	switch (compare) {
@@ -1220,7 +1220,7 @@ CF_INLINE const char* cf_compare_function_string(CF_CompareFunction compare) {
  * @enum     CF_StencilOp
  * @category graphics
  * @brief    Stencil operations. These can happen when passing/failing a stencil test.
- * @related  CF_StencilOp cf_stencil_op_string CF_StencilFunction
+ * @related  cf_stencil_op_string CF_StencilFunction
  */
 #define CF_STENCIL_OP_DEFS \
 	/* @entry Keep. */                     \
@@ -1252,7 +1252,7 @@ typedef enum CF_StencilOp
  * @function cf_stencil_op_string
  * @category graphics
  * @brief    Returns a `CF_StencilOp` converted to a C string.
- * @related  CF_StencilOp cf_stencil_op_string CF_StencilFunction
+ * @related  CF_StencilOp CF_StencilFunction
  */
 CF_INLINE const char* cf_stencil_op_string(CF_StencilOp op) {
 	switch (op) {
@@ -1268,7 +1268,7 @@ CF_INLINE const char* cf_stencil_op_string(CF_StencilOp op) {
  * @category graphics
  * @brief    Blend operations between two color components.
  * @remarks  See `CF_BlendState` for an overview.
- * @related  CF_BlendOp cf_blend_op_string CF_BlendState
+ * @related  cf_blend_op_string CF_BlendState
  */
 #define CF_BLEND_OP_DEFS \
 	/* @entry Add. */                     \
@@ -1294,7 +1294,7 @@ typedef enum CF_BlendOp
  * @function cf_blend_op_string
  * @category graphics
  * @brief    Returns a `CF_BlendOp` converted to a C string.
- * @related  CF_StencilOp cf_stencil_op_string CF_StencilFunction
+ * @related  cf_stencil_op_string CF_StencilOp CF_StencilFunction
  */
 CF_INLINE const char* cf_blend_op_string(CF_BlendOp op) {
 	switch (op) {
@@ -1310,7 +1310,7 @@ CF_INLINE const char* cf_blend_op_string(CF_BlendOp op) {
  * @category graphics
  * @brief    Blend factors to compose a blend equation.
  * @remarks  See `CF_BlendState` for an overview.
- * @related  CF_BlendFactor cf_blend_factor_string CF_BlendState
+ * @related  cf_blend_factor_string CF_BlendState
  */
 #define CF_BLENDFACTOR_DEFS \
 	/* @entry 0 */                                    \
@@ -1352,7 +1352,7 @@ typedef enum CF_BlendFactor
  * @function cf_blend_factor_string
  * @category graphics
  * @brief    Returns a `CF_BlendFactor` converted to a C string.
- * @related  CF_BlendFactor cf_blend_factor_string CF_BlendState
+ * @related  CF_BlendFactor CF_BlendState
  */
 CF_INLINE const char* cf_blend_factor_string(CF_BlendFactor factor) {
 	switch (factor) {
@@ -1367,7 +1367,7 @@ CF_INLINE const char* cf_blend_factor_string(CF_BlendFactor factor) {
  * @category graphics
  * @brief    Primitive topology used for rendering geometry.
  * @remarks  Controls how vertex input is interpreted as geometry.
- * @related  CF_PrimitiveType cf_primitive_type_string
+ * @related  cf_primitive_type_string
  */
 #define CF_PRIMITIVE_TYPE_DEFS \
 	/* @entry A series of separate triangles. */       \
@@ -1410,7 +1410,7 @@ CF_INLINE const char* cf_primitive_type_string(CF_PrimitiveType type) {
  * @remarks  The stencil buffer stores references values used for rendering with comparisons. Only comparisons that end up
  *           logically true pass the stencil test and end up getting drawn. For an overview of stencil testing [learnopengl.com
  *           has an excellent article](https://learnopengl.com/Advanced-OpenGL/Stencil-testing) on the topic.
- * @related  CF_StencilFunction CF_StencilParams CF_RenderState cf_material_set_render_state
+ * @related  cf_material_set_render_state CF_StencilParams
  */
 typedef struct CF_StencilFunction
 {
@@ -1433,7 +1433,7 @@ typedef struct CF_StencilFunction
  * @category graphics
  * @brief    Settings for the stencil buffer.
  * @remarks  For an overview of stencil testing [learnopengl.com has an excellent article](https://learnopengl.com/Advanced-OpenGL/Stencil-testing) on the topic.
- * @related  CF_StencilFunction CF_StencilParams CF_RenderState cf_material_set_render_state
+ * @related  cf_material_set_render_state CF_StencilFunction
  */
 typedef struct CF_StencilParams
 {
@@ -1510,7 +1510,7 @@ typedef struct CF_StencilParams
  *           this style as well. Here are some nice links on the topic.
  *           - https://developer.nvidia.com/content/alpha-blending-pre-or-not-pre
  *           - https://shawnhargreaves.com/blog/premultiplied-alpha.html
- * @related  CF_BlendFactor CF_BlendOp CF_RenderState cf_material_set_render_state
+ * @related  cf_material_set_render_state CF_BlendFactor CF_BlendOp
  */
 typedef struct CF_BlendState
 {
@@ -1560,7 +1560,7 @@ typedef struct CF_BlendState
  *           blending operations, depth and stencil settings, etc. Altering these on a material always means
  *           increasing your draw call count. It's best to try and set these once and leave them alone, though
  *           this is not always possible.
- * @related  CF_BlendState CF_CullMode CF_StencilParams cf_material_set_render_state
+ * @related  cf_material_set_render_state CF_BlendState CF_CullMode
  */
 typedef struct CF_RenderState
 {
@@ -1603,7 +1603,7 @@ typedef struct CF_RenderState
  * @function cf_render_state_defaults
  * @category graphics
  * @brief    Returns a good set of default parameters for a `CF_RenderState`.
- * @related  CF_RenderState cf_render_state_defaults cf_material_set_render_state
+ * @related  cf_material_set_render_state CF_RenderState
  */
 CF_API CF_RenderState CF_CALL cf_render_state_defaults(void);
 
@@ -1615,7 +1615,7 @@ CF_API CF_RenderState CF_CALL cf_render_state_defaults(void);
  * @category graphics
  * @brief    The available types of uniforms.
  * @remarks  A uniform is like a global variable for a shader. We set uniforms by using a `CF_Material`.
- * @related  CF_UniformType cf_uniform_type_string CF_Material cf_make_material
+ * @related  cf_uniform_type_string cf_make_material
  */
 #define CF_UNIFORM_TYPE_DEFS \
 	/* @entry In a shader: `uniform float` */  \
@@ -1649,7 +1649,7 @@ typedef enum CF_UniformType
  * @function cf_uniform_type_string
  * @category graphics
  * @brief    Returns a `CF_UniformType` converted to a C string.
- * @related  CF_UniformType cf_uniform_type_string CF_Material cf_make_material
+ * @related  cf_make_material CF_UniformType CF_Material
  */
 CF_INLINE const char* cf_uniform_type_string(CF_UniformType type) {
 	switch (type) {
@@ -1666,7 +1666,7 @@ CF_INLINE const char* cf_uniform_type_string(CF_UniformType type) {
  * @brief    Creates a new material.
  * @remarks  A material holds render state (see `CF_RenderState`), texture inputs (see `CF_Texture`), as well as shader inputs called
  *           uniforms (see `CF_UniformType`). For an overview see `CF_Material`.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs
  */
 CF_API CF_Material CF_CALL cf_make_material(void);
 
@@ -1674,7 +1674,7 @@ CF_API CF_Material CF_CALL cf_make_material(void);
  * @function cf_destroy_material
  * @category graphics
  * @brief    Frees up a material created by `cf_make_material`.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_make_material cf_material_set_render_state cf_material_set_texture_vs
  */
 CF_API void CF_CALL cf_destroy_material(CF_Material material);
 
@@ -1685,7 +1685,7 @@ CF_API void CF_CALL cf_destroy_material(CF_Material material);
  * @param    material      The material.
  * @param    render_state  The new render state to set on `material`.
  * @remarks  See `CF_RenderState` for an overview.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs
  */
 CF_API void CF_CALL cf_material_set_render_state(CF_Material material, CF_RenderState render_state);
 
@@ -1697,7 +1697,7 @@ CF_API void CF_CALL cf_material_set_render_state(CF_Material material, CF_Render
  * @param    name          The name of the texture, for referring to within a vertex shader.
  * @param    texture       Data (usually an image) for a shader to access.
  * @remarks  See `CF_Texture` and `CF_TextureParams` for an overview.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_texture_fs cf_material_set_render_state cf_material_set_uniform_vs
  */
 CF_API void CF_CALL cf_material_set_texture_vs(CF_Material material, const char* name, CF_Texture texture);
 
@@ -1709,7 +1709,7 @@ CF_API void CF_CALL cf_material_set_texture_vs(CF_Material material, const char*
  * @param    name          The name of the texture, for referring to within a fragment shader.
  * @param    texture       Data (usually an image) for a shader to access.
  * @remarks  See `CF_Texture` and `CF_TextureParams` for an overview.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_texture_vs cf_material_set_render_state cf_material_set_uniform_vs
  */
 CF_API void CF_CALL cf_material_set_texture_fs(CF_Material material, const char* name, CF_Texture texture);
 
@@ -1719,7 +1719,7 @@ CF_API void CF_CALL cf_material_set_texture_fs(CF_Material material, const char*
  * @brief    Clears all textures previously set by `cf_material_set_texture_vs` or `cf_material_set_texture_fs`.
  * @param    material      The material.
  * @remarks  See `CF_Texture` and `CF_TextureParams` for an overview.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs
  */
 CF_API void CF_CALL cf_material_clear_textures(CF_Material material);
 
@@ -1739,7 +1739,7 @@ CF_API void CF_CALL cf_material_clear_textures(CF_Material material);
  *
  *           `CF_Material`'s design supports using one material with various shaders, or using various materials with one shader. Since uniforms are
  *           grouped up into uniform blocks the performance overhead is usually quite minimal for setting a variety of uniform and shader combinations.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_uniform_fs cf_material_set_render_state cf_material_set_texture_vs
  */
 CF_API void CF_CALL cf_material_set_uniform_vs(CF_Material material, const char* name, void* data, CF_UniformType type, int array_length);
 
@@ -1759,7 +1759,7 @@ CF_API void CF_CALL cf_material_set_uniform_vs(CF_Material material, const char*
  *
  *           `CF_Material`'s design supports using one material with various shaders, or using various materials with one shader. Since uniforms are
  *           grouped up into uniform blocks the performance overhead is usually quite minimal for setting a variety of uniform and shader combinations.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_uniform_vs cf_material_set_render_state cf_material_set_texture_vs
  */
 CF_API void CF_CALL cf_material_set_uniform_fs(CF_Material material, const char* name, void* data, CF_UniformType type, int array_length);
 
@@ -1768,7 +1768,7 @@ CF_API void CF_CALL cf_material_set_uniform_fs(CF_Material material, const char*
  * @category graphics
  * @brief    Clears any uniforms previously set by `cf_material_set_uniform_vs` or `cf_material_set_uniform_fs`.
  * @param    material      The material.
- * @related  CF_UniformType CF_Material cf_make_material cf_destroy_material cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs cf_material_set_uniform_vs cf_material_set_uniform_fs
+ * @related  cf_material_set_render_state cf_material_set_texture_vs cf_material_set_texture_fs
  */
 CF_API void CF_CALL cf_material_clear_uniforms(CF_Material material);
 
@@ -1788,7 +1788,7 @@ CF_API void CF_CALL cf_clear_color(float red, float green, float blue, float alp
  * @category graphics
  * @brief    Sets the depth/stencil values used when clearing a canvas, if depth/stencil are enabled (see `CF_RenderState`).
  * @remarks  This will get used when `cf_apply_canvas` or when `cf_app_draw_onto_screen` is called and `clear` parameter is true.
- * @related  cf_clear_screen cf_clear_depth_stencil
+ * @related  cf_clear_screen
  */
 CF_API void CF_CALL cf_clear_depth_stencil(float depth, uint32_t stencil);
 
@@ -1798,7 +1798,7 @@ CF_API void CF_CALL cf_clear_depth_stencil(float depth, uint32_t stencil);
  * @brief    Sets up which canvas to draw to.
  * @param    canvas     The canvas to draw to.
  * @param    clear      Clears the screen to `cf_clear_color` if true.
- * @related  CF_Canvas cf_clear_color cf_apply_viewport cf_apply_scissor
+ * @related  cf_apply_viewport cf_apply_scissor cf_clear_color
  */
 CF_API void CF_CALL cf_apply_canvas(CF_Canvas canvas, bool clear);
 
@@ -1812,7 +1812,7 @@ CF_API void CF_CALL cf_apply_canvas(CF_Canvas canvas, bool clear);
  * @param    h          Height of the viewport in pixels.
  * @remarks  The viewport is a window on the screen to render within. The canvas will be stretched to fit onto the viewport. You must only call this
  *           after calling `cf_apply_shader`.
- * @related  cf_apply_canvas cf_apply_viewport cf_apply_scissor
+ * @related  cf_apply_canvas cf_apply_scissor
  */
 CF_API void CF_CALL cf_apply_viewport(int x, int y, int w, int h);
 
@@ -1827,7 +1827,7 @@ CF_API void CF_CALL cf_apply_viewport(int x, int y, int w, int h);
  * @remarks  The scissor box is a window on the screen that rendering will be clipped within. Any rendering that occurs outside the
  *           scissor box will simply be ignored, rendering nothing and leaving the previous pixel contents untouched. You must only call this
  *           after calling `cf_apply_shader`.
- * @related  cf_apply_canvas cf_apply_viewport cf_apply_scissor
+ * @related  cf_apply_canvas cf_apply_viewport
  */
 CF_API void CF_CALL cf_apply_scissor(int x, int y, int w, int h);
 
@@ -1856,7 +1856,7 @@ CF_API void CF_CALL cf_apply_blend_constants(float r, float g, float b, float a)
  * @brief    Uses a specific mesh for rendering.
  * @remarks  The mesh contains vertex data, defining the geometry to be rendered. The mesh vertices are sent to the GPU as inputs to
  *           the vertex shader. See `CF_Mesh` for an overview.
- * @related  CF_Mesh cf_create_mesh cf_apply_shader cf_draw_elements
+ * @related  cf_apply_shader cf_create_mesh cf_draw_elements
  */
 CF_API void CF_CALL cf_apply_mesh(CF_Mesh mesh);
 
@@ -1866,7 +1866,7 @@ CF_API void CF_CALL cf_apply_mesh(CF_Mesh mesh);
  * @brief    Uses a specific shader + material combo for rendering.
  * @remarks  The `CF_Shader` defines how to render a mesh's geometry, set by `cf_apply_mesh`. The `CF_Mesh` holds input geometry to the
  *           vertex shader. A `CF_Material` defines uniform and texture inputs to the shader.
- * @related  CF_Mesh cf_create_mesh cf_apply_shader cf_draw_elements
+ * @related  cf_create_mesh cf_draw_elements CF_Mesh
  */
 CF_API void CF_CALL cf_apply_shader(CF_Shader shader, CF_Material material);
 
@@ -1874,7 +1874,7 @@ CF_API void CF_CALL cf_apply_shader(CF_Shader shader, CF_Material material);
  * @function cf_draw_elements
  * @category graphics
  * @brief    Draws all elements within the last applied mesh.
- * @related  CF_Mesh cf_create_mesh cf_apply_shader cf_apply_canvas
+ * @related  cf_create_mesh cf_apply_shader cf_apply_canvas
  */
 CF_API void CF_CALL cf_draw_elements(void);
 
@@ -1883,7 +1883,7 @@ CF_API void CF_CALL cf_draw_elements(void);
  * @category graphics
  * @brief    Submits all previous draw commands to the GPU.
  * @remarks  You must call this after calling `cf_apply_shader` to "complete" the rendering pass.
- * @related  CF_Canvas cf_apply_canvas cf_apply_mesh cf_apply_shader
+ * @related  cf_apply_canvas cf_apply_mesh cf_apply_shader
  */
 CF_API void CF_CALL cf_commit(void);
 

--- a/include/cute_guid.h
+++ b/include/cute_guid.h
@@ -22,7 +22,7 @@ extern "C" {
  * @struct   CF_Guid
  * @category utility
  * @brief    A general purpose unique identifier.
- * @related  CF_Guid cf_make_guid cf_guid_equal
+ * @related  cf_guid_equal cf_make_guid
  */
 typedef struct CF_Guid
 {
@@ -36,7 +36,7 @@ typedef struct CF_Guid
  * @category utility
  * @brief    Returns a new `CF_Guid`.
  * @remarks  The bytes are generated in a cryptographically secure way.
- * @related  CF_Guid cf_make_guid cf_guid_equal
+ * @related  cf_guid_equal CF_Guid
  */
 CF_API CF_Guid CF_CALL cf_make_guid();
 
@@ -46,7 +46,7 @@ CF_API CF_Guid CF_CALL cf_make_guid();
  * @brief    Returns true if two `CF_Guid`'s are equal, false otherwise.
  * @param    a         A guid to compare.
  * @param    b         A guid to compare.
- * @related  CF_Guid cf_make_guid cf_guid_equal
+ * @related  cf_make_guid CF_Guid
  */
 CF_INLINE bool cf_guid_equal(CF_Guid a, CF_Guid b) { return !CF_MEMCMP(&a, &b, sizeof(a)); }
 

--- a/include/cute_haptics.h
+++ b/include/cute_haptics.h
@@ -32,7 +32,7 @@ extern "C" {
  *           - `cf_haptic_rumble_stop`
  *           
  *           TODO - Open haptic on the device itself (e.g. for phones).
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect
+ * @related  cf_haptic_open cf_haptic_close CF_HapticType
  */
 typedef struct CF_Haptic { uint64_t id; } CF_Haptic;
 // @end
@@ -65,7 +65,7 @@ typedef struct CF_Haptic { uint64_t id; } CF_Haptic;
  *           From (1) to (2) is the `attack_milliseconds`.
  *           From (1) to (4) is the effect duration (search for `duration_milliseconds` in this file).
  *           From (3) to (4) is the `fade_milliseconds`.
- * @related  CF_Haptic CF_HapticEnvelope CF_HapticEffect CF_HapticData cf_haptic_create_effect
+ * @related  cf_haptic_create_effect CF_HapticEffect CF_Haptic
  */
 typedef struct CF_HapticEnvelope
 {
@@ -87,7 +87,7 @@ typedef struct CF_HapticEnvelope
  * @enum     CF_HapticType
  * @category haptic
  * @brief    Various types of supported haptic effects.
- * @related  cf_haptic_type_to_string CF_HapticData CF_HapticLeftRight CF_HapticPeriodic CF_HapticRamp
+ * @related  cf_haptic_type_to_string CF_HapticData CF_HapticLeftRight
  */
 #define CF_HAPTIC_TYPE_DEFS \
 	/* @entry An invalid haptic type. */           \
@@ -112,7 +112,7 @@ typedef enum CF_HapticType
  * @category haptic
  * @brief    Converts a `CF_HapticType` to a C string.
  * @param    type       The type to convert.
- * @related  CF_HapticType cf_haptic_type_to_string
+ * @related  CF_HapticType
  */
 CF_INLINE const char* cf_haptic_type_to_string(CF_HapticType type)
 {
@@ -128,7 +128,7 @@ CF_INLINE const char* cf_haptic_type_to_string(CF_HapticType type)
  * @struct   CF_HapticLeftRight
  * @category haptic
  * @brief    The leftright haptic allows direct control of one larger and one smaller freqeuncy motors, as commonly found in game controllers.
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect cf_haptic_create_effect
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 typedef struct CF_HapticLeftRight
 {
@@ -147,7 +147,7 @@ typedef struct CF_HapticLeftRight
  * @enum     CF_HapticWaveType
  * @category haptic
  * @brief    Various types of supported haptic waves.
- * @related  CF_HapticWaveType cf_haptic_wave_type_to_string CF_HapticPeriodic CF_HapticEffect cf_haptic_create_effect
+ * @related  cf_haptic_wave_type_to_string cf_haptic_create_effect
  */
 #define CF_HAPTIC_WAVE_TYPE_DEFS \
 	/* @entry Sin wave haptic type. */         \
@@ -170,7 +170,7 @@ typedef enum CF_HapticWaveType
  * @category haptic
  * @brief    Converts a `CF_HapticWaveType` to a C string.
  * @param    type       The string to convert.
- * @related  CF_HapticWaveType cf_haptic_wave_type_to_string
+ * @related  CF_HapticWaveType
  */
 CF_INLINE const char* cf_haptic_wave_type_to_string(CF_HapticWaveType type)
 {
@@ -186,7 +186,7 @@ CF_INLINE const char* cf_haptic_wave_type_to_string(CF_HapticWaveType type)
  * @struct   CF_HapticPeriodic
  * @category haptic
  * @brief    A basic haptic for sine-based waveforms (https://en.wikipedia.org/wiki/Sine_wave).
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect cf_haptic_create_effect
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 typedef struct CF_HapticPeriodic
 {
@@ -211,7 +211,7 @@ typedef struct CF_HapticPeriodic
  * @struct   CF_HapticRamp
  * @category haptic
  * @brief    Adjusts the strength from `start` to `end` over `duration_milliseconds`.
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect cf_haptic_create_effect
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 typedef struct CF_HapticRamp
 {
@@ -233,7 +233,7 @@ typedef struct CF_HapticRamp
  * @struct   CF_HapticData
  * @category haptic
  * @brief    Container struct for all possible supported haptic types.
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect cf_haptic_create_effect CF_HapticRamp CF_HapticPeriodic CF_HapticLeftRight
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 typedef struct CF_HapticData
 {
@@ -262,7 +262,7 @@ typedef struct CF_HapticData
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @return   Returns a new `CF_Haptic`.
  * @remarks  Returns `NULL` upon any errors, including missing support from the underlying device.
- * @related  CF_Haptic CF_Joypad cf_haptic_open cf_haptic_close cf_haptic_create_effect cf_haptic_run_effect cf_haptic_rumble_play
+ * @related  cf_haptic_close cf_haptic_create_effect cf_haptic_run_effect
  */
 CF_API CF_Haptic CF_CALL cf_haptic_open(int player_index);
 
@@ -271,7 +271,7 @@ CF_API CF_Haptic CF_CALL cf_haptic_open(int player_index);
  * @category haptic
  * @brief    Frees up a `CF_Haptic` previously created by `cf_haptic_open`.
  * @param    haptic         The haptic.
- * @related  CF_Haptic cf_haptic_open cf_haptic_close cf_haptic_create_effect cf_haptic_run_effect cf_haptic_rumble_play
+ * @related  cf_haptic_create_effect cf_haptic_open cf_haptic_run_effect
  */
 CF_API void CF_CALL cf_haptic_close(CF_Haptic haptic);
 
@@ -282,7 +282,7 @@ CF_API void CF_CALL cf_haptic_close(CF_Haptic haptic);
  * @param    haptic         The haptic.
  * @param    type           The `CF_HapticType` to check support for.
  * @return   Returns true if supported, false otherwise.
- * @related  CF_Haptic cf_haptic_open cf_haptic_close cf_haptic_create_effect cf_haptic_run_effect
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 CF_API bool CF_CALL cf_haptic_supports(CF_Haptic haptic, CF_HapticType type);
 
@@ -292,7 +292,7 @@ CF_API bool CF_CALL cf_haptic_supports(CF_Haptic haptic, CF_HapticType type);
  * @brief    Sets the global gain for all haptics on this device.
  * @param    haptic         The haptic.
  * @param    gain           Must be from 0 to 1. This is like a global "volume" for the strength of all haptics that run on this device.
- * @related  CF_Haptic cf_haptic_open cf_haptic_close cf_haptic_create_effect cf_haptic_run_effect
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 CF_API void CF_CALL cf_haptic_set_gain(CF_Haptic haptic, float gain);
 
@@ -300,7 +300,7 @@ CF_API void CF_CALL cf_haptic_set_gain(CF_Haptic haptic, float gain);
  * @struct   CF_HapticEffect
  * @category haptic
  * @brief    An opaque handle representing a single instance of a `CF_HapticData` on a device.
- * @related  CF_Haptic CF_HapticType cf_haptic_open cf_haptic_close CF_HapticEffect cf_haptic_create_effect CF_HapticRamp CF_HapticPeriodic CF_HapticLeftRight
+ * @related  cf_haptic_open cf_haptic_close cf_haptic_create_effect
  */
 typedef struct CF_HapticEffect { int id; } CF_HapticEffect;
 // @end
@@ -312,7 +312,7 @@ typedef struct CF_HapticEffect { int id; } CF_HapticEffect;
  * @param    haptic         The haptic.
  * @param    data           The haptic specification.
  * @remarks  Run the haptic with `haptic_run_effect`.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_run_effect
+ * @related  cf_haptic_open cf_haptic_run_effect CF_Haptic
  */
 CF_API CF_HapticEffect CF_CALL cf_haptic_create_effect(CF_Haptic haptic, CF_HapticData data);
 
@@ -323,7 +323,7 @@ CF_API CF_HapticEffect CF_CALL cf_haptic_create_effect(CF_Haptic haptic, CF_Hapt
  * @param    haptic         The haptic.
  * @param    effect         The haptic effect created by `cf_haptic_create_effect`.
  * @param    iterations     A number of times to play the effect.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_run_effect cf_haptic_stop_effect
+ * @related  cf_haptic_open cf_haptic_create_effect cf_haptic_stop_effect
  */
 CF_API void CF_CALL cf_haptic_run_effect(CF_Haptic haptic, CF_HapticEffect effect, int iterations);
 
@@ -334,7 +334,7 @@ CF_API void CF_CALL cf_haptic_run_effect(CF_Haptic haptic, CF_HapticEffect effec
  * @param    haptic         The haptic.
  * @param    effect         The haptic effect created by `cf_haptic_create_effect`.
  * @param    data           The updated haptic specification.
- * @related  CF_Haptic cf_haptic_open CF_HapticData CF_HapticEffect cf_haptic_create_effect cf_haptic_run_effect cf_haptic_stop_effect
+ * @related  cf_haptic_open cf_haptic_create_effect cf_haptic_run_effect
  */
 CF_API void CF_CALL cf_haptic_update_effect(CF_Haptic haptic, CF_HapticEffect effect, CF_HapticData data);
 
@@ -345,7 +345,7 @@ CF_API void CF_CALL cf_haptic_update_effect(CF_Haptic haptic, CF_HapticEffect ef
  * @param    haptic         The haptic.
  * @param    effect         The haptic effect created by `cf_haptic_create_effect`.
  * @remarks  The effect is not destroyed.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_stop_effect cf_haptic_destroy_effect cf_haptic_pause cf_haptic_unpause cf_haptic_stop_all
+ * @related  cf_haptic_stop_all cf_haptic_open cf_haptic_create_effect
  */
 CF_API void CF_CALL cf_haptic_stop_effect(CF_Haptic haptic, CF_HapticEffect effect);
 
@@ -355,7 +355,7 @@ CF_API void CF_CALL cf_haptic_stop_effect(CF_Haptic haptic, CF_HapticEffect effe
  * @brief    Destroys an instance of an effect on the device.
  * @param    haptic         The haptic.
  * @param    effect         The haptic effect created by `cf_haptic_create_effect`.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_stop_effect cf_haptic_destroy_effect cf_haptic_pause cf_haptic_unpause cf_haptic_stop_all
+ * @related  cf_haptic_open cf_haptic_create_effect cf_haptic_stop_effect
  */
 CF_API void CF_CALL cf_haptic_destroy_effect(CF_Haptic haptic, CF_HapticEffect effect);
 
@@ -364,7 +364,7 @@ CF_API void CF_CALL cf_haptic_destroy_effect(CF_Haptic haptic, CF_HapticEffect e
  * @category haptic
  * @brief    Pause all haptics on the device.
  * @param    haptic         The haptic.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_stop_effect cf_haptic_destroy_effect cf_haptic_pause cf_haptic_unpause cf_haptic_stop_all
+ * @related  cf_haptic_open cf_haptic_create_effect cf_haptic_stop_effect
  */
 CF_API void CF_CALL cf_haptic_pause(CF_Haptic haptic);
 
@@ -373,7 +373,7 @@ CF_API void CF_CALL cf_haptic_pause(CF_Haptic haptic);
  * @category haptic
  * @brief    Unpause all haptics on the device.
  * @param    haptic         The haptic.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_stop_effect cf_haptic_destroy_effect cf_haptic_pause cf_haptic_unpause cf_haptic_stop_all
+ * @related  cf_haptic_open cf_haptic_create_effect cf_haptic_stop_effect
  */
 CF_API void CF_CALL cf_haptic_unpause(CF_Haptic haptic);
 
@@ -383,7 +383,7 @@ CF_API void CF_CALL cf_haptic_unpause(CF_Haptic haptic);
  * @brief    Stops all haptics on the device.
  * @param    haptic         The haptic.
  * @remarks  The effects are not destroyed.
- * @related  CF_Haptic cf_haptic_open CF_HapticEffect cf_haptic_create_effect cf_haptic_stop_effect cf_haptic_destroy_effect cf_haptic_pause cf_haptic_unpause cf_haptic_stop_all
+ * @related  cf_haptic_stop_effect cf_haptic_open cf_haptic_create_effect
  */
 CF_API void CF_CALL cf_haptic_stop_all(CF_Haptic haptic);
 
@@ -395,7 +395,7 @@ CF_API void CF_CALL cf_haptic_stop_all(CF_Haptic haptic);
  * @brief    Checks to see if a simple sine/leftright haptic can be supported on the device.
  * @param    haptic         The haptic.
  * @remarks  Creates a set of decent parameters to play a rumbling effect in an easy to use way.
- * @related  CF_Haptic cf_haptic_open cf_haptic_rumble_supported cf_haptic_rumble_play cf_haptic_rumble_stop
+ * @related  cf_haptic_rumble_stop cf_haptic_rumble_play cf_haptic_open
  */
 CF_API bool CF_CALL cf_haptic_rumble_supported(CF_Haptic haptic);
 
@@ -407,7 +407,7 @@ CF_API bool CF_CALL cf_haptic_rumble_supported(CF_Haptic haptic);
  * @param    strength               Must be from 0.0f to 1.0f. How strong the rumble is.
  * @param    duration_milliseconds  The duration of the rumble in milliseconds.
  * @remarks  Successive calls on this function will update the underlying rumble effect, instead of creating and playing multiple different effect instances.
- * @related  CF_Haptic cf_haptic_open cf_haptic_rumble_supported cf_haptic_rumble_play cf_haptic_rumble_stop
+ * @related  cf_haptic_rumble_supported cf_haptic_rumble_stop cf_haptic_open
  */
 CF_API void CF_CALL cf_haptic_rumble_play(CF_Haptic haptic, float strength, int duration_milliseconds);
 
@@ -417,7 +417,7 @@ CF_API void CF_CALL cf_haptic_rumble_play(CF_Haptic haptic, float strength, int 
  * @brief    Stops playing the simple rumble effect.
  * @param    haptic         The haptic.
  * @remarks  See `cf_haptic_rumble_play` for more details.
- * @related  CF_Haptic cf_haptic_open cf_haptic_rumble_supported cf_haptic_rumble_play cf_haptic_rumble_stop
+ * @related  cf_haptic_rumble_supported cf_haptic_rumble_play cf_haptic_open
  */
 CF_API void CF_CALL cf_haptic_rumble_stop(CF_Haptic haptic);
 

--- a/include/cute_hashtable.h
+++ b/include/cute_hashtable.h
@@ -44,7 +44,7 @@
  *           on typed pointers, there's no actual hashtable struct type. It can get really annoying to sometimes forget if a pointer is an
  *           array, a hashtable, or just a pointer. This macro can be used to markup the type to make it much more clear for function
  *           parameters or struct member definitions. It's saying "Hey, I'm a hashtable!" to mitigate this downside.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hset hadd hget
  */
 #define htbl
 
@@ -66,7 +66,7 @@
  * @remarks  If the item does not exist in the table it is added. The pointer returned is not stable. Internally the table can be resized,
  *           invalidating _all_ pointers to any elements within the table. Therefor, no items may store pointers to themselves or other items.
  *           Indices however, are totally fine.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hswap hsize htbl
  */
 #define hset(h, k, ...) cf_hashtable_set(h, k, (__VA_ARGS__))
 
@@ -88,7 +88,7 @@
  * @remarks  This function works the same as `hset`. If the item already exists in the table, it's simply updated to a new value.
  *           The pointer returned is not stable. Internally the table can be resized, invalidating _all_ pointers to any elements
  *           within the table. Therefor, no items may store pointers to themselves or other items. Indices however, are totally fine.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  htbl hset hget
  */
 #define hadd(h, k, ...) cf_hashtable_add(h, k, (__VA_ARGS__))
 
@@ -109,7 +109,7 @@
  * @remarks  Items are returned by value, not pointer. If the item doesn't exist a zero'd out item is instead returned. If you want to get a pointer
  *           (so you can see if it's `NULL` in case the item didn't exist, then use `hget_ptr`). You can also call `hhas` for a bool. This function does
  *           the same as `hfind`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hget_ptr htbl hset
  */
 #define hget(h, k) cf_hashtable_get(h, k)
 
@@ -130,7 +130,7 @@
  * @remarks  Items are returned by value, not pointer. If the item doesn't exist a zero'd out item is instead returned. If you want to get a pointer
  *           (so you can see if it's `NULL` in case the item didn't exist, then use `hfind_ptr`). You can also call `hhas` for a bool. This function does
  *           the same as `hget`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hfind_ptr hfree htbl
  */
 #define hfind(h, k) cf_hashtable_find(h, k)
 
@@ -150,7 +150,7 @@
  *     hfree(table);
  * @return   Returns a pointer to an item. Returns `NULL` if not found.
  * @remarks  If you want to fetch an item by value, you can use `hget` or `hfind`. Does the same thing as `hfind_ptr`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hget htbl hset
  */
 #define hget_ptr(h, k) cf_hashtable_get_ptr(h, k)
 
@@ -170,7 +170,7 @@
  *     hfree(table);
  * @return   Returns a pointer to an item. Returns `NULL` if not found.
  * @remarks  If you want to fetch an item by value, you can use `hget` or `hfind`. Does the same thing as `hget_ptr`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hfind hfree htbl
  */
 #define hfind_ptr(h, k) cf_hashtable_find_ptr(h, k)
 
@@ -186,7 +186,7 @@
  *     CF_ASSERT(hhas(table, 10));
  *     hfree(table);
  * @return   Returns true if the item was found, false otherwise.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  htbl hset hadd
  */
 #define hhas(h, k) cf_hashtable_has(h, k)
 
@@ -202,7 +202,7 @@
  *     hdel(table, 10);
  *     hfree(table);
  * @remarks  Asserts if the item does not exist.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  htbl hset hadd
  */
 #define hdel(h, k) cf_hashtable_del(h, k)
 
@@ -212,7 +212,7 @@
  * @brief    Clears the hashtable.
  * @param    h        The hashtable. Can be `NULL`. Needs to be a pointer to the type of items in the table.
  * @remarks  The count of items will now be zero. Does not free any memory. Call `hfree` when you are done.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hcount htbl hset
  */
 #define hclear(h) cf_hashtable_clear(h)
 
@@ -230,7 +230,7 @@
  *         // ...
  *     }
  * @remarks  The keys are type `uint64_t`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  htbl hset hadd
  */
 #define hkeys(h) cf_hashtable_keys(h)
 
@@ -248,7 +248,7 @@
  *         // ...
  *     }
  * @remarks  This macro doesn't do much as `h` is already a valid pointer to the items.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  htbl hset hadd
  */
 #define hitems(h) cf_hashtable_items(h)
 
@@ -270,7 +270,7 @@
  *         }
  *     }
  * @remarks  Use this for e.g. implementing a priority queue on top of the hash table.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree hsort hssort hsisort
+ * @related  hset hsize hsort
  */
 #define hswap(h, index_a, index_b) cf_hashtable_swap(h, index_a, index_b)
 
@@ -281,7 +281,7 @@
  * @param    h        The hashtable. Can be `NULL`. Needs to be a pointer to the type of items in the table.
  * @remarks  The keys and items returned by `hkeys` and `hitems` will be sorted. Recall that all keys in the hashtable are treated
  *           as `uint64_t`, so the sorting simply sorts the keys from least to greatest as `uint64_t`. This is _not_ a stable sort.
- * @related  htbl hswap hsort hssort hsisort
+ * @related  hswap hssort hsisort
  */
 #define hsort(h) cf_hashtable_sort(h)
 
@@ -293,7 +293,7 @@
  * @remarks  The keys and items returned by `hkeys` and `hitems` will be sorted. Normally it's not valid to store strings as keys,
  *           since all keys are simply typecasted to `uint64_t`. However, if you use `sintern` each unique string has a unique and
  *           stable pointer, making them valid keys for hashtables. This is _not_ a stable sort.
- * @related  htbl hswap hsort hssort hsisort sintern
+ * @related  hswap hsort hsisort
  */
 #define hssort(h) cf_hashtable_ssort(h)
 
@@ -306,7 +306,7 @@
  * @remarks  The keys and items returned by `hkeys` and `hitems` will be sorted. Normally it's not valid to store strings as keys,
  *           since all keys are simply typecasted to `uint64_t`. However, if you use `sintern` each unique string has a unique and
  *           stable pointer, making them valid keys for hashtables. This is _not_ a stable sort.
- * @related  htbl hswap hsort hssort hsisort sintern
+ * @related  hswap hsort hssort
  */
 #define hsisort(h) cf_hashtable_sisort(h)
 
@@ -316,7 +316,7 @@
  * @brief    The number of {key, item} pairs in the table.
  * @param    h        The hashtable. Can be `NULL`. Needs to be a pointer to the type of items in the table.
  * @remarks  `h` can be `NULL`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hset hswap htbl
  */
 #define hsize(h) cf_hashtable_size(h)
 
@@ -326,7 +326,7 @@
  * @brief    The number of {key, item} pairs in the table.
  * @param    h        The hashtable. Can be `NULL`. Needs to be a pointer to the type of items in the table.
  * @remarks  `h` can be `NULL`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hclear htbl hset
  */
 #define hcount(h) cf_hashtable_count(h)
 
@@ -336,7 +336,7 @@
  * @brief    Frees up all resources used and sets `h` to `NULL`.
  * @param    h        The hashtable. Can be `NULL`. Needs to be a pointer to the type of items in the table.
  * @remarks  `h` can be `NULL`.
- * @related  htbl hset hadd hget hfind hget_ptr hfind_ptr hhas hdel hclear hkeys hitems hswap hsize hcount hfree
+ * @related  hfind hfind_ptr htbl
  */
 #define hfree(h) cf_hashtable_free(h)
 

--- a/include/cute_https.h
+++ b/include/cute_https.h
@@ -60,7 +60,7 @@ extern "C" {
  *     }
  * @remarks  You may create a request by calling either `cf_https_get` or `cf_https_post`. It is intended to continually
  *           call `cf_https_process` in a loop until the request generates a response, or fails.
- * @related  CF_HttpsRequest CF_HttpsResponse cf_https_get cf_https_post
+ * @related  cf_https_get cf_https_post CF_HttpsResponse
  */
 typedef struct CF_HttpsRequest { uint64_t id; } CF_HttpsRequest;
 // @end
@@ -70,7 +70,7 @@ typedef struct CF_HttpsRequest { uint64_t id; } CF_HttpsRequest;
  * @category web
  * @brief    Represents an [HTTPS response](https://www.ibm.com/docs/en/cics-ts/5.2?topic=protocol-http-responses).
  * @remarks  The response may be fetched from a `CF_HttpsRequest` by calling `cf_https_response`.
- * @related  CF_HttpsRequest CF_HttpsResponse cf_https_response cf_https_response_find_header cf_https_response_content
+ * @related  cf_https_response cf_https_response_find_header cf_https_response_content
  */
 typedef struct CF_HttpsResponse { uint64_t id; } CF_HttpsResponse;
 // @end
@@ -80,7 +80,7 @@ typedef struct CF_HttpsResponse { uint64_t id; } CF_HttpsResponse;
  * @category web
  * @brief    Represents an [HTTPS header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers).
  * @remarks  Headers may be fetched from a `CF_HttpsResponse` by calling `cf_https_response_find_header`, or `cf_https_response_headers`.
- * @related  CF_HttpsRequest CF_HttpsResponse CF_HttpsHeader cf_https_response_find_header cf_https_response_headers
+ * @related  cf_https_response_find_header cf_https_response_headers CF_HttpsRequest
  */
 typedef struct CF_HttpsHeader
 {
@@ -102,7 +102,7 @@ typedef struct CF_HttpsHeader
  * @param    verify_cert  Recommended as true. Set to true to verify the server certificate (you want this on).
  * @return   Returns a `CF_HttpsRequest` for processing the get request and receiving a response.
  * @remarks  You should continually call `cf_https_process` on the `CF_HttpsRequest`. See `CF_HttpsRequest` for details.
- * @related  CF_HttpsRequest cf_https_get cf_https_post cf_https_destroy cf_https_process cf_https_response
+ * @related  cf_https_post cf_https_destroy cf_https_process
  */
 CF_API CF_HttpsRequest CF_CALL cf_https_get(const char* host, int port, const char* uri, bool verify_cert);
 
@@ -119,7 +119,7 @@ CF_API CF_HttpsRequest CF_CALL cf_https_get(const char* host, int port, const ch
  * @param    verify_cert  Recommended as true. Set to true to verify the server certificate (you want this on).
  * @return   Returns a `CF_HttpsRequest` for processing the get request and receiving a response.
  * @remarks  You should continually call `cf_https_process` on the `CF_HttpsRequest`. See `CF_HttpsRequest` for details.
- * @related  CF_HttpsRequest cf_https_get cf_https_post cf_https_destroy cf_https_process cf_https_response
+ * @related  cf_https_process cf_https_get cf_https_destroy
  */
 CF_API CF_HttpsRequest CF_CALL cf_https_post(const char* host, int port, const char* uri, const void* content, int content_length, bool verify_cert);
 
@@ -131,7 +131,7 @@ CF_API CF_HttpsRequest CF_CALL cf_https_post(const char* host, int port, const c
  * @param    name       The key value of the header.
  * @param    value      String representation of the header's value.
  * @remarks  You should call this before calling `cf_https_process`. Calling this after `cf_https_process` will break things.
- * @related  CF_HttpsRequest cf_https_get cf_https_post cf_https_destroy cf_https_process cf_https_response
+ * @related  cf_https_get cf_https_post cf_https_destroy
  */
 CF_API void CF_CALL cf_https_add_header(CF_HttpsRequest request, const char* name, const char* value);
 
@@ -139,7 +139,7 @@ CF_API void CF_CALL cf_https_add_header(CF_HttpsRequest request, const char* nam
  * @function cf_https_destroy
  * @category web
  * @brief    Destroys a `CF_HttpsRequest`.
- * @related  CF_HttpsRequest cf_https_get cf_https_post cf_https_destroy cf_https_process cf_https_response
+ * @related  cf_https_get cf_https_post cf_https_process
  */
 CF_API void CF_CALL cf_https_destroy(CF_HttpsRequest request);
 
@@ -148,7 +148,7 @@ CF_API void CF_CALL cf_https_destroy(CF_HttpsRequest request);
  * @category web
  * @brief    Status of a `CF_HttpsRequest`.
  * @remarks  Intended to be used in a loop, along with `cf_https_process`. See `CF_HttpsRequest`.
- * @related  CF_HttpsRequest cf_https_process cf_https_result_to_string
+ * @related  cf_https_process cf_https_result_to_string CF_HttpsRequest
  */
 #define CF_HTTPS_RESULT_DEFS \
 	/* @entry The server has an invalid certificate. */          \
@@ -183,7 +183,7 @@ typedef enum CF_HttpsResult
  * @category web
  * @brief    Convert an enum `CF_HttpsState` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_HttpsRequest cf_https_process cf_https_result_to_string
+ * @related  cf_https_process CF_HttpsRequest
  */
 CF_INLINE const char* cf_https_result_to_string(CF_HttpsResult state)
 {
@@ -201,7 +201,7 @@ CF_INLINE const char* cf_https_result_to_string(CF_HttpsResult state)
  * @brief    Processes a request and generates a response.
  * @return   Returns the status of the request `CF_HttpsResult`.
  * @remarks  You should call this function in a loop. See `CF_HttpsResult`.
- * @related  CF_HttpsResult cf_https_process cf_https_get cf_https_post cf_https_response
+ * @related  cf_https_post cf_https_get cf_https_response
  */
 CF_API CF_HttpsResult CF_CALL cf_https_process(CF_HttpsRequest request);
 
@@ -212,7 +212,7 @@ CF_API CF_HttpsResult CF_CALL cf_https_process(CF_HttpsRequest request);
  * @remarks  A response can be retrieved from the `https` object after `cf_https_state` returns `CF_HTTPS_STATE_COMPLETED`.
  *           Calling this function otherwise will get you a NULL pointer returned. This will get cleaned up automatically
  *           when `cf_https_destroy` is called.
- * @related  CF_Https cf_https_get cf_https_post cf_https_destroy cf_https_process cf_https_response cf_https_state
+ * @related  cf_https_get cf_https_post cf_https_destroy
  */
 CF_API CF_HttpsResponse CF_CALL cf_https_response(CF_HttpsRequest request);
 
@@ -220,7 +220,7 @@ CF_API CF_HttpsResponse CF_CALL cf_https_response(CF_HttpsRequest request);
  * @function cf_https_response_code
  * @category web
  * @brief    Returns the HTTP code for the response.
- * @related  CF_HttpsResponse cf_https_response cf_https_response_code
+ * @related  cf_https_response CF_HttpsResponse
  */
 CF_API int CF_CALL cf_https_response_code(CF_HttpsResponse response);
 
@@ -228,7 +228,7 @@ CF_API int CF_CALL cf_https_response_code(CF_HttpsResponse response);
  * @function cf_https_response_content_length
  * @category web
  * @brief    Returns the length of the response content.
- * @related  CF_HttpsResponse cf_https_response cf_https_response_content
+ * @related  cf_https_response_content cf_https_response CF_HttpsResponse
  */
 CF_API int CF_CALL cf_https_response_content_length(CF_HttpsResponse response);
 
@@ -236,7 +236,7 @@ CF_API int CF_CALL cf_https_response_content_length(CF_HttpsResponse response);
  * @function cf_https_response_content
  * @category web
  * @brief    Returns the content of the response as a string.
- * @related  CF_HttpsResponse cf_https_response_content cf_https_response_content_length
+ * @related  cf_https_response_content_length CF_HttpsResponse
  */
 CF_API char* CF_CALL cf_https_response_content(CF_HttpsResponse response);
 
@@ -246,7 +246,7 @@ CF_API char* CF_CALL cf_https_response_content(CF_HttpsResponse response);
  * @brief    Searches for and returns a header by name.
  * @param    response     The HTTP response.
  * @param    header_name  The name of the header to search for.
- * @related  CF_HttpsHeader CF_HttpsResponse cf_https_response_find_header cf_https_response_headers
+ * @related  cf_https_response_headers CF_HttpsHeader CF_HttpsResponse
  */
 CF_API CF_HttpsHeader CF_CALL cf_https_response_find_header(CF_HttpsResponse response, const char* header_name);
 
@@ -255,7 +255,7 @@ CF_API CF_HttpsHeader CF_CALL cf_https_response_find_header(CF_HttpsResponse res
  * @category web
  * @brief    Returns the number of headers in the response.
  * @remarks  Intended to be used with `cf_https_response_headers`.
- * @related  CF_HttpsHeader CF_HttpsResponse cf_https_response_find_header cf_https_response_headers
+ * @related  cf_https_response_headers cf_https_response_find_header CF_HttpsHeader
  */
 CF_API int CF_CALL cf_https_response_headers_count(CF_HttpsResponse response);
 
@@ -266,7 +266,7 @@ CF_API int CF_CALL cf_https_response_headers_count(CF_HttpsResponse response);
  * @remarks  Intended to be used with `cf_https_response_headers_count`. Do not free this array, it will
  *           get cleaned up when the originating `CF_HttpsRequest` is destroyed via `cf_https_destroy`.
  *           If you're familiar with `htbl` you may treat this pointer as a hashtable key'd by strings.
- * @related  CF_HttpsHeader CF_HttpsResponse cf_https_response_find_header cf_https_response_headers
+ * @related  cf_https_response_find_header CF_HttpsHeader CF_HttpsResponse
  */
 CF_API htbl const CF_HttpsHeader* CF_CALL cf_https_response_headers(CF_HttpsResponse response);
 

--- a/include/cute_image.h
+++ b/include/cute_image.h
@@ -26,7 +26,7 @@ extern "C" {
  * @remarks  You probably do not need this. In Cute Framework loading images manually is not often
  *           necessary, as most games can use CF's [Draw API](https://randygaul.github.io/cute_framework/topics/drawing) to get sprites onto the screen.
  *           However, a good use case is, for example, if you want to implement some custom shader and feed it a texture.
- * @related  CF_Image CF_ImageIndexed cf_image_load_png cf_image_premultiply
+ * @related  cf_image_load_png cf_image_premultiply CF_ImageIndexed
  */
 typedef struct CF_Image
 {
@@ -48,7 +48,7 @@ typedef struct CF_Image
  * @remarks  You probably do not need this. In Cute Framework loading images manually is not often
  *           necessary, as most games can use CF's [Draw API](https://randygaul.github.io/cute_framework/topics/drawing) to get sprites onto the screen.
  *           However, a good use case is, for example, if you want to implement some custom shader and feed it a texture.
- * @related  CF_Image CF_ImageIndexed cf_image_load_png
+ * @related  cf_image_load_png CF_Image
  */
 typedef struct CF_ImageIndexed
 {
@@ -79,7 +79,7 @@ typedef struct CF_ImageIndexed
  * @param    virtual_path  A virtual path to the image file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @param    img           Out parameter for the image.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_Image cf_image_load_png cf_image_free cf_image_load_png_from_memory cf_image_load_png_wh cf_image_load_png_indexed cf_image_premultiply
+ * @related  cf_image_load_png_from_memory cf_image_load_png_wh cf_image_load_png_indexed
  */
 CF_API CF_Result CF_CALL cf_image_load_png(const char* virtual_path, CF_Image* img);
 
@@ -91,7 +91,7 @@ CF_API CF_Result CF_CALL cf_image_load_png(const char* virtual_path, CF_Image* i
  * @param    size          The number of bytes in the `data` pointer.
  * @param    img           Out parameter for the image.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_Image cf_image_load_png cf_image_load_png_from_memory cf_image_load_png_wh cf_image_load_png_indexed cf_image_premultiply
+ * @related  cf_image_load_png_wh cf_image_load_png_indexed cf_image_load_png
  */
 CF_API CF_Result CF_CALL cf_image_load_png_from_memory(const void* data, int size, CF_Image* img);
 
@@ -104,7 +104,7 @@ CF_API CF_Result CF_CALL cf_image_load_png_from_memory(const void* data, int siz
  * @param    w             Out parameter for the width of the image.
  * @param    h             Out parameter for the height of the image.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_Image cf_image_load_png cf_image_load_png_from_memory cf_image_load_png_wh cf_image_load_png_indexed cf_image_premultiply
+ * @related  cf_image_load_png_from_memory cf_image_load_png_indexed cf_image_load_png
  */
 CF_API CF_Result CF_CALL cf_image_load_png_wh(const void* data, int size, int* w, int* h);
 
@@ -114,7 +114,7 @@ CF_API CF_Result CF_CALL cf_image_load_png_wh(const void* data, int size, int* w
  * @brief    Frees a png image.
  * @param    img           The image to free.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_Image cf_image_load_png cf_image_free cf_image_load_png_from_memory cf_image_load_png_wh cf_image_load_png_indexed cf_image_premultiply
+ * @related  cf_image_load_png cf_image_load_png_from_memory cf_image_load_png_wh
  */
 CF_API void CF_CALL cf_image_free(CF_Image* img);
 
@@ -125,7 +125,7 @@ CF_API void CF_CALL cf_image_free(CF_Image* img);
  * @param    virtual_path  A virtual path to the image file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @param    img           Out parameter for the image.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_ImageIndexed cf_image_load_png_indexed cf_image_load_png_from_memory_indexed cf_image_free_indexed cf_image_depallete
+ * @related  cf_image_load_png_from_memory_indexed cf_image_free_indexed cf_image_depallete
  */
 CF_API CF_Result CF_CALL cf_image_load_png_indexed(const char* virtual_path, CF_ImageIndexed* img);
 
@@ -137,7 +137,7 @@ CF_API CF_Result CF_CALL cf_image_load_png_indexed(const char* virtual_path, CF_
  * @param    size          The number of bytes in the `data` pointer.
  * @param    img           Out parameter for the image.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_ImageIndexed cf_image_load_png_indexed cf_image_load_png_from_memory_indexed cf_image_free_indexed cf_image_depallete
+ * @related  cf_image_load_png_indexed cf_image_free_indexed cf_image_depallete
  */
 CF_API CF_Result CF_CALL cf_image_load_png_from_memory_indexed(const void* data, int size, CF_ImageIndexed* img);
 
@@ -147,7 +147,7 @@ CF_API CF_Result CF_CALL cf_image_load_png_from_memory_indexed(const void* data,
  * @brief    Frees an indexed png image.
  * @param    img           The image to free.
  * @return   Check the `CF_Result` for errors.
- * @related  CF_ImageIndexed cf_image_load_png_indexed cf_image_load_png_from_memory_indexed cf_image_free_indexed cf_image_depallete
+ * @related  cf_image_load_png_indexed cf_image_load_png_from_memory_indexed cf_image_depallete
  */
 CF_API void CF_CALL cf_image_free_indexed(CF_ImageIndexed* img);
 
@@ -160,7 +160,7 @@ CF_API void CF_CALL cf_image_free_indexed(CF_ImageIndexed* img);
  * @brief    Converts a paletted image to a typical image with an array of pixels.
  * @param    img           The image to depalette.
  * @return   Returns an image without a palette.
- * @related  CF_Image CF_ImageIndexed cf_image_load_png_indexed
+ * @related  cf_image_load_png_indexed CF_Image CF_ImageIndexed
  */
 CF_API CF_Image CF_CALL cf_image_depallete(CF_ImageIndexed* img);
 
@@ -189,7 +189,7 @@ CF_API void CF_CALL cf_image_flip_horizontal(CF_Image* img);
  * @brief    Saves out greyscale image to a png file on disk.
  * @remarks  Does *not* use the virtual file system. Instead it uses plain old platform-dependent path notation. This
  *           function is not really optimized whatsoever and outputs poorly compressed file sizes.
- * @related  CF_Image cf_debug_dump_greyscale_pixels cf_debug_dump_pixels
+ * @related  cf_debug_dump_pixels CF_Image
  */
 CF_API void CF_CALL cf_debug_dump_greyscale_pixels(const char* path, uint8_t* pixels, int w, int h);
 
@@ -199,7 +199,7 @@ CF_API void CF_CALL cf_debug_dump_greyscale_pixels(const char* path, uint8_t* pi
  * @brief    Saves out an image to a png file on disk.
  * @remarks  Does *not* use the virtual file system. Instead it uses plain old platform-dependent path notation. This
  *           function is not really optimized whatsoever and outputs poorly compressed file sizes.
- * @related  CF_Image cf_debug_dump_greyscale_pixels cf_debug_dump_pixels
+ * @related  cf_debug_dump_greyscale_pixels CF_Image
  */
 CF_API void CF_CALL cf_debug_dump_pixels(const char* path, CF_Pixel* pixels, int w, int h);
 

--- a/include/cute_input.h
+++ b/include/cute_input.h
@@ -21,7 +21,7 @@ extern "C" {
  * @enum     CF_MouseButton
  * @category input
  * @brief    The mouse buttons.
- * @related  CF_MouseButton cf_mouse_button_to_string cf_mouse_down
+ * @related  cf_mouse_button_to_string cf_mouse_down
  */
 #define CF_MOUSE_BUTTON_DEFS \
 	/* @entry */ \
@@ -50,7 +50,7 @@ typedef enum CF_MouseButton
  * @category input
  * @brief    Convert an enum `CF_MouseButton` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_MouseButton cf_mouse_button_to_string cf_mouse_down
+ * @related  cf_mouse_down CF_MouseButton
  */
 CF_INLINE const char* cf_mouse_button_to_string(CF_MouseButton button)
 {
@@ -66,7 +66,7 @@ CF_INLINE const char* cf_mouse_button_to_string(CF_MouseButton button)
  * @enum     CF_KeyButton
  * @category input
  * @brief    The keys.
- * @related  CF_KeyButton cf_key_button_to_string cf_key_down
+ * @related  cf_key_button_to_string cf_key_down
  */
 #define CF_KEY_BUTTON_DEFS \
 	/* @entry */ \
@@ -557,7 +557,7 @@ typedef enum CF_KeyButton
  * @category input
  * @brief    Convert an enum `CF_KeyButton` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_KeyButton cf_key_button_to_string cf_key_down
+ * @related  cf_key_down CF_KeyButton
  */
 CF_INLINE const char* cf_key_button_to_string(CF_KeyButton button)
 {
@@ -573,7 +573,7 @@ CF_INLINE const char* cf_key_button_to_string(CF_KeyButton button)
  * @function cf_key_down
  * @category input
  * @brief    Returns true if a key is currently down.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_up cf_key_just_pressed cf_key_just_released
  */
 CF_API bool CF_CALL cf_key_down(CF_KeyButton key);
 
@@ -581,7 +581,7 @@ CF_API bool CF_CALL cf_key_down(CF_KeyButton key);
  * @function cf_key_up
  * @category input
  * @brief    Returns true if a key is currently up.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_down cf_key_just_pressed cf_key_just_released
  */
 CF_API bool CF_CALL cf_key_up(CF_KeyButton key);
 
@@ -589,7 +589,7 @@ CF_API bool CF_CALL cf_key_up(CF_KeyButton key);
  * @function cf_key_just_pressed
  * @category input
  * @brief    Returns true if a key was just pressed.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_just_released cf_key_down cf_key_up
  */
 CF_API bool CF_CALL cf_key_just_pressed(CF_KeyButton key);
 
@@ -597,7 +597,7 @@ CF_API bool CF_CALL cf_key_just_pressed(CF_KeyButton key);
  * @function cf_key_just_released
  * @category input
  * @brief    Returns true if a key was just released.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_just_pressed cf_key_down cf_key_up
  */
 CF_API bool CF_CALL cf_key_just_released(CF_KeyButton key);
 
@@ -605,7 +605,7 @@ CF_API bool CF_CALL cf_key_just_released(CF_KeyButton key);
  * @function cf_key_repeating
  * @category input
  * @brief    Returns true if a key was held long enough to repeat.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API bool CF_CALL cf_key_repeating(CF_KeyButton key);
 
@@ -613,7 +613,7 @@ CF_API bool CF_CALL cf_key_repeating(CF_KeyButton key);
  * @function cf_key_ctrl
  * @category input
  * @brief    Returns true if the left or right control key is currently down.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states cf_key_repeating
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API bool CF_CALL cf_key_ctrl(void);
 
@@ -621,7 +621,7 @@ CF_API bool CF_CALL cf_key_ctrl(void);
  * @function cf_key_shift
  * @category input
  * @brief    Returns true if the left or right shift key is currently down.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API bool CF_CALL cf_key_shift(void);
 
@@ -629,7 +629,7 @@ CF_API bool CF_CALL cf_key_shift(void);
  * @function cf_key_alt
  * @category input
  * @brief    Returns true if the left or right alt key is currently down.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API bool CF_CALL cf_key_alt(void);
 
@@ -638,7 +638,7 @@ CF_API bool CF_CALL cf_key_alt(void);
  * @category input
  * @brief    Returns true if the left or right gui key is currently down.
  * @remarks  Windows key in Windows, Command key in OSX.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API bool CF_CALL cf_key_gui(void);
 
@@ -646,7 +646,7 @@ CF_API bool CF_CALL cf_key_gui(void);
  * @function cf_clear_key_states
  * @category input
  * @brief    Zeroes out all internal keyboard state.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API void CF_CALL cf_clear_key_states(void);
 
@@ -654,7 +654,7 @@ CF_API void CF_CALL cf_clear_key_states(void);
  * @function cf_register_key_callback
  * @category input
  * @brief    Registers a callback invoked whenever a key is pressed.
- * @related  CF_KeyButton cf_key_down cf_key_up cf_key_just_pressed cf_key_just_released cf_key_ctrl cf_key_shift cf_key_alt cf_key_gui cf_clear_key_states
+ * @related  cf_key_down cf_key_up cf_key_just_pressed
  */
 CF_API void CF_CALL cf_register_key_callback(void (*key_callback)(CF_KeyButton key, bool true_down_false_up));
 
@@ -663,7 +663,7 @@ CF_API void CF_CALL cf_register_key_callback(void (*key_callback)(CF_KeyButton k
  * @category input
  * @brief    Returns the current mouse x-coordinate in pixels.
  * @remarks  (0, 0) is the top-left of the screen, y-downards.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
+ * @related  cf_mouse_down cf_mouse_y cf_mouse_motion_x
  */
 CF_API float CF_CALL cf_mouse_x(void);
 
@@ -672,7 +672,7 @@ CF_API float CF_CALL cf_mouse_x(void);
  * @category input
  * @brief    Returns the current mouse y-coordinate in pixels.
  * @remarks  (0, 0) is the top-left of the screen, y-downwards.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
+ * @related  cf_mouse_down cf_mouse_x cf_mouse_motion_x
  */
 CF_API float CF_CALL cf_mouse_y(void);
 
@@ -681,7 +681,7 @@ CF_API float CF_CALL cf_mouse_y(void);
  * @category input
  * @brief    Returns the current mouse motion x-coordinates in pixels.
  * @remarks  (0, 0) means there is no mouse movement, y-downwards.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
+ * @related  cf_mouse_motion_y cf_mouse_down cf_mouse_x
  */
 CF_API float CF_CALL cf_mouse_motion_x(void);
 
@@ -690,7 +690,7 @@ CF_API float CF_CALL cf_mouse_motion_x(void);
  * @category input
  * @brief    Returns the current mouse motion y-coordinates in pixels.
  * @remarks  (0, 0) means there is no mouse movement, y-downwards.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_motion_x cf_mouse_motion_y
+ * @related  cf_mouse_motion_x cf_mouse_down cf_mouse_x
  */
 CF_API float CF_CALL cf_mouse_motion_y(void);
 
@@ -698,7 +698,7 @@ CF_API float CF_CALL cf_mouse_motion_y(void);
  * @function cf_mouse_down
  * @category input
  * @brief    Returns true if the mouse button is currently down.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_double_click_held cf_mouse_double_clicked cf_mouse_x
  */
 CF_API bool CF_CALL cf_mouse_down(CF_MouseButton button);
 
@@ -706,7 +706,7 @@ CF_API bool CF_CALL cf_mouse_down(CF_MouseButton button);
  * @function cf_mouse_just_pressed
  * @category input
  * @brief    Returns true if the mouse button was just pressed.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_just_released cf_mouse_down cf_mouse_x
  */
 CF_API bool CF_CALL cf_mouse_just_pressed(CF_MouseButton button);
 
@@ -714,7 +714,7 @@ CF_API bool CF_CALL cf_mouse_just_pressed(CF_MouseButton button);
  * @function cf_mouse_just_released
  * @category input
  * @brief    Returns true if the mouse button was just released.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_just_pressed cf_mouse_down cf_mouse_x
  */
 CF_API bool CF_CALL cf_mouse_just_released(CF_MouseButton button);
 
@@ -722,7 +722,7 @@ CF_API bool CF_CALL cf_mouse_just_released(CF_MouseButton button);
  * @function cf_mouse_wheel_motion
  * @category input
  * @brief    Returns a signed integer representing by how much the mouse wheel was rotated.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_down cf_mouse_x cf_mouse_y
  */
 CF_API float CF_CALL cf_mouse_wheel_motion(void);
 
@@ -730,7 +730,7 @@ CF_API float CF_CALL cf_mouse_wheel_motion(void);
  * @function cf_mouse_double_click_held
  * @category input
  * @brief    Returns true while a double click was detected and currently held down.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_double_clicked cf_mouse_down cf_mouse_x
  */
 CF_API bool CF_CALL cf_mouse_double_click_held(CF_MouseButton button);
 
@@ -738,7 +738,7 @@ CF_API bool CF_CALL cf_mouse_double_click_held(CF_MouseButton button);
  * @function cf_mouse_double_clicked
  * @category input
  * @brief    Returns true if a double click was just detected.
- * @related  CF_MouseButton cf_mouse_down cf_mouse_x cf_mouse_y cf_mouse_just_pressed cf_mouse_just_released cf_mouse_wheel_motion cf_mouse_double_click_held cf_mouse_double_clicked
+ * @related  cf_mouse_double_click_held cf_mouse_down cf_mouse_x
  */
 CF_API bool CF_CALL cf_mouse_double_clicked(CF_MouseButton button);
 
@@ -746,7 +746,7 @@ CF_API bool CF_CALL cf_mouse_double_clicked(CF_MouseButton button);
  * @function cf_mouse_hide
  * @category input
  * @brief    Hides or shows the mouse.
- * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window
+ * @related  cf_mouse_hidden cf_mouse_lock_inside_window
  */
 CF_API void CF_CALL cf_mouse_hide(bool true_to_hide);
 
@@ -755,7 +755,7 @@ CF_API void CF_CALL cf_mouse_hide(bool true_to_hide);
  * @category input
  * @brief    Returns whether the mouse is hidden.
  * @return   True means hidden, false means not hidden.
- * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window
+ * @related  cf_mouse_hide cf_mouse_lock_inside_window
  */
 CF_API bool CF_CALL cf_mouse_hidden(void);
 
@@ -764,7 +764,7 @@ CF_API bool CF_CALL cf_mouse_hidden(void);
  * @category input
  * @brief    Locks the mouse within the window's borders.
  * @remarks  This is off by default, meaning the mouse is free to leave the border of the window.
- * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window cf_mouse_set_relative_mode
+ * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_set_relative_mode
  */
 CF_API void CF_CALL cf_mouse_lock_inside_window(bool true_to_lock);
 
@@ -773,7 +773,7 @@ CF_API void CF_CALL cf_mouse_lock_inside_window(bool true_to_lock);
  * @category input
  * @brief    Locks the mouse within the window's borders and hides the mouse.
  * @remarks  This is off by default, meaning the mouse is free to leave the border of the window.
- * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window cf_mouse_set_relative_mode
+ * @related  cf_mouse_hide cf_mouse_hidden cf_mouse_lock_inside_window
  */
 CF_API void CF_CALL cf_mouse_set_relative_mode(bool true_to_set_relative);
 
@@ -781,7 +781,7 @@ CF_API void CF_CALL cf_mouse_set_relative_mode(bool true_to_set_relative);
  * @struct   CF_InputTextBuffer
  * @category input
  * @brief    Represents the application's input text buffer.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_text_get_buffer cf_input_text_clear
+ * @related  cf_input_enable_ime cf_input_disable_ime cf_input_text_get_buffer
  */
 typedef struct CF_InputTextBuffer
 {
@@ -799,7 +799,7 @@ typedef struct CF_InputTextBuffer
  * @brief    Adds a utf8 codepoint to the input buffer of the application.
  * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
- * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
+ * @related  cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
  */
 CF_API void CF_CALL cf_input_text_add_utf8(const char* text);
 
@@ -809,7 +809,7 @@ CF_API void CF_CALL cf_input_text_add_utf8(const char* text);
  * @brief    Pops a utf8 codepoint off of the input buffer of the application.
  * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
- * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
+ * @related  cf_input_text_add_utf8 cf_input_text_has_data cf_input_text_clear
  */
 CF_API int CF_CALL cf_input_text_pop_utf32(void);
 
@@ -819,7 +819,7 @@ CF_API int CF_CALL cf_input_text_pop_utf32(void);
  * @brief    Returns true if the input buffer of the application has any text within.
  * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
- * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
+ * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_clear
  */
 CF_API bool CF_CALL cf_input_text_has_data(void);
 
@@ -830,7 +830,7 @@ CF_API bool CF_CALL cf_input_text_has_data(void);
  * @return   Returns true if the input buffer of the application has any text within.
  * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_text_clear
+ * @related  cf_input_text_clear cf_input_enable_ime cf_input_disable_ime
  */
 CF_API bool CF_CALL cf_input_text_get_buffer(CF_InputTextBuffer* buffer);
 
@@ -840,7 +840,7 @@ CF_API bool CF_CALL cf_input_text_get_buffer(CF_InputTextBuffer* buffer);
  * @brief    Clears the application's input text buffer.
  * @remarks  The input text functions are for dealing with text input. Not all text inputs come from a single key-stroke, as some are comprised of
  *           multiple keystrokes, especially when dealing with non-Latin based inputs.
- * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data cf_input_text_clear
+ * @related  cf_input_text_add_utf8 cf_input_text_pop_utf32 cf_input_text_has_data
  */
 CF_API void CF_CALL cf_input_text_clear(void);
 
@@ -850,7 +850,7 @@ CF_API void CF_CALL cf_input_text_clear(void);
  * @brief    Enables the IME (Input Method Editor) for the operating system.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support
  */
 CF_API void CF_CALL cf_input_enable_ime(void);
 
@@ -860,7 +860,7 @@ CF_API void CF_CALL cf_input_enable_ime(void);
  * @brief    Disables the IME (Input Method Editor) for the operating system.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_enable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support
  */
 CF_API void CF_CALL cf_input_disable_ime(void);
 
@@ -870,7 +870,7 @@ CF_API void CF_CALL cf_input_disable_ime(void);
  * @brief    Returns true if the IME (Input Method Editor) for the operating system is enabled.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_is_ime_keyboard_shown cf_input_enable_ime cf_input_disable_ime
  */
 CF_API bool CF_CALL cf_input_is_ime_enabled(void);
 
@@ -880,7 +880,7 @@ CF_API bool CF_CALL cf_input_is_ime_enabled(void);
  * @brief    Returns true if the IME (Input Method Editor) for the operating system has keyboard support.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled
  */
 CF_API bool CF_CALL cf_input_has_ime_keyboard_support(void);
 
@@ -890,7 +890,7 @@ CF_API bool CF_CALL cf_input_has_ime_keyboard_support(void);
  * @brief    Returns true if the IME (Input Method Editor) for the operating system is currently showing the keyboard.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_is_ime_enabled cf_input_enable_ime cf_input_disable_ime
  */
 CF_API bool CF_CALL cf_input_is_ime_keyboard_shown(void);
 
@@ -900,7 +900,7 @@ CF_API bool CF_CALL cf_input_is_ime_keyboard_shown(void);
  * @brief    Tells the operating system where the current IME (Input Method Editor) rect should be.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled cf_input_has_ime_keyboard_support cf_input_is_ime_keyboard_shown cf_input_set_ime_rect
+ * @related  cf_input_enable_ime cf_input_disable_ime cf_input_is_ime_enabled
  */
 CF_API void CF_CALL cf_input_set_ime_rect(int x, int y, int w, int h);
 
@@ -908,7 +908,7 @@ CF_API void CF_CALL cf_input_set_ime_rect(int x, int y, int w, int h);
  * @struct   CF_ImeComposition
  * @category input
  * @brief    Represents the IME (Input Method Editor) composition from the operating system, for gathering complex text inputs.
- * @related  cf_input_enable_ime CF_ImeComposition cf_input_get_ime_composition
+ * @related  cf_input_enable_ime cf_input_get_ime_composition
  */
 typedef struct CF_ImeComposition
 {
@@ -931,7 +931,7 @@ typedef struct CF_ImeComposition
  * @return   Returns true if the IME (Input Method Editor) is currently composing text.
  * @remarks  This is an advanced function. It's useful for gathering input from a variety of languages, where keystrokes are translated into a variety
  *           of different language inputs. This is usually a feature of the underlying operating system.
- * @related  cf_input_enable_ime CF_ImeComposition cf_input_get_ime_composition
+ * @related  cf_input_enable_ime CF_ImeComposition
  */
 CF_API bool CF_CALL cf_input_get_ime_composition(CF_ImeComposition* composition);
 
@@ -939,7 +939,7 @@ CF_API bool CF_CALL cf_input_get_ime_composition(CF_ImeComposition* composition)
  * @struct   CF_Touch
  * @category input
  * @brief    Represents a single touch event on the device.
- * @related  CF_Touch cf_touch_get_all cf_touch_get
+ * @related  cf_touch_get_all cf_touch_get
  */
 typedef struct CF_Touch
 {
@@ -969,7 +969,7 @@ typedef struct CF_Touch
  *     for (int i = 0; i < touch_count; ++i) {
  *         do_something(touches[i]);
  *     }
- * @related  CF_Touch cf_touch_get_all cf_touch_get
+ * @related  cf_touch_get CF_Touch
  */
 CF_API int CF_CALL cf_touch_get_all(CF_Touch** touch_all);
 
@@ -983,7 +983,7 @@ CF_API int CF_CALL cf_touch_get_all(CF_Touch** touch_all);
  * @remarks  You should use `cf_touch_get_all` to peek at all current touch events. Make note of any touch events that are
  *           new. Then, you can loop over all touch events you've noted with this function, and remove them when they
  *           become unavailable.
- * @related  CF_Touch cf_touch_get_all cf_touch_get
+ * @related  cf_touch_get_all CF_Touch
  */
 CF_API bool CF_CALL cf_touch_get(uint64_t id, CF_Touch* touch);
 

--- a/include/cute_joypad.h
+++ b/include/cute_joypad.h
@@ -24,7 +24,7 @@ extern "C" {
  * @enum     CF_JoypadPowerLevel
  * @category input
  * @brief    The states of power for a `CF_Joypad`.
- * @related  CF_JoypadPowerLevel cf_joypad_power_level_to_string cf_joypad_power_level CF_Joypad
+ * @related  cf_joypad_power_level_to_string cf_joypad_power_level CF_Joypad
  */
 #define CF_JOYPAD_POWER_LEVEL_DEFS \
 	/* @entry */ \
@@ -55,7 +55,7 @@ typedef enum CF_JoypadPowerLevel
  * @category input
  * @brief    Convert an enum `CF_JoypadPowerLevel` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_JoypadPowerLevel cf_joypad_power_level_to_string cf_joypad_power_level CF_Joypad
+ * @related  cf_joypad_power_level CF_JoypadPowerLevel CF_Joypad
  */
 CF_INLINE const char* cf_joypad_power_level_to_string(CF_JoypadPowerLevel level)
 {
@@ -71,7 +71,7 @@ CF_INLINE const char* cf_joypad_power_level_to_string(CF_JoypadPowerLevel level)
  * @enum     CF_JoypadButton
  * @category input
  * @brief    Various buttons on a `CF_Joypad`.
- * @related  CF_JoypadButton cf_joypad_button_to_string CF_Joypad cf_joypad_button_down
+ * @related  cf_joypad_button_to_string cf_joypad_button_down
  */
 #define CF_JOYPAD_BUTTON_DEFS \
 	/* @entry */ \
@@ -122,7 +122,7 @@ typedef enum CF_JoypadButton
  * @category input
  * @brief    Convert an enum `CF_JoypadButton` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_JoypadButton cf_joypad_button_to_string CF_Joypad cf_joypad_button_down
+ * @related  cf_joypad_button_down CF_JoypadButton CF_Joypad
  */
 CF_INLINE const char* cf_joypad_button_to_string(CF_JoypadButton button)
 {
@@ -138,7 +138,7 @@ CF_INLINE const char* cf_joypad_button_to_string(CF_JoypadButton button)
  * @enum     CF_JoypadAxis
  * @category input
  * @brief    Various axis actions on a `CF_Joypad`.
- * @related  CF_JoypadAxis cf_joypad_axis_to_string CF_Joypad cf_joypad_axis CF_JoypadType
+ * @related  cf_joypad_axis_to_string cf_joypad_axis
  */
 #define CF_JOYPAD_AXIS_DEFS \
 	/* @entry */ \
@@ -171,7 +171,7 @@ typedef enum CF_JoypadAxis
  * @category input
  * @brief    Convert an enum `CF_JoypadAxis` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_JoypadAxis cf_joypad_axis_to_string CF_Joypad cf_joypad_axis CF_JoypadType
+ * @related  cf_joypad_axis CF_JoypadAxis CF_Joypad
  */
 CF_INLINE const char* cf_joypad_axis_to_string(CF_JoypadAxis axis)
 {
@@ -187,7 +187,7 @@ CF_INLINE const char* cf_joypad_axis_to_string(CF_JoypadAxis axis)
  * @enum     CF_JoypadType
  * @category input
  * @brief    Various types of joypads by enum name.
- * @related  CF_Joypad CF_JoypadType cf_joypad_type_to_string cf_joypad_type
+ * @related  cf_joypad_type_to_string cf_joypad_type CF_Joypad
  */
 #define CF_JOYPAD_TYPE_DEFS \
 	/* @entry */ \
@@ -234,7 +234,7 @@ typedef enum CF_JoypadType
  * @category input
  * @brief    Convert an enum `CF_JoypadType` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_Joypad CF_JoypadType cf_joypad_type_to_string cf_joypad_type
+ * @related  cf_joypad_type CF_Joypad CF_JoypadType
  */
 CF_INLINE const char* cf_joypad_type_to_string(CF_JoypadType type)
 {
@@ -264,7 +264,7 @@ CF_API CF_Result CF_CALL cf_joypad_add_mapping(const char* mapping);
  * @brief    Returns the number of joypads currently connected to the system.
  * @remarks  This may return a number larger than `CF_MAX_JOYPADS` (8), though, only up to 8 will
  *           be seen by Cute Framework.
- * @related  CF_Joypad cf_joypad_count cf_joypad_open cf_joypad_close
+ * @related  cf_joypad_close cf_joypad_open CF_Joypad
  */
 CF_API int CF_CALL cf_joypad_count(void);
 
@@ -273,7 +273,7 @@ CF_API int CF_CALL cf_joypad_count(void);
  * @category input
  * @brief    Returns true if a joypad is connected.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
- * @related  CF_Joypad cf_joypad_count cf_joypad_open cf_joypad_close
+ * @related  cf_joypad_count cf_joypad_open cf_joypad_close
  */
 CF_API bool CF_CALL cf_joypad_is_connected(int player_index);
 
@@ -282,7 +282,7 @@ CF_API bool CF_CALL cf_joypad_is_connected(int player_index);
  * @category input
  * @brief    Returns the power level of the joypad.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
- * @related  CF_JoypadPowerLevel cf_joypad_power_level_to_string cf_joypad_power_level CF_Joypad
+ * @related  cf_joypad_power_level_to_string CF_JoypadPowerLevel CF_Joypad
  */
 CF_API CF_JoypadPowerLevel CF_CALL cf_joypad_power_level(int player_index);
 
@@ -291,7 +291,7 @@ CF_API CF_JoypadPowerLevel CF_CALL cf_joypad_power_level(int player_index);
  * @category input
  * @brief    Returns the name of the joypad.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
- * @related  CF_Joypad cf_joypad_count cf_joypad_open cf_joypad_close
+ * @related  cf_joypad_count cf_joypad_open cf_joypad_close
  */
 CF_API const char* CF_CALL cf_joypad_name(int player_index);
 
@@ -360,7 +360,7 @@ CF_API uint16_t CF_CALL cf_joypad_product_version(int player_index);
  * @brief    Returns true if the button is currently down.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @param    button     The button.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
  */
 CF_API bool CF_CALL cf_joypad_button_down(int player_index, CF_JoypadButton button);
 
@@ -370,7 +370,7 @@ CF_API bool CF_CALL cf_joypad_button_down(int player_index, CF_JoypadButton butt
  * @brief    Returns true if the button was just pressed.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @param    button     The button.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_button_just_released cf_joypad_button_down cf_joypad_axis
  */
 CF_API bool CF_CALL cf_joypad_button_just_pressed(int player_index, CF_JoypadButton button);
 
@@ -380,7 +380,7 @@ CF_API bool CF_CALL cf_joypad_button_just_pressed(int player_index, CF_JoypadBut
  * @brief    Returns true if the button was just released.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @param    button     The button.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_button_just_pressed cf_joypad_button_down cf_joypad_axis
  */
 CF_API bool CF_CALL cf_joypad_button_just_released(int player_index, CF_JoypadButton button);
 
@@ -390,7 +390,7 @@ CF_API bool CF_CALL cf_joypad_button_just_released(int player_index, CF_JoypadBu
  * @brief    Returns a signed 16-bit integer representing how much a joypad axis is activated by.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @param    axis       The axis.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released
  */
 CF_API int16_t CF_CALL cf_joypad_axis(int player_index, CF_JoypadAxis axis);
 
@@ -400,7 +400,7 @@ CF_API int16_t CF_CALL cf_joypad_axis(int player_index, CF_JoypadAxis axis);
  * @brief    Returns the previous axis value from the last frame.
  * @param    player_index     An index represeting the joypad for a particular player, starting at 0.
  * @param    axis       The axis.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_axis cf_joypad_button_down cf_joypad_button_just_pressed
  */
 CF_API int16_t CF_CALL cf_joypad_axis_prev(int player_index, CF_JoypadAxis axis);
 
@@ -412,7 +412,7 @@ CF_API int16_t CF_CALL cf_joypad_axis_prev(int player_index, CF_JoypadAxis axis)
  * @param    lo_frequency_rumble       Rumble intensity from 0 to 65535. Represents the low frequency motor (or left motor).
  * @param    hi_frequency_rumble       Rumble intensity from 0 to 65535. Represents the high frequency motor (or right motor).
  * @remarks  Calling this function cancels any previous rumbles. Sending in 0 for either low/high frequency parameters cancels the rumble.
- * @related  CF_Joypad CF_JoypadButton cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released cf_joypad_axis
+ * @related  cf_joypad_button_down cf_joypad_button_just_pressed cf_joypad_button_just_released
  */
 CF_API void CF_CALL cf_joypad_rumble(int player_index, uint16_t lo_frequency_rumble, uint16_t hi_frequency_rumble, int duration_ms);
 

--- a/include/cute_json.h
+++ b/include/cute_json.h
@@ -23,7 +23,7 @@ extern "C" {
  * @struct   CF_JDoc
  * @category json
  * @brief    Represents a single json document.
- * @related  CF_JDoc CF_JVal cf_make_json
+ * @related  cf_make_json CF_JVal
  */
 typedef struct CF_JDoc { uintptr_t id; } CF_JDoc;
 /* @end */
@@ -32,7 +32,7 @@ typedef struct CF_JDoc { uintptr_t id; } CF_JDoc;
  * @struct   CF_JVal
  * @category json
  * @brief    Represents a single json value, such an integer or array.
- * @related  CF_JDoc CF_JVal cf_make_json CF_JType
+ * @related  cf_make_json CF_JDoc CF_JType
  */
 typedef struct CF_JVal { uintptr_t id; } CF_JVal;
 /* @end */
@@ -41,7 +41,7 @@ typedef struct CF_JVal { uintptr_t id; } CF_JVal;
  * @enum     CF_JType
  * @category json
  * @brief    Describes the type of a `CF_JVal`.
- * @related  CF_JDoc CF_JVal cf_make_json
+ * @related  cf_make_json CF_JDoc CF_JVal
  */
 #define CF_JTYPE_DEFS \
 	/* @entry Empty value, representing an uninitialized state. This is not the same as `CF_JTYPE_NULL`. */ \
@@ -94,7 +94,7 @@ CF_INLINE const char* cf_json_type_to_string(CF_JType type)
  * @param    size       The number of bytes in the `data` pointer.
  * @return   Returns a `CF_JDoc`.
  * @remarks  You should call `cf_json_get_root` on this document to begin fetching values out of it.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file
+ * @related  cf_make_json_from_file cf_json_get_root cf_destroy_json
  */
 CF_API CF_JDoc CF_CALL cf_make_json(const void* data, size_t size);
 
@@ -105,7 +105,7 @@ CF_API CF_JDoc CF_CALL cf_make_json(const void* data, size_t size);
  * @param    virtual_path  A virtual path to the json file. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @return   Returns a `CF_JDoc`.
  * @remarks  You should call `cf_json_get_root` on this document to begin fetching values out of it.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file
+ * @related  cf_make_json cf_json_get_root cf_destroy_json
  */
 CF_API CF_JDoc CF_CALL cf_make_json_from_file(const char* virtual_path);
 
@@ -113,7 +113,7 @@ CF_API CF_JDoc CF_CALL cf_make_json_from_file(const char* virtual_path);
  * @function cf_destroy_json
  * @category json
  * @brief    Destroys a json blob `CF_JDoc`.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file
+ * @related  cf_make_json cf_make_json_from_file cf_json_get_root
  */
 CF_API void CF_CALL cf_destroy_json(CF_JDoc doc);
 
@@ -122,7 +122,7 @@ CF_API void CF_CALL cf_destroy_json(CF_JDoc doc);
  * @category json
  * @brief    Fetches the root of the document.
  * @return   Returns a `CF_JVal`, the root of the document.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_set_root
+ * @related  cf_json_set_root cf_make_json cf_make_json_from_file
  */
 CF_API CF_JVal CF_CALL cf_json_get_root(CF_JDoc doc);
 
@@ -130,7 +130,7 @@ CF_API CF_JVal CF_CALL cf_json_get_root(CF_JDoc doc);
  * @function cf_json_set_root
  * @category json
  * @brief    Sets the root of the document.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_set_root
+ * @related  cf_json_get_root cf_make_json cf_make_json_from_file
  */
 CF_API void CF_CALL cf_json_set_root(CF_JDoc doc, CF_JVal val);
 
@@ -141,7 +141,7 @@ CF_API void CF_CALL cf_json_set_root(CF_JDoc doc, CF_JVal val);
  * @function cf_json_type
  * @category json
  * @brief    Returns the type of the `CF_JVal` via enum `CF_JType`.
- * @related  CF_JType CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_float
  */
 CF_API CF_JType CF_CALL cf_json_type(CF_JVal val);
 
@@ -149,7 +149,7 @@ CF_API CF_JType CF_CALL cf_json_type(CF_JVal val);
  * @function cf_json_is_null
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_NULL`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_int cf_json_is_float cf_json_is_bool
  */
 CF_API bool CF_CALL cf_json_is_null(CF_JVal val);
 
@@ -157,7 +157,7 @@ CF_API bool CF_CALL cf_json_is_null(CF_JVal val);
  * @function cf_json_is_int
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_INT`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_float cf_json_is_bool
  */
 CF_API bool CF_CALL cf_json_is_int(CF_JVal val);
 
@@ -165,7 +165,7 @@ CF_API bool CF_CALL cf_json_is_int(CF_JVal val);
  * @function cf_json_is_float
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_FLOAT`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_bool
  */
 CF_API bool CF_CALL cf_json_is_float(CF_JVal val);
 
@@ -173,7 +173,7 @@ CF_API bool CF_CALL cf_json_is_float(CF_JVal val);
  * @function cf_json_is_bool
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_BOOL`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_float
  */
 CF_API bool CF_CALL cf_json_is_bool(CF_JVal val);
 
@@ -181,7 +181,7 @@ CF_API bool CF_CALL cf_json_is_bool(CF_JVal val);
  * @function cf_json_is_string
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_STRING`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_float
  */
 CF_API bool CF_CALL cf_json_is_string(CF_JVal val);
 
@@ -189,7 +189,7 @@ CF_API bool CF_CALL cf_json_is_string(CF_JVal val);
  * @function cf_json_is_array
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_ARRAY`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_float
  */
 CF_API bool CF_CALL cf_json_is_array(CF_JVal val);
 
@@ -197,7 +197,7 @@ CF_API bool CF_CALL cf_json_is_array(CF_JVal val);
  * @function cf_json_is_object
  * @category json
  * @brief    Returns true if the `CF_JType` is `CF_JTYPE_OBJECT`.
- * @related  CF_JVal cf_json_type cf_json_is_null cf_json_is_int cf_json_is_float cf_json_is_bool cf_json_is_string cf_json_is_array cf_json_is_object
+ * @related  cf_json_is_null cf_json_is_int cf_json_is_float
  */
 CF_API bool CF_CALL cf_json_is_object(CF_JVal val);
 
@@ -205,7 +205,7 @@ CF_API bool CF_CALL cf_json_is_object(CF_JVal val);
  * @function cf_json_get_int
  * @category json
  * @brief    Interprets the `CF_JVal` as an integer.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_i64 cf_json_get_u64 cf_json_get_float
  */
 CF_API int CF_CALL cf_json_get_int(CF_JVal val);
 
@@ -213,7 +213,7 @@ CF_API int CF_CALL cf_json_get_int(CF_JVal val);
  * @function cf_json_get_i64
  * @category json
  * @brief    Interprets the `CF_JVal` as a 64-bit signed integer.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_u64 cf_json_get_float
  */
 CF_API int64_t CF_CALL cf_json_get_i64(CF_JVal val);
 
@@ -221,7 +221,7 @@ CF_API int64_t CF_CALL cf_json_get_i64(CF_JVal val);
  * @function cf_json_get_u64
  * @category json
  * @brief    Interprets the `CF_JVal` as a 64-bit unsigned integer.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_float
  */
 CF_API uint64_t CF_CALL cf_json_get_u64(CF_JVal val);
 
@@ -229,7 +229,7 @@ CF_API uint64_t CF_CALL cf_json_get_u64(CF_JVal val);
  * @function cf_json_get_float
  * @category json
  * @brief    Interprets the `CF_JVal` as a 32-bit float.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_u64
  */
 CF_API float CF_CALL cf_json_get_float(CF_JVal val);
 
@@ -237,7 +237,7 @@ CF_API float CF_CALL cf_json_get_float(CF_JVal val);
  * @function cf_json_get_double
  * @category json
  * @brief    Interprets the `CF_JVal` as a 64-bit float.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_u64
  */
 CF_API double CF_CALL cf_json_get_double(CF_JVal val);
 
@@ -245,7 +245,7 @@ CF_API double CF_CALL cf_json_get_double(CF_JVal val);
  * @function cf_json_get_bool
  * @category json
  * @brief    Interprets the `CF_JVal` as a boolean.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_u64
  */
 CF_API bool CF_CALL cf_json_get_bool(CF_JVal val);
 
@@ -253,7 +253,7 @@ CF_API bool CF_CALL cf_json_get_bool(CF_JVal val);
  * @function cf_json_get_string
  * @category json
  * @brief    Interprets the `CF_JVal` as a plain C-string.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_u64
  */
 CF_API const char* CF_CALL cf_json_get_string(CF_JVal val);
 
@@ -261,7 +261,7 @@ CF_API const char* CF_CALL cf_json_get_string(CF_JVal val);
  * @function cf_json_get_len
  * @category json
  * @brief    Returns the length of the `CF_JVal`'s string, if it is a valid string.
- * @related  CF_JVal cf_json_get_int cf_json_get_i64 cf_json_get_u64 cf_json_get_float cf_json_get_double cf_json_get_bool cf_json_get_string cf_json_get_len
+ * @related  cf_json_get_int cf_json_get_i64 cf_json_get_u64
  */
 CF_API int CF_CALL cf_json_get_len(CF_JVal val);
 
@@ -275,7 +275,7 @@ CF_API int CF_CALL cf_json_get_len(CF_JVal val);
  * @param    val       The JSON value to search for `key` within.
  * @param    key       The search key.
  * @return   Returns the `CF_JVal` associated with `key` on the object `val`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter
+ * @related  cf_json_array_at cf_json_array_get cf_json_iter
  */
 CF_API CF_JVal CF_CALL cf_json_get(CF_JVal val, const char* key);
 
@@ -287,7 +287,7 @@ CF_API CF_JVal CF_CALL cf_json_get(CF_JVal val, const char* key);
  * @param    index     The index of the value to return.
  * @return   Returns the `CF_JVal` associated with `index` on the object `val`.
  * @remarks  This function does the same thing as `cf_json_array_get`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter
+ * @related  cf_json_array_get cf_json_get cf_json_iter
  */
 CF_API CF_JVal CF_CALL cf_json_array_at(CF_JVal val, int index);
 
@@ -299,7 +299,7 @@ CF_API CF_JVal CF_CALL cf_json_array_at(CF_JVal val, int index);
  * @param    index     The index of the value to return.
  * @return   Returns the `CF_JVal` associated with `index` on the object `val`.
  * @remarks  This function does the same thing as `cf_json_array_at`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter
+ * @related  cf_json_array_at cf_json_get cf_json_iter
  */
 CF_API CF_JVal CF_CALL cf_json_array_get(CF_JVal val, int index);
 
@@ -307,7 +307,7 @@ CF_API CF_JVal CF_CALL cf_json_array_get(CF_JVal val, int index);
  * @struct   CF_JIter
  * @category json
  * @brief    An iterator for looping over arrays or key-value pairs.
- * @related  CF_JIter cf_json_iter cf_json_iter_next cf_json_iter_next_by_name cf_json_iter_remove cf_json_iter_key cf_json_iter_val
+ * @related  cf_json_iter cf_json_iter_next cf_json_iter_next_by_name
  */
 typedef struct CF_JIter
 {
@@ -344,7 +344,7 @@ typedef struct CF_JIter
  *           }
  * @remarks  The `CF_JIter` can be used in foor loops, and can traverse both JSON arrays and objects. When
  *           traversing arrays do not call `cf_json_iter_key`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_get cf_json_array_at
  */
 CF_API CF_JIter CF_CALL cf_json_iter(CF_JVal val);
 
@@ -353,7 +353,7 @@ CF_API CF_JIter CF_CALL cf_json_iter(CF_JVal val);
  * @category json
  * @brief    Returns true if the `CF_JIter` has finished iterating over all elements.
  * @remarks  See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_iter cf_json_get
  */
 #define cf_json_iter_done(iter) ((iter).index >= (iter).count)
 
@@ -362,7 +362,7 @@ CF_API CF_JIter CF_CALL cf_json_iter(CF_JVal val);
  * @category json
  * @brief    Proceeds to the next element.
  * @remarks  See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_iter cf_json_get
  */
 CF_API CF_JIter CF_CALL cf_json_iter_next(CF_JIter iter);
 
@@ -371,7 +371,7 @@ CF_API CF_JIter CF_CALL cf_json_iter_next(CF_JIter iter);
  * @category json
  * @brief    Proceeds to the next element with a matching name.
  * @remarks  You should know the ordering of your key/val pairs before calling this function, as it only searches forwards. See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_iter cf_json_get
  */
 CF_API CF_JVal CF_CALL cf_json_iter_next_by_name(CF_JIter* iter, const char* key);
 
@@ -380,7 +380,7 @@ CF_API CF_JVal CF_CALL cf_json_iter_next_by_name(CF_JIter* iter, const char* key
  * @category json
  * @brief    Removes the element currently referenced by the iterator.
  * @remarks  See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter cf_json_get cf_json_array_at
  */
 CF_API CF_JVal CF_CALL cf_json_iter_remove(CF_JIter* iter);
 
@@ -389,7 +389,7 @@ CF_API CF_JVal CF_CALL cf_json_iter_remove(CF_JIter* iter);
  * @category json
  * @brief    Returns the key currently referenced by the iterator.
  * @remarks  You should not call this function when iterating over an array. See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_iter cf_json_get
  */
 CF_API const char* CF_CALL cf_json_iter_key(CF_JIter iter);
 
@@ -398,7 +398,7 @@ CF_API const char* CF_CALL cf_json_iter_key(CF_JIter iter);
  * @category json
  * @brief    Returns the value currently referenced by the iterator.
  * @remarks  See `cf_json_iter`.
- * @related  CF_JVal cf_json_get cf_json_array_at cf_json_array_get cf_json_iter cf_json_iter_remove
+ * @related  cf_json_iter_remove cf_json_iter cf_json_get
  */
 CF_API CF_JVal CF_CALL cf_json_iter_val(CF_JIter iter);
 
@@ -410,7 +410,7 @@ CF_API CF_JVal CF_CALL cf_json_iter_val(CF_JIter iter);
  * @category json
  * @brief    Creates and returns a new NULL json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_int cf_json_from_float cf_json_from_bool
  */
 CF_API CF_JVal CF_CALL cf_json_from_null(CF_JDoc doc);
 
@@ -419,7 +419,7 @@ CF_API CF_JVal CF_CALL cf_json_from_null(CF_JDoc doc);
  * @category json
  * @brief    Creates and returns a new 32-bit int json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_i64 cf_json_from_u64 cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_i64 cf_json_from_null cf_json_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_from_int(CF_JDoc doc, int val);
 
@@ -428,7 +428,7 @@ CF_API CF_JVal CF_CALL cf_json_from_int(CF_JDoc doc, int val);
  * @category json
  * @brief    Creates and returns a new 64-bit signed int json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_i64 cf_json_from_u64 cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_int cf_json_from_null cf_json_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_from_i64(CF_JDoc doc, int64_t val);
 
@@ -437,7 +437,7 @@ CF_API CF_JVal CF_CALL cf_json_from_i64(CF_JDoc doc, int64_t val);
  * @category json
  * @brief    Creates and returns a new 64-bit unsigned int json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_i64 cf_json_from_u64 cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_null cf_json_from_int cf_json_from_i64
  */
 CF_API CF_JVal CF_CALL cf_json_from_u64(CF_JDoc doc, uint64_t val);
 
@@ -446,7 +446,7 @@ CF_API CF_JVal CF_CALL cf_json_from_u64(CF_JDoc doc, uint64_t val);
  * @category json
  * @brief    Creates and returns a new 32-bit float json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_double cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_null cf_json_from_int cf_json_from_double
  */
 CF_API CF_JVal CF_CALL cf_json_from_float(CF_JDoc doc, float val);
 
@@ -455,7 +455,7 @@ CF_API CF_JVal CF_CALL cf_json_from_float(CF_JDoc doc, float val);
  * @category json
  * @brief    Creates and returns a new 64-bit float json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_double cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_null cf_json_from_int cf_json_from_float
  */
 CF_API CF_JVal CF_CALL cf_json_from_double(CF_JDoc doc, double val);
 
@@ -464,7 +464,7 @@ CF_API CF_JVal CF_CALL cf_json_from_double(CF_JDoc doc, double val);
  * @category json
  * @brief    Creates and returns a new boolean json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_null cf_json_from_int cf_json_from_float
  */
 CF_API CF_JVal CF_CALL cf_json_from_bool(CF_JDoc doc, bool val);
 
@@ -473,7 +473,7 @@ CF_API CF_JVal CF_CALL cf_json_from_bool(CF_JDoc doc, bool val);
  * @category json
  * @brief    Creates and returns a new string json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_from_string_range cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_string_range cf_json_from_null cf_json_from_int
  */
 CF_API CF_JVal CF_CALL cf_json_from_string(CF_JDoc doc, const char* val);
 
@@ -482,7 +482,7 @@ CF_API CF_JVal CF_CALL cf_json_from_string(CF_JDoc doc, const char* val);
  * @category json
  * @brief    Creates and returns a new string json value.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_from_null cf_json_from_int cf_json_from_float cf_json_from_bool cf_json_from_string cf_json_from_string_range cf_json_array_add cf_json_object_add
+ * @related  cf_json_from_string cf_json_from_null cf_json_from_int
  */
 CF_API CF_JVal CF_CALL cf_json_from_string_range(CF_JDoc doc, const char* begin, const char* end);
 
@@ -493,7 +493,7 @@ CF_API CF_JVal CF_CALL cf_json_from_string_range(CF_JDoc doc, const char* begin,
  * @function cf_json_set_null
  * @category json
  * @brief    Sets the `CF_JVal` to null.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_int cf_json_set_i64 cf_json_set_u64
  */
 CF_API void CF_CALL cf_json_set_null(CF_JVal jval);
 
@@ -501,7 +501,7 @@ CF_API void CF_CALL cf_json_set_null(CF_JVal jval);
  * @function cf_json_set_int
  * @category json
  * @brief    Sets the `CF_JVal` to a 32-bit signed int.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_i64 cf_json_set_null cf_json_set_u64
  */
 CF_API void CF_CALL cf_json_set_int(CF_JVal jval, int val);
 
@@ -509,7 +509,7 @@ CF_API void CF_CALL cf_json_set_int(CF_JVal jval, int val);
  * @function cf_json_set_i64
  * @category json
  * @brief    Sets the `CF_JVal` to a 64-bit signed int.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_int cf_json_set_null cf_json_set_u64
  */
 CF_API void CF_CALL cf_json_set_i64(CF_JVal jval, int64_t val);
 
@@ -517,7 +517,7 @@ CF_API void CF_CALL cf_json_set_i64(CF_JVal jval, int64_t val);
  * @function cf_json_set_u64
  * @category json
  * @brief    Sets the `CF_JVal` to an unsigned 64-bit int.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_null cf_json_set_int cf_json_set_i64
  */
 CF_API void CF_CALL cf_json_set_u64(CF_JVal jval, uint64_t val);
 
@@ -525,7 +525,7 @@ CF_API void CF_CALL cf_json_set_u64(CF_JVal jval, uint64_t val);
  * @function cf_json_set_float
  * @category json
  * @brief    Sets the `CF_JVal` to a 32-bit float.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_null cf_json_set_int cf_json_set_i64
  */
 CF_API void CF_CALL cf_json_set_float(CF_JVal jval, float val);
 
@@ -533,7 +533,7 @@ CF_API void CF_CALL cf_json_set_float(CF_JVal jval, float val);
  * @function cf_json_set_double
  * @category json
  * @brief    Sets the `CF_JVal` to a 64-bit float.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_null cf_json_set_int cf_json_set_i64
  */
 CF_API void CF_CALL cf_json_set_double(CF_JVal jval, double val);
 
@@ -541,7 +541,7 @@ CF_API void CF_CALL cf_json_set_double(CF_JVal jval, double val);
  * @function cf_json_set_bool
  * @category json
  * @brief    Sets the `CF_JVal` to a boolean.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_null cf_json_set_int cf_json_set_i64
  */
 CF_API void CF_CALL cf_json_set_bool(CF_JVal jval, bool val);
 
@@ -550,7 +550,7 @@ CF_API void CF_CALL cf_json_set_bool(CF_JVal jval, bool val);
  * @category json
  * @brief    Sets the `CF_JVal` to a string.
  * @remarks  The string must be retained in memory while the `CF_JDoc` persists.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_string_range cf_json_set_null cf_json_set_int
  */
 CF_API void CF_CALL cf_json_set_string(CF_JVal jval, const char* val);
 
@@ -559,7 +559,7 @@ CF_API void CF_CALL cf_json_set_string(CF_JVal jval, const char* val);
  * @category json
  * @brief    Sets the `CF_JVal` to a string.
  * @remarks  The string must be retained in memory while the `CF_JDoc` persists.
- * @related  CF_JVal cf_json_set_null cf_json_set_int cf_json_set_i64 cf_json_set_u64 cf_json_set_float cf_json_set_double cf_json_set_bool cf_json_set_string cf_json_set_string_range
+ * @related  cf_json_set_string cf_json_set_null cf_json_set_int
  */
 CF_API void CF_CALL cf_json_set_string_range(CF_JVal jval, const char* begin, const char* end);
 
@@ -571,7 +571,7 @@ CF_API void CF_CALL cf_json_set_string_range(CF_JVal jval, const char* begin, co
  * @category json
  * @brief    Creates a new json array.
  * @remarks  The value can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_array(CF_JDoc doc);
 
@@ -580,7 +580,7 @@ CF_API CF_JVal CF_CALL cf_json_array(CF_JDoc doc);
  * @category json
  * @brief    Creates a new json array from an array of integers.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_int(CF_JDoc doc, int* vals, int count);
 
@@ -589,7 +589,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_int(CF_JDoc doc, int* vals, int count)
  * @category json
  * @brief    Creates a new json array from an array of integers.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_u64 cf_json_array_from_float
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_i64(CF_JDoc doc, int64_t* vals, int count);
 
@@ -598,7 +598,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_i64(CF_JDoc doc, int64_t* vals, int co
  * @category json
  * @brief    Creates a new json array from an array of integers.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_float
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_u64(CF_JDoc doc, uint64_t* vals, int count);
 
@@ -607,7 +607,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_u64(CF_JDoc doc, uint64_t* vals, int c
  * @category json
  * @brief    Creates a new json array from an array of floats.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_float(CF_JDoc doc, float* vals, int count);
 
@@ -616,7 +616,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_float(CF_JDoc doc, float* vals, int co
  * @category json
  * @brief    Creates a new json array from an array of 64-bit floats.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_double(CF_JDoc doc, double* vals, int count);
 
@@ -625,7 +625,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_double(CF_JDoc doc, double* vals, int 
  * @category json
  * @brief    Creates a new json array from an array of bools.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_bool(CF_JDoc doc, bool* vals, int count);
 
@@ -634,7 +634,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_bool(CF_JDoc doc, bool* vals, int coun
  * @category json
  * @brief    Creates a new json array from an array of strings.
  * @remarks  The returned `CF_JVal` can be attached to the document by `cf_json_array_add` or `cf_json_object_add`.
- * @related  CF_JVal cf_json_array cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64 cf_json_array_from_float cf_json_array_from_double cf_json_array_from_bool cf_json_array_from_string cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_from_int cf_json_array_from_i64 cf_json_array_from_u64
  */
 CF_API CF_JVal CF_CALL cf_json_array_from_string(CF_JDoc doc, const char** vals, int count);
 
@@ -645,7 +645,7 @@ CF_API CF_JVal CF_CALL cf_json_array_from_string(CF_JDoc doc, const char** vals,
  * @function cf_json_array_add
  * @category json
  * @brief    Adds a json value to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add(CF_JVal arr, CF_JVal val);
 
@@ -653,7 +653,7 @@ CF_API void CF_CALL cf_json_array_add(CF_JVal arr, CF_JVal val);
  * @function cf_json_array_add_null
  * @category json
  * @brief    Adds a null value to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_null(CF_JDoc doc, CF_JVal arr);
 
@@ -661,7 +661,7 @@ CF_API void CF_CALL cf_json_array_add_null(CF_JDoc doc, CF_JVal arr);
  * @function cf_json_array_add_int
  * @category json
  * @brief    Adds a 32-bit signed int to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_int(CF_JDoc doc, CF_JVal arr, int val);
 
@@ -669,7 +669,7 @@ CF_API void CF_CALL cf_json_array_add_int(CF_JDoc doc, CF_JVal arr, int val);
  * @function cf_json_array_add_i64
  * @category json
  * @brief    Adds a 64-bit signed int to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_i64(CF_JDoc doc, CF_JVal arr, int64_t val);
 
@@ -677,7 +677,7 @@ CF_API void CF_CALL cf_json_array_add_i64(CF_JDoc doc, CF_JVal arr, int64_t val)
  * @function cf_json_array_add_u64
  * @category json
  * @brief    Adds a 64-bit unsigned int to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_u64(CF_JDoc doc, CF_JVal arr, uint64_t val);
 
@@ -685,7 +685,7 @@ CF_API void CF_CALL cf_json_array_add_u64(CF_JDoc doc, CF_JVal arr, uint64_t val
  * @function cf_json_array_add_float
  * @category json
  * @brief    Adds a 32-bit float to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_float(CF_JDoc doc, CF_JVal arr, float val);
 
@@ -693,7 +693,7 @@ CF_API void CF_CALL cf_json_array_add_float(CF_JDoc doc, CF_JVal arr, float val)
  * @function cf_json_array_add_double
  * @category json
  * @brief    Adds a 64-bit float to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_double(CF_JDoc doc, CF_JVal arr, double val);
 
@@ -701,7 +701,7 @@ CF_API void CF_CALL cf_json_array_add_double(CF_JDoc doc, CF_JVal arr, double va
  * @function cf_json_array_add_bool
  * @category json
  * @brief    Adds a bool to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_bool(CF_JDoc doc, CF_JVal arr, bool val);
 
@@ -709,7 +709,7 @@ CF_API void CF_CALL cf_json_array_add_bool(CF_JDoc doc, CF_JVal arr, bool val);
  * @function cf_json_array_add_string
  * @category json
  * @brief    Adds a string to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_string(CF_JDoc doc, CF_JVal arr, const char* val);
 
@@ -717,7 +717,7 @@ CF_API void CF_CALL cf_json_array_add_string(CF_JDoc doc, CF_JVal arr, const cha
  * @function cf_json_array_add_string_range
  * @category json
  * @brief    Adds a string to the end of a json array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API void CF_CALL cf_json_array_add_string_range(CF_JDoc doc, CF_JVal arr, const char* begin, const char* end);
 
@@ -726,7 +726,7 @@ CF_API void CF_CALL cf_json_array_add_string_range(CF_JDoc doc, CF_JVal arr, con
  * @category json
  * @brief    Creates a new array and adds it to the end of a json array.
  * @return   Returns the newly added array.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_array_add_array(CF_JDoc doc, CF_JVal arr);
 
@@ -735,7 +735,7 @@ CF_API CF_JVal CF_CALL cf_json_array_add_array(CF_JDoc doc, CF_JVal arr);
  * @category json
  * @brief    Adds an empty object to the end of a json array.
  * @return   Returns the newly added empty object.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_array_add_object(CF_JDoc doc, CF_JVal arr);
 
@@ -743,7 +743,7 @@ CF_API CF_JVal CF_CALL cf_json_array_add_object(CF_JDoc doc, CF_JVal arr);
  * @function cf_json_array_pop
  * @category json
  * @brief    Removes the last element of the array and returns it.
- * @related  CF_JVal cf_json_array_add cf_json_object_add
+ * @related  cf_json_array_add cf_json_object_add CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_array_pop(CF_JVal arr);
 
@@ -754,7 +754,7 @@ CF_API CF_JVal CF_CALL cf_json_array_pop(CF_JVal arr);
  * @function cf_json_object
  * @category json
  * @brief    Creates a new empty json object.
- * @related  CF_JVal cf_json_object cf_json_object_from_strings cf_json_object_from_string_pairs
+ * @related  cf_json_object_from_strings cf_json_object_from_string_pairs CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_object(CF_JDoc doc);
 
@@ -762,7 +762,7 @@ CF_API CF_JVal CF_CALL cf_json_object(CF_JDoc doc);
  * @function cf_json_object_from_strings
  * @category json
  * @brief    Creates a new json object from an array of key/val pairs as strings.
- * @related  CF_JVal cf_json_object cf_json_object_from_strings cf_json_object_from_string_pairs
+ * @related  cf_json_object_from_string_pairs cf_json_object CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_object_from_strings(CF_JDoc doc, const char** keys, const char** vals, int count);
 
@@ -770,7 +770,7 @@ CF_API CF_JVal CF_CALL cf_json_object_from_strings(CF_JDoc doc, const char** key
  * @function cf_json_object_from_string_pairs
  * @category json
  * @brief    Creates a new json object from an array of key/val pairs as strings.
- * @related  CF_JVal cf_json_object cf_json_object_from_strings cf_json_object_from_string_pairs
+ * @related  cf_json_object_from_strings cf_json_object CF_JVal
  */
 CF_API CF_JVal CF_CALL cf_json_object_from_string_pairs(CF_JDoc doc, const char** kv_pairs, int pair_count);
 
@@ -781,7 +781,7 @@ CF_API CF_JVal CF_CALL cf_json_object_from_string_pairs(CF_JDoc doc, const char*
  * @function cf_json_object_add
  * @category json
  * @brief    Adds a property (key/val pair) to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float
  */
 CF_API void CF_CALL cf_json_object_add(CF_JDoc doc, CF_JVal obj, const char* key, CF_JVal val);
 
@@ -789,7 +789,7 @@ CF_API void CF_CALL cf_json_object_add(CF_JDoc doc, CF_JVal obj, const char* key
  * @function cf_json_object_add_null
  * @category json
  * @brief    Adds a null to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool
  */
 CF_API void CF_CALL cf_json_object_add_null(CF_JDoc doc, CF_JVal obj, const char* key);
 
@@ -797,7 +797,7 @@ CF_API void CF_CALL cf_json_object_add_null(CF_JDoc doc, CF_JVal obj, const char
  * @function cf_json_object_add_int
  * @category json
  * @brief    Adds a 32-bit signed int to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_float cf_json_object_add_bool
  */
 CF_API void CF_CALL cf_json_object_add_int(CF_JDoc doc, CF_JVal obj, const char* key, int val);
 
@@ -805,7 +805,7 @@ CF_API void CF_CALL cf_json_object_add_int(CF_JDoc doc, CF_JVal obj, const char*
  * @function cf_json_object_add_i64
  * @category json
  * @brief    Adds a 64-bit signed int to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_int cf_json_object_add_null cf_json_object_add_float
  */
 CF_API void CF_CALL cf_json_object_add_i64(CF_JDoc doc, CF_JVal obj, const char* key, int64_t val);
 
@@ -813,7 +813,7 @@ CF_API void CF_CALL cf_json_object_add_i64(CF_JDoc doc, CF_JVal obj, const char*
  * @function cf_json_object_add_u64
  * @category json
  * @brief    Adds a 64-bit unsigned int to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float
  */
 CF_API void CF_CALL cf_json_object_add_u64(CF_JDoc doc, CF_JVal obj, const char* key, uint64_t val);
 
@@ -821,7 +821,7 @@ CF_API void CF_CALL cf_json_object_add_u64(CF_JDoc doc, CF_JVal obj, const char*
  * @function cf_json_object_add_float
  * @category json
  * @brief    Adds a 32-bit float to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_int cf_json_object_add_bool
  */
 CF_API void CF_CALL cf_json_object_add_float(CF_JDoc doc, CF_JVal obj, const char* key, float val);
 
@@ -829,7 +829,7 @@ CF_API void CF_CALL cf_json_object_add_float(CF_JDoc doc, CF_JVal obj, const cha
  * @function cf_json_object_add_double
  * @category json
  * @brief    Adds a 64-bit float to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float
  */
 CF_API void CF_CALL cf_json_object_add_double(CF_JDoc doc, CF_JVal obj, const char* key, double val);
 
@@ -837,7 +837,7 @@ CF_API void CF_CALL cf_json_object_add_double(CF_JDoc doc, CF_JVal obj, const ch
  * @function cf_json_object_add_bool
  * @category json
  * @brief    Adds a bool to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string
+ * @related  cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float
  */
 CF_API void CF_CALL cf_json_object_add_bool(CF_JDoc doc, CF_JVal obj, const char* key, bool val);
 
@@ -845,7 +845,7 @@ CF_API void CF_CALL cf_json_object_add_bool(CF_JDoc doc, CF_JVal obj, const char
  * @function cf_json_object_add_string
  * @category json
  * @brief    Adds a string to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string cf_json_object_add_string_range
+ * @related  cf_json_object_add_string_range cf_json_object_add_null cf_json_object_add_int
  */
 CF_API void CF_CALL cf_json_object_add_string(CF_JDoc doc, CF_JVal obj, const char* key, const char* val);
 
@@ -853,7 +853,7 @@ CF_API void CF_CALL cf_json_object_add_string(CF_JDoc doc, CF_JVal obj, const ch
  * @function cf_json_object_add_string_range
  * @category json
  * @brief    Adds a string to a json object.
- * @related  CF_JVal cf_json_object_add cf_json_object_add_null cf_json_object_add_int cf_json_object_add_float cf_json_object_add_bool cf_json_object_add_string cf_json_object_add_string_range
+ * @related  cf_json_object_add_string cf_json_object_add_null cf_json_object_add_int
  */
 CF_API void CF_CALL cf_json_object_add_string_range(CF_JDoc doc, CF_JVal obj, const char* key, const char* begin, const char* end);
 
@@ -864,7 +864,7 @@ CF_API void CF_CALL cf_json_object_add_string_range(CF_JDoc doc, CF_JVal obj, co
  * @function cf_json_object_remove_key
  * @category json
  * @brief    Removes a key/val pair from a json object.
- * @related  CF_JVal cf_json_object_remove_key cf_json_object_remove_key_range cf_json_object_rename_key cf_json_object_rename_key_range
+ * @related  cf_json_object_remove_key_range cf_json_object_rename_key cf_json_object_rename_key_range
  */
 CF_API void CF_CALL cf_json_object_remove_key(CF_JVal obj, const char* key);
 
@@ -872,7 +872,7 @@ CF_API void CF_CALL cf_json_object_remove_key(CF_JVal obj, const char* key);
  * @function cf_json_object_remove_key_range
  * @category json
  * @brief    Removes a key/val pair from a json object.
- * @related  CF_JVal cf_json_object_remove_key cf_json_object_remove_key_range cf_json_object_rename_key cf_json_object_rename_key_range
+ * @related  cf_json_object_remove_key cf_json_object_rename_key cf_json_object_rename_key_range
  */
 CF_API void CF_CALL cf_json_object_remove_key_range(CF_JVal obj, const char* key_begin, const char* key_end);
 
@@ -880,7 +880,7 @@ CF_API void CF_CALL cf_json_object_remove_key_range(CF_JVal obj, const char* key
  * @function cf_json_object_rename_key
  * @category json
  * @brief    Renames a key/val pair from a json object.
- * @related  CF_JVal cf_json_object_remove_key cf_json_object_remove_key_range cf_json_object_rename_key cf_json_object_rename_key_range
+ * @related  cf_json_object_rename_key_range cf_json_object_remove_key cf_json_object_remove_key_range
  */
 CF_API void CF_CALL cf_json_object_rename_key(CF_JDoc doc, CF_JVal obj, const char* key, const char* rename);
 
@@ -888,7 +888,7 @@ CF_API void CF_CALL cf_json_object_rename_key(CF_JDoc doc, CF_JVal obj, const ch
  * @function cf_json_object_rename_key_range
  * @category json
  * @brief    Renames a key/val pair from a json object.
- * @related  CF_JVal cf_json_object_remove_key cf_json_object_remove_key_range cf_json_object_rename_key cf_json_object_rename_key_range
+ * @related  cf_json_object_rename_key cf_json_object_remove_key cf_json_object_remove_key_range
  */
 CF_API void CF_CALL cf_json_object_rename_key_range(CF_JDoc doc, CF_JVal obj, const char* key_begin, const char* key_end, const char* rename_begin, const char* rename_end);
 
@@ -901,7 +901,7 @@ CF_API void CF_CALL cf_json_object_rename_key_range(CF_JDoc doc, CF_JVal obj, co
  * @brief    Saves the json document as a string.
  * @return   Returns a dynamic string, free it with `sfree` when done.
  * @remarks  If you want to remove all unnecessary formatting/whitespace then use `cf_json_to_string_minimal`.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file cf_json_to_string_minimal cf_json_to_file_minimal
+ * @related  cf_json_to_string_minimal cf_json_to_file cf_json_to_file_minimal
  */
 CF_API dyna char* CF_CALL cf_json_to_string(CF_JDoc doc);
 
@@ -910,7 +910,7 @@ CF_API dyna char* CF_CALL cf_json_to_string(CF_JDoc doc);
  * @category json
  * @brief    Saves the json document as a string.
  * @return   Returns a dynamic string, free it with `sfree` when done.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file
+ * @related  cf_json_to_string cf_json_to_file cf_json_get_root
  */
 CF_API dyna char* CF_CALL cf_json_to_string_minimal(CF_JDoc doc);
 
@@ -921,7 +921,7 @@ CF_API dyna char* CF_CALL cf_json_to_string_minimal(CF_JDoc doc);
  * @param    virtual_path  A virtual path to the json file. Make sure to setup your write directory with `cf_fs_set_write_directory`. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @brief    Saves the json document to a file.
  * @remarks  If you want to remove all unnecessary formatting/whitespace then use `cf_json_to_file_minimal`.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file cf_json_to_string_minimal cf_json_to_file_minimal
+ * @related  cf_json_to_file_minimal cf_json_to_string cf_json_to_string_minimal
  */
 CF_API CF_Result CF_CALL cf_json_to_file(CF_JDoc doc, const char* virtual_path);
 
@@ -931,7 +931,7 @@ CF_API CF_Result CF_CALL cf_json_to_file(CF_JDoc doc, const char* virtual_path);
  * @param    doc           The json document to save.
  * @param    virtual_path  A virtual path to the json file. Make sure to setup your write directory with `cf_fs_set_write_directory`. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
  * @brief    Saves the json document to a file.
- * @related  CF_JDoc cf_make_json cf_make_json_from_file cf_json_get_root cf_destroy_json cf_json_get_root cf_json_to_string cf_json_to_file cf_json_to_string_minimal cf_json_to_file_minimal
+ * @related  cf_json_to_file cf_json_to_string cf_json_to_string_minimal
  */
 CF_API CF_Result CF_CALL cf_json_to_file_minimal(CF_JDoc doc, const char* virtual_path);
 

--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -84,7 +84,7 @@ extern "C" {
  *           ```
  *           
  *           The C++ API uses `V2(x, y)`.
- * @related  CF_V2 cf_add_v2 cf_sub_v2 cf_dot cf_mul_v2_f cf_div_v2_f
+ * @related  cf_add_v2 cf_sub_v2 cf_dot
  */
 typedef struct CF_V2
 {
@@ -109,7 +109,7 @@ CF_INLINE CF_V2 cf_v2(float x, float y)
  * @category math
  * @brief    Rotation about an axis composed of cos/sin pair.
  * @remarks  You can construct an identity with the `CF_SinCos cf_sin_cos()` function.
- * @related  CF_SinCos cf_sincos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2
+ * @related  cf_sincos cf_sincos_f cf_x_axis
  */
 typedef struct CF_SinCos
 {
@@ -125,7 +125,7 @@ typedef struct CF_SinCos
  * @struct   CF_M2x2
  * @category math
  * @brief    2x2 matrix.
- * @related  CF_M2x2 cf_mul_m2_f cf_mul_m2_v2 cf_mul_m2
+ * @related  cf_mul_m2_f cf_mul_m2_v2 cf_mul_m2
  */
 typedef struct CF_M2x2
 {
@@ -142,7 +142,7 @@ typedef struct CF_M2x2
  * @category math
  * @brief    2d transformation.
  * @remarks  Mostly useful for graphics and not physics colliders, since it supports scale.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_mul_m32_v2 cf_mul_m32 cf_make_identity
  */
 typedef struct CF_M3x2
 {
@@ -159,7 +159,7 @@ typedef struct CF_M3x2
  * @category math
  * @brief    2d transformation.
  * @remarks  Mostly useful for physics colliders since there's no scale.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_make_transform cf_make_transform_TR cf_mul_tf_v2
  */
 typedef struct CF_Transform
 {
@@ -175,7 +175,7 @@ typedef struct CF_Transform
  * @struct   CF_Halfspace
  * @category math
  * @brief    2d plane, aka line.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_intersect_halfspace
+ * @related  cf_plane cf_origin cf_distance_hs
  */
 typedef struct CF_Halfspace
 {
@@ -192,7 +192,7 @@ typedef struct CF_Halfspace
  * @category math
  * @brief    A ray.
  * @remarks  A ray is a directional line segment. It starts at an endpoint and extends into another direction for a specified distance (defined by `t`).
- * @related  CF_Ray cf_impact cf_endpoint cf_ray_to_halfspace cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_halfspace cf_ray_to_circle cf_ray_to_aabb
  */
 typedef struct CF_Ray
 {
@@ -211,7 +211,7 @@ typedef struct CF_Ray
  * @struct   CF_Raycast
  * @category math
  * @brief    The results for a raycast query.
- * @related  CF_Raycast cf_ray_to_halfspace cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_halfspace cf_ray_to_circle cf_ray_to_aabb
  */
 typedef struct CF_Raycast
 {
@@ -230,7 +230,7 @@ typedef struct CF_Raycast
  * @struct   CF_Circle
  * @category math
  * @brief    A circle.
- * @related  cf_ray_to_circle cf_circle_to_circle cf_circle_to_aabb cf_circle_to_capsule cf_circle_to_poly cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_circle_to_poly_manifold
+ * @related  cf_circle_to_circle cf_circle_to_aabb cf_circle_to_capsule
  */
 typedef struct CF_Circle
 {
@@ -248,7 +248,7 @@ typedef struct CF_Circle
  * @brief    Axis-aligned bounding box. A box that cannot rotate.
  * @remarks  There are many ways to describ an AABB, such as a point + half-extents, or a point and width/height pair. However, of all
  *           these options the min/max choice is the simplest when it comes to the majority of collision detection routine implementations.
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right cf_contains_point cf_overlaps cf_make_aabb_verts cf_aabb_verts cf_circle_to_aabb cf_aabb_to_aabb cf_aabb_to_capsule cf_aabb_to_poly cf_ray_to_aabb cf_circle_to_aabb_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_aabb_to_poly_manifold
+ * @related  cf_aabb_verts cf_aabb_to_aabb cf_aabb_to_capsule
  */
 typedef struct CF_Aabb
 {
@@ -265,7 +265,7 @@ typedef struct CF_Aabb
  * @category math
  * @brief    Box that cannot rotate defined with integers instead of floats.
  * @remarks  Not used for collision detection, but still sometimes useful.
- * @related  CF_Rect cf_render_settings_push_viewport cf_render_settings_push_scissor
+ * @related  cf_render_settings_push_viewport cf_render_settings_push_scissor
  */
 typedef struct CF_Rect
 {
@@ -280,7 +280,7 @@ typedef struct CF_Rect
  * @brief    The maximum number of vertices in a `CF_Poly`.
  * @remarks  It's quite common to limit the number of verts on polygons to a low number. Feel free to adjust this number if needed,
  *           but be warned: higher than 8 and shapes generally start to look more like circles/ovals; it becomes pointless beyond a certain point.
- * @related  CF_POLY_MAX_VERTS CF_Poly
+ * @related  CF_Poly
  */
 #define CF_POLY_MAX_VERTS 8
 
@@ -289,7 +289,7 @@ typedef struct CF_Rect
  * @category collision
  * @brief    2D polygon, used for collision detection functions.
  * @remarks  Verts are ordered in counter-clockwise order (CCW).
- * @related  CF_POLY_MAX_VERTS CF_Poly cf_circle_to_poly cf_aabb_to_poly cf_capsule_to_poly cf_poly_to_poly cf_ray_to_poly cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_poly_to_poly cf_poly_to_poly_manifold cf_circle_to_poly
  */
 typedef struct CF_Poly
 {
@@ -309,7 +309,7 @@ typedef struct CF_Poly
  * @category collision
  * @brief    A capsule shape.
  * @remarks  It's like a shrink-wrap of 2 circles connected by a rod.
- * @related  CF_Capsule cf_circle_to_capsule cf_aabb_to_capsule cf_capsule_to_capsule cf_capsule_to_poly cf_ray_to_capsule cf_circle_to_capsule_manifold cf_aabb_to_capsule_manifold cf_capsule_to_capsule_manifold cf_capsule_to_poly_manifold
+ * @related  cf_capsule_to_capsule cf_circle_to_capsule cf_aabb_to_capsule
  */
 typedef struct CF_Capsule
 {
@@ -329,7 +329,7 @@ typedef struct CF_Capsule
  * @category collision
  * @brief    Contains all information necessary to resolve a collision.
  * @remarks  This is the information needed to separate shapes that are colliding.
- * @related  CF_Manifold cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_capsule_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_poly_to_poly_manifold cf_circle_to_circle_manifold cf_circle_to_aabb_manifold
  */
 typedef struct CF_Manifold
 {
@@ -368,7 +368,7 @@ typedef struct CF_Manifold
  * @function cf_min
  * @category math
  * @brief    Returns the minimum of two values.
- * @related  cf_min cf_max
+ * @related  cf_max
  */
 #define cf_min(a, b) ((a) < (b) ? (a) : (b))
 
@@ -376,7 +376,7 @@ typedef struct CF_Manifold
  * @function cf_max
  * @category math
  * @brief    Returns the maximum of two values.
- * @related  cf_min cf_max
+ * @related  cf_min
  */
 #define cf_max(a, b) ((b) < (a) ? (a) : (b))
 
@@ -384,7 +384,7 @@ typedef struct CF_Manifold
  * @function cf_abs
  * @category math
  * @brief    Returns absolute value of a float.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_abs(float a) { return CF_FABSF(a); }
 
@@ -392,7 +392,7 @@ CF_INLINE float cf_abs(float a) { return CF_FABSF(a); }
  * @function cf_clamp
  * @category math
  * @brief    Returns `a` float clamped between `lo` and `hi`.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_clamp01 cf_min cf_max
  */
 CF_INLINE float cf_clamp(float a, float lo, float hi) { return cf_max(lo, cf_min(a, hi)); }
 
@@ -400,7 +400,7 @@ CF_INLINE float cf_clamp(float a, float lo, float hi) { return cf_max(lo, cf_min
  * @function cf_clamp01
  * @category math
  * @brief    Returns `a` float clamped between 0.0f and 1.0f.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_clamp cf_min cf_max
  */
 CF_INLINE float cf_clamp01(float a) { return cf_max(0.0f, cf_min(a, 1.0f)); }
 
@@ -408,7 +408,7 @@ CF_INLINE float cf_clamp01(float a) { return cf_max(0.0f, cf_min(a, 1.0f)); }
  * @function cf_sign
  * @category math
  * @brief    Returns the sign (either 1.0f or -1.0f) of `a` float.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_safe_invert cf_min cf_max
  */
 CF_INLINE float cf_sign(float a) { return a < 0 ? -1.0f : 1.0f; }
 
@@ -417,7 +417,7 @@ CF_INLINE float cf_sign(float a) { return a < 0 ? -1.0f : 1.0f; }
  * @category math
  * @brief    Given the distances of two points `a` and `b` to a plane (`da` and `db` respectively), compute the insterection
  *           value used to lerp from `a` to `b` to find the intersection point.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_intersect(float da, float db) { return da / (da - db); }
 
@@ -425,7 +425,7 @@ CF_INLINE float cf_intersect(float da, float db) { return da / (da - db); }
  * @function cf_safe_invert
  * @category math
  * @brief    Computes `1.0f/a`, but returns 0.0f if `a` is zero.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_sign cf_min cf_max
  */
 CF_INLINE float cf_safe_invert(float a) { return a != 0 ? 1.0f / a : 0; }
 
@@ -433,7 +433,7 @@ CF_INLINE float cf_safe_invert(float a) { return a != 0 ? 1.0f / a : 0; }
  * @function cf_lerp
  * @category math
  * @brief    Returns the linear interpolation from `a` to `b` along `t`, where `t` is _usually_ a value from 0.0f to 1.0f.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_lerp(float a, float b, float t) { return a + (b - a) * t; }
 
@@ -441,7 +441,7 @@ CF_INLINE float cf_lerp(float a, float b, float t) { return a + (b - a) * t; }
  * @function cf_remap01
  * @category math
  * @brief    Returns the value `t` remaped from [0, 1] to [lo, hi].
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_remap cf_min cf_max
  */
 CF_INLINE float cf_remap01(float t, float lo, float hi) { return lo + t * (hi - lo); }
 
@@ -449,7 +449,7 @@ CF_INLINE float cf_remap01(float t, float lo, float hi) { return lo + t * (hi - 
  * @function cf_remap
  * @category math
  * @brief    Returns the value `t` remaped from [old_lo, old_hi] to [lo, hi].
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_remap(float t, float old_lo, float old_hi, float lo, float hi) { return lo + ((old_hi - old_lo) != 0 ? (t - old_lo) / (old_hi - old_lo) : 0) * (hi - lo); }
 
@@ -457,7 +457,7 @@ CF_INLINE float cf_remap(float t, float old_lo, float old_hi, float lo, float hi
  * @function cf_mod
  * @category math
  * @brief    Returns floating point `x % m`. Can return negative numbers.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_mod(float x, float m) { return x - (int)(x / m) * m; }
 
@@ -465,7 +465,7 @@ CF_INLINE float cf_mod(float x, float m) { return x - (int)(x / m) * m; }
  * @function cf_fract
  * @category math
  * @brief    Returns the fractional portion of a float.
- * @related  cf_min cf_max cf_clamp cf_clamp01 cf_sign cf_intersect cf_safe_invert cf_lerp cf_remap cf_mod cf_fract
+ * @related  cf_min cf_max cf_clamp
  */
 CF_INLINE float cf_fract(float x) { return x - CF_FLOORF(x); }
 
@@ -473,7 +473,7 @@ CF_INLINE float cf_fract(float x) { return x - CF_FLOORF(x); }
  * @function cf_sign_int
  * @category math
  * @brief    Returns the sign (either 1 or -1) of an int.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_abs_int cf_clamp_int cf_clamp01_int
  */
 CF_INLINE int cf_sign_int(int a) { return a < 0 ? -1 : 1; }
 
@@ -481,7 +481,7 @@ CF_INLINE int cf_sign_int(int a) { return a < 0 ? -1 : 1; }
  * @function cf_abs_int
  * @category math
  * @brief    Returns the absolute value of an int.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_sign_int cf_clamp_int cf_clamp01_int
  */
 CF_INLINE int cf_abs_int(int a) { int mask = a >> ((sizeof(int) * 8) - 1); return (a + mask) ^ mask; }
 
@@ -489,7 +489,7 @@ CF_INLINE int cf_abs_int(int a) { int mask = a >> ((sizeof(int) * 8) - 1); retur
  * @function cf_clamp_int
  * @category math
  * @brief    Returns an int clamped between `lo` and `hi`.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_clamp01_int cf_sign_int cf_abs_int
  */
 CF_INLINE int cf_clamp_int(int a, int lo, int hi) { return cf_max(lo, cf_min(a, hi)); }
 
@@ -497,7 +497,7 @@ CF_INLINE int cf_clamp_int(int a, int lo, int hi) { return cf_max(lo, cf_min(a, 
  * @function cf_clamp01_int
  * @category math
  * @brief    Returns an int clamped between 0 and 1.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_clamp_int cf_sign_int cf_abs_int
  */
 CF_INLINE int cf_clamp01_int(int a) { return cf_max(0, cf_min(a, 1)); }
 
@@ -505,7 +505,7 @@ CF_INLINE int cf_clamp01_int(int a) { return cf_max(0, cf_min(a, 1)); }
  * @function cf_is_even
  * @category math
  * @brief    Returns true if an int is even.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_is_odd cf_sign_int cf_abs_int
  */
 CF_INLINE bool cf_is_even(int x) { return (x % 2) == 0; }
 
@@ -513,7 +513,7 @@ CF_INLINE bool cf_is_even(int x) { return (x % 2) == 0; }
  * @function cf_is_odd
  * @category math
  * @brief    Returns true if an int is odd.
- * @related  cf_sign_int cf_abs_int cf_clamp_int cf_clamp01_int cf_is_even cf_is_odd
+ * @related  cf_is_even cf_sign_int cf_abs_int
  */
 CF_INLINE bool cf_is_odd(int x) { return !cf_is_even(x); }
 
@@ -524,7 +524,7 @@ CF_INLINE bool cf_is_odd(int x) { return !cf_is_even(x); }
  * @function cf_is_power_of_two
  * @category math
  * @brief    Returns true if an int is a power of two.
- * @related  cf_is_power_of_two cf_is_power_of_two_uint cf_fit_power_of_two
+ * @related  cf_is_power_of_two_uint cf_fit_power_of_two
  */
 CF_INLINE bool cf_is_power_of_two(int a) { return a != 0 && (a & (a - 1)) == 0; }
 
@@ -532,7 +532,7 @@ CF_INLINE bool cf_is_power_of_two(int a) { return a != 0 && (a & (a - 1)) == 0; 
  * @function cf_is_power_of_two_uint
  * @category math
  * @brief    Returns true if an unsigned int is a power of two.
- * @related  cf_is_power_of_two cf_is_power_of_two_uint cf_fit_power_of_two
+ * @related  cf_is_power_of_two cf_fit_power_of_two
  */
 CF_INLINE bool cf_is_power_of_two_uint(uint64_t a) { return a != 0 && (a & (a - 1)) == 0; }
 
@@ -540,7 +540,7 @@ CF_INLINE bool cf_is_power_of_two_uint(uint64_t a) { return a != 0 && (a & (a - 
  * @function cf_fit_power_of_two
  * @category math
  * @brief    Returns an integer clamped upwards to the nearest power of two.
- * @related  cf_is_power_of_two cf_is_power_of_two_uint cf_fit_power_of_two
+ * @related  cf_is_power_of_two cf_is_power_of_two_uint
  */
 CF_INLINE int cf_fit_power_of_two(int a) { a--; a |= a >> 1; a |= a >> 2; a |= a >> 4; a |= a >> 8; a |= a >> 16; a++; return a; }
 
@@ -561,7 +561,7 @@ CF_INLINE float cf_smoothstep(float x) { return x * x * (3.0f - 2.0f * x); }
  * @category math
  * @brief    Returns the quadratic-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quad_in cf_quad_out cf_quad_in_out
+ * @related  cf_quad_in_out cf_quad_out
  */
 CF_INLINE float cf_quad_in(float x) { return x * x; }
 
@@ -570,7 +570,7 @@ CF_INLINE float cf_quad_in(float x) { return x * x; }
  * @category math
  * @brief    Returns the quadratic-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quad_in cf_quad_out cf_quad_in_out
+ * @related  cf_quad_in cf_quad_in_out
  */
 CF_INLINE float cf_quad_out(float x) { return -(x * (x - 2.0f)); }
 
@@ -579,7 +579,7 @@ CF_INLINE float cf_quad_out(float x) { return -(x * (x - 2.0f)); }
  * @category math
  * @brief    Returns the quadratic ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quad_in cf_quad_out cf_quad_in_out
+ * @related  cf_quad_in cf_quad_out
  */
 CF_INLINE float cf_quad_in_out(float x) { if (x < 0.5f) return 2.0f * x * x; else return (-2.0f * x * x) + (4.0f * x) - 1.0f; }
 
@@ -588,7 +588,7 @@ CF_INLINE float cf_quad_in_out(float x) { if (x < 0.5f) return 2.0f * x * x; els
  * @category math
  * @brief    Returns the cubic-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_cube_in cf_cube_out cf_cube_in_out
+ * @related  cf_cube_in_out cf_cube_out
  */
 CF_INLINE float cf_cube_in(float x) { return x * x * x; }
 
@@ -597,7 +597,7 @@ CF_INLINE float cf_cube_in(float x) { return x * x * x; }
  * @category math
  * @brief    Returns the cubic-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_cube_in cf_cube_out cf_cube_in_out
+ * @related  cf_cube_in cf_cube_in_out
  */
 CF_INLINE float cf_cube_out(float x) { float f = (x - 1); return f * f * f + 1.0f; }
 
@@ -606,7 +606,7 @@ CF_INLINE float cf_cube_out(float x) { float f = (x - 1); return f * f * f + 1.0
  * @category math
  * @brief    Returns the cubic ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_cube_in cf_cube_out cf_cube_in_out
+ * @related  cf_cube_in cf_cube_out
  */
 CF_INLINE float cf_cube_in_out(float x) { if (x < 0.5f) return 4.0f * x * x * x; else { return 0.5f * x * x * x + 1.0f; } }
 
@@ -615,7 +615,7 @@ CF_INLINE float cf_cube_in_out(float x) { if (x < 0.5f) return 4.0f * x * x * x;
  * @category math
  * @brief    Returns the quartic-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quart_in cf_quart_out cf_quart_in_out
+ * @related  cf_quart_in_out cf_quart_out
  */
 CF_INLINE float cf_quart_in(float x) { return x * x * x * x; }
 
@@ -624,7 +624,7 @@ CF_INLINE float cf_quart_in(float x) { return x * x * x * x; }
  * @category math
  * @brief    Returns the quartic-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quart_in cf_quart_out cf_quart_in_out
+ * @related  cf_quart_in cf_quart_in_out
  */
 CF_INLINE float cf_quart_out(float x) { float f = (x - 1.0f); return f * f * f * (1.0f - x) + 1.0f; }
 
@@ -633,7 +633,7 @@ CF_INLINE float cf_quart_out(float x) { float f = (x - 1.0f); return f * f * f *
  * @category math
  * @brief    Returns the quartic ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quart_in cf_quart_out cf_quart_in_out
+ * @related  cf_quart_in cf_quart_out
  */
 CF_INLINE float cf_quart_in_out(float x) { if (x < 0.5f) return 8.0f * x * x * x * x; else { float f = (x - 1); return -8.0f * f * f * f * f + 1.0f; } }
 
@@ -642,7 +642,7 @@ CF_INLINE float cf_quart_in_out(float x) { if (x < 0.5f) return 8.0f * x * x * x
  * @category math
  * @brief    Returns the quintic-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quint_in cf_quint_out cf_quint_in_out
+ * @related  cf_quint_in_out cf_quint_out
  */
 CF_INLINE float cf_quint_in(float x) { return x * x * x * x * x; }
 
@@ -651,7 +651,7 @@ CF_INLINE float cf_quint_in(float x) { return x * x * x * x * x; }
  * @category math
  * @brief    Returns the quintic-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quint_in cf_quint_out cf_quint_in_out
+ * @related  cf_quint_in cf_quint_in_out
  */
 CF_INLINE float cf_quint_out(float x) { float f = (x - 1); return f * f * f * f * f + 1.0f; }
 
@@ -660,7 +660,7 @@ CF_INLINE float cf_quint_out(float x) { float f = (x - 1); return f * f * f * f 
  * @category math
  * @brief    Returns the quintic ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_quint_in cf_quint_out cf_quint_in_out
+ * @related  cf_quint_in cf_quint_out
  */
 CF_INLINE float cf_quint_in_out(float x) { if (x < 0.5f) return 16.0f * x * x * x * x * x; else { float f = ((2.0f * x) - 2.0f); return  0.5f * f * f * f * f * f + 1.0f; } }
 
@@ -669,7 +669,7 @@ CF_INLINE float cf_quint_in_out(float x) { if (x < 0.5f) return 16.0f * x * x * 
  * @category math
  * @brief    Returns the sin-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_sin_in cf_sin_out cf_sin_in_out
+ * @related  cf_sin_in_out cf_sin_out
  */
 CF_INLINE float cf_sin_in(float x) { return CF_SINF((x - 1.0f) * CF_PI * 0.5f) + 1.0f; }
 
@@ -678,7 +678,7 @@ CF_INLINE float cf_sin_in(float x) { return CF_SINF((x - 1.0f) * CF_PI * 0.5f) +
  * @category math
  * @brief    Returns the sin-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_sin_in cf_sin_out cf_sin_in_out
+ * @related  cf_sin_in cf_sin_in_out
  */
 CF_INLINE float cf_sin_out(float x) { return CF_SINF(x * (CF_PI * 0.5f)); }
 
@@ -687,7 +687,7 @@ CF_INLINE float cf_sin_out(float x) { return CF_SINF(x * (CF_PI * 0.5f)); }
  * @category math
  * @brief    Returns the sin ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_sin_in cf_sin_out cf_sin_in_out
+ * @related  cf_sin_in cf_sin_out
  */
 CF_INLINE float cf_sin_in_out(float x) { return 0.5f * (1.0f - CF_COSF(x * CF_PI)); }
 
@@ -696,7 +696,7 @@ CF_INLINE float cf_sin_in_out(float x) { return 0.5f * (1.0f - CF_COSF(x * CF_PI
  * @category math
  * @brief    Returns the circle-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_circle_in cf_circle_out cf_circle_in_out
+ * @related  cf_circle_in_out cf_circle_out
  */
 CF_INLINE float cf_circle_in(float x) { return 1.0f - CF_SQRTF(1.0f - (x * x)); }
 
@@ -705,7 +705,7 @@ CF_INLINE float cf_circle_in(float x) { return 1.0f - CF_SQRTF(1.0f - (x * x)); 
  * @category math
  * @brief    Returns the circle-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_circle_in cf_circle_out cf_circle_in_out
+ * @related  cf_circle_in cf_circle_in_out
  */
 CF_INLINE float cf_circle_out(float x) { return CF_SQRTF((2.0f - x) * x); }
 
@@ -714,7 +714,7 @@ CF_INLINE float cf_circle_out(float x) { return CF_SQRTF((2.0f - x) * x); }
  * @category math
  * @brief    Returns the circle ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_circle_in cf_circle_out cf_circle_in_out
+ * @related  cf_circle_in cf_circle_out
  */
 CF_INLINE float cf_circle_in_out(float x) { if (x < 0.5f) return 0.5f * (1.0f - CF_SQRTF(1.0f - 4.0f * (x * x))); else return 0.5f * (CF_SQRTF(-((2.0f * x) - 3.0f) * ((2.0f * x) - 1.0f)) + 1.0f); }
 
@@ -723,7 +723,7 @@ CF_INLINE float cf_circle_in_out(float x) { if (x < 0.5f) return 0.5f * (1.0f - 
  * @category math
  * @brief    Returns the back-in ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_back_in cf_back_out cf_back_in_out
+ * @related  cf_back_in_out cf_back_out
  */
 CF_INLINE float cf_back_in(float x) { return x * x * x - x * CF_SINF(x * CF_PI); }
 
@@ -732,7 +732,7 @@ CF_INLINE float cf_back_in(float x) { return x * x * x - x * CF_SINF(x * CF_PI);
  * @category math
  * @brief    Returns the back-out ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_back_in cf_back_out cf_back_in_out
+ * @related  cf_back_in cf_back_in_out
  */
 CF_INLINE float cf_back_out(float x) { float f = (1.0f - x); return 1.0f - (x * x * x - x * CF_SINF(f * CF_PI)); }
 
@@ -741,7 +741,7 @@ CF_INLINE float cf_back_out(float x) { float f = (1.0f - x); return 1.0f - (x * 
  * @category math
  * @brief    Returns the back ease of a float from 0.0f to 1.0f.
  * @remarks  Here is a great link to [visualize each easing function](https://easings.net/).
- * @related  cf_back_in cf_back_out cf_back_in_out
+ * @related  cf_back_in cf_back_out
  */
 CF_INLINE float cf_back_in_out(float x) { if (x < 0.5f) { float f = 2.0f * x; return 0.5f * (f * f * f - f * CF_SINF(f * CF_PI)); } else { float f = (1.0f - (2.0f * x - 1.0f)); return 0.5f * (1.0f - (f * f * f - f * CF_SINF(f * CF_PI))) + 0.5f; } }
 
@@ -752,7 +752,7 @@ CF_INLINE float cf_back_in_out(float x) { if (x < 0.5f) { float f = 2.0f * x; re
  * @function cf_add_v2
  * @category math
  * @brief    Returns two vectors added together.
- * @related  CF_V2 cf_add_v2 cf_sub_v2 cf_dot cf_mul_v2_f cf_div_v2_f
+ * @related  cf_sub_v2 cf_dot cf_mul_v2_f
  */
 CF_INLINE CF_V2 cf_add_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x + b.x, a.y + b.y); }
 
@@ -760,7 +760,7 @@ CF_INLINE CF_V2 cf_add_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x + b.x, a.y + b.y)
  * @function cf_sub_v2
  * @category math
  * @brief    Returns a vector subtracted from another.
- * @related  CF_V2 cf_add_v2 cf_sub_v2 cf_dot cf_mul_v2_f cf_div_v2_f
+ * @related  cf_add_v2 cf_dot cf_mul_v2_f
  */
 CF_INLINE CF_V2 cf_sub_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x - b.x, a.y - b.y); }
 
@@ -768,7 +768,7 @@ CF_INLINE CF_V2 cf_sub_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x - b.x, a.y - b.y)
  * @function cf_dot
  * @category math
  * @brief    Returns the dot product of two vectors.
- * @related  CF_V2 cf_add_v2 cf_sub_v2 cf_dot cf_mul_v2_f cf_div_v2_f
+ * @related  cf_div_v2_f cf_add_v2 cf_sub_v2
  */
 CF_INLINE float cf_dot(CF_V2 a, CF_V2 b) { return a.x * b.x + a.y * b.y; }
 
@@ -776,7 +776,7 @@ CF_INLINE float cf_dot(CF_V2 a, CF_V2 b) { return a.x * b.x + a.y * b.y; }
  * @function cf_mul_v2_f
  * @category math
  * @brief    Multiplies a vector with a float.
- * @related  CF_V2 cf_mul_v2_f cf_mul_v2 cf_div_v2_f
+ * @related  cf_mul_v2 cf_div_v2_f CF_V2
  */
 CF_INLINE CF_V2 cf_mul_v2_f(CF_V2 a, float b) { return cf_v2(a.x * b, a.y * b); }
 
@@ -785,7 +785,7 @@ CF_INLINE CF_V2 cf_mul_v2_f(CF_V2 a, float b) { return cf_v2(a.x * b, a.y * b); 
  * @category math
  * @brief    Multiplies two vectors together component-wise.
  * @remarks  The vector returned is `{ a.x * b.x, a.y * b.y }`.
- * @related  CF_V2 cf_mul_v2_f cf_mul_v2 cf_div_v2_f
+ * @related  cf_mul_v2_f cf_div_v2_f CF_V2
  */
 CF_INLINE CF_V2 cf_mul_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x * b.x, a.y * b.y); }
 
@@ -793,7 +793,7 @@ CF_INLINE CF_V2 cf_mul_v2(CF_V2 a, CF_V2 b) { return cf_v2(a.x * b.x, a.y * b.y)
  * @function cf_div_v2_f
  * @category math
  * @brief    Divides a vector by a float.
- * @related  CF_V2 cf_mul_v2_f cf_mul_v2 cf_div_v2_f
+ * @related  cf_mul_v2_f cf_mul_v2 CF_V2
  */
 CF_INLINE CF_V2 cf_div_v2_f(CF_V2 a, float b) { return cf_v2(a.x / b, a.y / b); }
 
@@ -801,7 +801,7 @@ CF_INLINE CF_V2 cf_div_v2_f(CF_V2 a, float b) { return cf_v2(a.x / b, a.y / b); 
  * @function cf_skew
  * @category math
  * @brief    Returns the skew of a vector. This acts like a 90 degree rotation counter-clockwise.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_perp
+ * @related  cf_cw90 cf_det2 cf_cross
  */
 CF_INLINE CF_V2 cf_skew(CF_V2 a) { return cf_v2(-a.y, a.x); }
 
@@ -810,7 +810,7 @@ CF_INLINE CF_V2 cf_skew(CF_V2 a) { return cf_v2(-a.y, a.x); }
  * @category math
  * @brief    Returns the skew of a vector. This acts like a 90 degree rotation counter-clockwise. In this case
  *           perp stands for perpendicular.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_perp
+ * @related  cf_skew cf_cw90 cf_det2
  */
 CF_INLINE CF_V2 cf_perp(CF_V2 a) { return cf_v2(-a.y, a.x); }
 
@@ -818,7 +818,7 @@ CF_INLINE CF_V2 cf_perp(CF_V2 a) { return cf_v2(-a.y, a.x); }
  * @function cf_cw90
  * @category math
  * @brief    Returns the anti-skew of a vector. This acts like a 90 degree rotation clockwise.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross
+ * @related  cf_cross cf_skew cf_det2
  */
 CF_INLINE CF_V2 cf_cw90(CF_V2 a) { return cf_v2(a.y, -a.x); }
 
@@ -827,7 +827,7 @@ CF_INLINE CF_V2 cf_cw90(CF_V2 a) { return cf_v2(a.y, -a.x); }
  * @category math
  * @brief    Returns the 2x2 determinant of a matrix constructed with `a` and `b` as its columns.
  * @remarks  Also known as the 2D cross product.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_perp
+ * @related  cf_skew cf_cw90 cf_cross
  */
 CF_INLINE float cf_det2(CF_V2 a, CF_V2 b) { return a.x * b.y - a.y * b.x; }
 
@@ -835,7 +835,7 @@ CF_INLINE float cf_det2(CF_V2 a, CF_V2 b) { return a.x * b.y - a.y * b.x; }
  * @function cf_cross
  * @category math
  * @brief    Returns the 2D cross product of two vectors.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_perp
+ * @related  cf_cw90 cf_skew cf_det2
  */
 CF_INLINE float cf_cross(CF_V2 a, CF_V2 b) { return cf_det2(a, b); }
 
@@ -843,7 +843,7 @@ CF_INLINE float cf_cross(CF_V2 a, CF_V2 b) { return cf_det2(a, b); }
  * @function cf_cross_v2_f
  * @category math
  * @brief    Returns the 2D cross product of a vector against a scalar.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_cross_v2_f cf_cross_f_v2
+ * @related  cf_cross_f_v2 cf_cross cf_cw90
  */
 CF_INLINE CF_V2 cf_cross_v2_f(CF_V2 a, float b) { return cf_v2(b * a.y, -b * a.x); }
 
@@ -851,7 +851,7 @@ CF_INLINE CF_V2 cf_cross_v2_f(CF_V2 a, float b) { return cf_v2(b * a.y, -b * a.x
  * @function cf_cross_f_v2
  * @category math
  * @brief    Returns the 2D cross product of a scalar against a vector.
- * @related  CF_V2 cf_skew cf_cw90 cf_det2 cf_cross cf_cross_v2_f cf_cross_f_v2
+ * @related  cf_cross_v2_f cf_cross cf_cw90
  */
 CF_INLINE CF_V2 cf_cross_f_v2(float a, CF_V2 b) { return cf_v2(-a * b.y, a * b.x); }
 
@@ -860,7 +860,7 @@ CF_INLINE CF_V2 cf_cross_f_v2(float a, CF_V2 b) { return cf_v2(-a * b.y, a * b.x
  * @category math
  * @brief    Returns the component-wise minimum of two vectors.
  * @remarks  The vector returned has the value `{ cf_min(a.x, b.x), cf_min(a.y, b.y) }`. See `cf_min`.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_max_v2 cf_clamp_v2 cf_clamp01_v2
  */
 CF_INLINE CF_V2 cf_min_v2(CF_V2 a, CF_V2 b) { return cf_v2(cf_min(a.x, b.x), cf_min(a.y, b.y)); }
 
@@ -869,7 +869,7 @@ CF_INLINE CF_V2 cf_min_v2(CF_V2 a, CF_V2 b) { return cf_v2(cf_min(a.x, b.x), cf_
  * @category math
  * @brief    Returns the component-wise maximum of two vectors.
  * @remarks  The vector returned has the value `{ cf_max(a.x, b.x), cf_max(a.y, b.y) }`. See `cf_max`.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_min_v2 cf_clamp_v2 cf_clamp01_v2
  */
 CF_INLINE CF_V2 cf_max_v2(CF_V2 a, CF_V2 b) { return cf_v2(cf_max(a.x, b.x), cf_max(a.y, b.y)); }
 
@@ -877,7 +877,7 @@ CF_INLINE CF_V2 cf_max_v2(CF_V2 a, CF_V2 b) { return cf_v2(cf_max(a.x, b.x), cf_
  * @function cf_clamp_v2
  * @category math
  * @brief    Returns the component-wise clamp of two vectors from `lo` to `hi`.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_clamp01_v2 cf_min_v2 cf_max_v2
  */
 CF_INLINE CF_V2 cf_clamp_v2(CF_V2 a, CF_V2 lo, CF_V2 hi) { return cf_max_v2(lo, cf_min_v2(a, hi)); }
 
@@ -885,7 +885,7 @@ CF_INLINE CF_V2 cf_clamp_v2(CF_V2 a, CF_V2 lo, CF_V2 hi) { return cf_max_v2(lo, 
  * @function cf_clamp01_v2
  * @category math
  * @brief    Returns the component-wise clamp of two vectors from 0.0f to 1.0f.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_clamp_v2 cf_min_v2 cf_max_v2
  */
 CF_INLINE CF_V2 cf_clamp01_v2(CF_V2 a) { return cf_max_v2(cf_v2(0, 0), cf_min_v2(a, cf_v2(1, 1))); }
 
@@ -893,7 +893,7 @@ CF_INLINE CF_V2 cf_clamp01_v2(CF_V2 a) { return cf_max_v2(cf_v2(0, 0), cf_min_v2
  * @function cf_abs_v2
  * @category math
  * @brief    Returns the component-wise absolute value of two vectors.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_min_v2 cf_max_v2 cf_clamp_v2
  */
 CF_INLINE CF_V2 cf_abs_v2(CF_V2 a) { return cf_v2(CF_FABSF(a.x), CF_FABSF(a.y)); }
 
@@ -901,7 +901,7 @@ CF_INLINE CF_V2 cf_abs_v2(CF_V2 a) { return cf_v2(CF_FABSF(a.x), CF_FABSF(a.y));
  * @function cf_hmin
  * @category math
  * @brief    Returns minimum of all components of a vector.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_hmax cf_min_v2 cf_max_v2
  */
 CF_INLINE float cf_hmin(CF_V2 a) { return cf_min(a.x, a.y); }
 
@@ -909,7 +909,7 @@ CF_INLINE float cf_hmin(CF_V2 a) { return cf_min(a.x, a.y); }
  * @function cf_hmax
  * @category math
  * @brief    Returns maximum of all components of a vector.
- * @related  CF_V2 cf_min_v2 cf_max_v2 cf_clamp_v2 cf_clamp01_v2 cf_abs_v2 cf_hmin cf_hmax
+ * @related  cf_hmin cf_min_v2 cf_max_v2
  */
 CF_INLINE float cf_hmax(CF_V2 a) { return cf_max(a.x, a.y); }
 
@@ -917,7 +917,7 @@ CF_INLINE float cf_hmax(CF_V2 a) { return cf_max(a.x, a.y); }
  * @function cf_len
  * @category math
  * @brief    Returns length of a vector.
- * @related  CF_V2 cf_len cf_distance cf_norm cf_safe_norm
+ * @related  cf_distance cf_norm cf_safe_norm
  */
 CF_INLINE float cf_len(CF_V2 a) { return CF_SQRTF(cf_dot(a, a)); }
 
@@ -925,7 +925,7 @@ CF_INLINE float cf_len(CF_V2 a) { return CF_SQRTF(cf_dot(a, a)); }
  * @function cf_len_sq
  * @category math
  * @brief    Returns squared length of a vector.
- * @related  CF_V2 cf_len cf_distance cf_norm cf_safe_norm
+ * @related  cf_len cf_distance cf_norm
  */
 CF_INLINE float cf_len_sq(CF_V2 a) { return cf_dot(a, a); }
 
@@ -933,7 +933,7 @@ CF_INLINE float cf_len_sq(CF_V2 a) { return cf_dot(a, a); }
  * @function cf_distance
  * @category math
  * @brief    Returns distance between two points.
- * @related  CF_V2 cf_len cf_distance cf_norm cf_safe_norm
+ * @related  cf_len cf_norm cf_safe_norm
  */
 CF_INLINE float cf_distance(CF_V2 a, CF_V2 b) { CF_V2 d = cf_sub_v2(b, a); return CF_SQRTF(cf_dot(d, d)); }
 
@@ -942,7 +942,7 @@ CF_INLINE float cf_distance(CF_V2 a, CF_V2 b) { CF_V2 d = cf_sub_v2(b, a); retur
  * @category math
  * @brief    Returns a normalized vector.
  * @remarks  Normalized vectors have unit-length without changing the vector's direction. Fails if the vector has a length of zero.
- * @related  CF_V2 cf_len cf_distance cf_norm cf_safe_norm
+ * @related  cf_len cf_distance cf_safe_norm
  */
 CF_INLINE CF_V2 cf_norm(CF_V2 a) { return cf_div_v2_f(a, cf_len(a)); }
 
@@ -952,7 +952,7 @@ CF_INLINE CF_V2 cf_norm(CF_V2 a) { return cf_div_v2_f(a, cf_len(a)); }
  * @brief    Returns a normalized vector.
  * @remarks  Sets the vector to `{ 0, 0 }` if the length of the vector is zero. Unlike `cf_norm`, this function cannot fail for
  *           the case of a zero vector.
- * @related  CF_V2 cf_len cf_distance cf_norm cf_safe_norm
+ * @related  cf_len cf_distance cf_norm
  */
 CF_INLINE CF_V2 cf_safe_norm(CF_V2 a) { float sq = cf_dot(a, a); return sq ? cf_div_v2_f(a, CF_SQRTF(sq)) : cf_v2(0, 0); }
 
@@ -960,7 +960,7 @@ CF_INLINE CF_V2 cf_safe_norm(CF_V2 a) { float sq = cf_dot(a, a); return sq ? cf_
  * @function cf_safe_norm_f
  * @category math
  * @brief    Returns the sign of a float, or zero if the float is zero.
- * @related  cf_safe_norm_f cf_safe_norm_int
+ * @related  cf_safe_norm_int
  */
 CF_INLINE float cf_safe_norm_f(float a) { return a == 0 ? 0 : cf_sign(a); }
 
@@ -968,7 +968,7 @@ CF_INLINE float cf_safe_norm_f(float a) { return a == 0 ? 0 : cf_sign(a); }
  * @function cf_safe_norm_int
  * @category math
  * @brief    Returns the sign of an int, or zero if the int is zero.
- * @related  cf_safe_norm_f cf_safe_norm_int
+ * @related  cf_safe_norm_f
  */
 CF_INLINE int cf_safe_norm_int(int a) { return a == 0 ? 0 : cf_sign_int(a); }
 
@@ -976,7 +976,7 @@ CF_INLINE int cf_safe_norm_int(int a) { return a == 0 ? 0 : cf_sign_int(a); }
  * @function cf_neg_v2
  * @category math
  * @brief    Returns a negated vector.
- * @related  CF_V2 cf_neg_v2 cf_sign_v2
+ * @related  cf_sign_v2 CF_V2
  */
 CF_INLINE CF_V2 cf_neg_v2(CF_V2 a) { return cf_v2(-a.x, -a.y); }
 
@@ -986,7 +986,7 @@ CF_INLINE CF_V2 cf_neg_v2(CF_V2 a) { return cf_v2(-a.x, -a.y); }
  * @brief    Returns a vector of equal length to `a` but with its direction reflected
  * @param    a        The vector being reflected
  * @param    n        The normal of the plane that is being reflected off of
- * @related  CF_V2 cf_neg_v2 cf_norm cf_safe_norm
+ * @related  cf_neg_v2 cf_norm cf_safe_norm
  */
 CF_INLINE CF_V2 cf_reflect_v2(CF_V2 a, CF_V2 n) { return cf_sub_v2(a, cf_mul_v2_f(n, (2.f * cf_dot(a, n)))); }
 
@@ -994,7 +994,7 @@ CF_INLINE CF_V2 cf_reflect_v2(CF_V2 a, CF_V2 n) { return cf_sub_v2(a, cf_mul_v2_
  * @function cf_lerp_v2
  * @category math
  * @brief    Returns a vector linearly interpolated from `a` to `b` along `t`, a value _usually_ from 0.0f to 1.0f.
- * @related  CF_V2 cf_lerp_v2 cf_bezier
+ * @related  cf_bezier CF_V2
  */
 CF_INLINE CF_V2 cf_lerp_v2(CF_V2 a, CF_V2 b, float t) { return cf_add_v2(a, cf_mul_v2_f(cf_sub_v2(b, a), t)); }
 
@@ -1006,7 +1006,7 @@ CF_INLINE CF_V2 cf_lerp_v2(CF_V2 a, CF_V2 b, float t) { return cf_add_v2(a, cf_m
  * @param    c0       A control point.
  * @param    b        The end point.
  * @param    t        A position along the curve.
- * @related  CF_V2 cf_lerp_v2 cf_bezier cf_bezier2
+ * @related  cf_bezier2 cf_lerp_v2 CF_V2
  */
 CF_INLINE CF_V2 cf_bezier(CF_V2 a, CF_V2 c0, CF_V2 b, float t) { return cf_lerp_v2(cf_lerp_v2(a, c0, t), cf_lerp_v2(c0, b, t), t); }
 
@@ -1019,7 +1019,7 @@ CF_INLINE CF_V2 cf_bezier(CF_V2 a, CF_V2 c0, CF_V2 b, float t) { return cf_lerp_
  * @param    c1       A control point.
  * @param    b        The end point.
  * @param    t        A position along the curve.
- * @related  CF_V2 cf_lerp_v2 cf_bezier cf_bezier2
+ * @related  cf_bezier cf_lerp_v2 CF_V2
  */
 CF_INLINE CF_V2 cf_bezier2(CF_V2 a, CF_V2 c0, CF_V2 c1, CF_V2 b, float t) { return cf_bezier(cf_lerp_v2(a, c0, t), cf_lerp_v2(c0, c1, t), cf_lerp_v2(c1, b, t), t); }
 
@@ -1027,7 +1027,7 @@ CF_INLINE CF_V2 cf_bezier2(CF_V2 a, CF_V2 c0, CF_V2 c1, CF_V2 b, float t) { retu
  * @function cf_lesser_v2
  * @category math
  * @brief    Returns true if `a.x < b.y` and `a.y < b.y`.
- * @related  CF_V2 cf_round cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel
+ * @related  cf_lesser_equal_v2 cf_round cf_greater_v2
  */
 CF_INLINE int cf_lesser_v2(CF_V2 a, CF_V2 b) { return a.x < b.x && a.y < b.y; }
 
@@ -1035,7 +1035,7 @@ CF_INLINE int cf_lesser_v2(CF_V2 a, CF_V2 b) { return a.x < b.x && a.y < b.y; }
  * @function cf_greater_v2
  * @category math
  * @brief    Returns true if `a.x > b.y` and `a.y > b.y`.
- * @related  CF_V2 cf_round cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel
+ * @related  cf_greater_equal_v2 cf_round cf_lesser_v2
  */
 CF_INLINE int cf_greater_v2(CF_V2 a, CF_V2 b) { return a.x > b.x && a.y > b.y; }
 
@@ -1043,7 +1043,7 @@ CF_INLINE int cf_greater_v2(CF_V2 a, CF_V2 b) { return a.x > b.x && a.y > b.y; }
  * @function cf_lesser_equal_v2
  * @category math
  * @brief    Returns true if `a.x <= b.y` and `a.y <= b.y`.
- * @related  CF_V2 cf_round cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel
+ * @related  cf_lesser_v2 cf_round cf_greater_v2
  */
 CF_INLINE int cf_lesser_equal_v2(CF_V2 a, CF_V2 b) { return a.x <= b.x && a.y <= b.y; }
 
@@ -1051,7 +1051,7 @@ CF_INLINE int cf_lesser_equal_v2(CF_V2 a, CF_V2 b) { return a.x <= b.x && a.y <=
  * @function cf_greater_equal_v2
  * @category math
  * @brief    Returns true if `a.x >= b.y` and `a.y >= b.y`.
- * @related  CF_V2 cf_roundcf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel
+ * @related  cf_greater_v2 cf_roundcf_lesser_v2 cf_lesser_equal_v2
  */
 CF_INLINE int cf_greater_equal_v2(CF_V2 a, CF_V2 b) { return a.x >= b.x && a.y >= b.y; }
 
@@ -1060,7 +1060,7 @@ CF_INLINE int cf_greater_equal_v2(CF_V2 a, CF_V2 b) { return a.x >= b.x && a.y >
  * @category math
  * @brief    Returns the component-wise floor of a vector.
  * @remarks  Floor means the decimal-point part is zero'd out.
- * @related  CF_V2 cf_round cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel cf_floor cf_ceil
+ * @related  cf_round cf_lesser_v2 cf_greater_v2
  */
 CF_INLINE CF_V2 cf_floor(CF_V2 a) { return cf_v2(CF_FLOORF(a.x), CF_FLOORF(a.y)); }
 
@@ -1069,7 +1069,7 @@ CF_INLINE CF_V2 cf_floor(CF_V2 a) { return cf_v2(CF_FLOORF(a.x), CF_FLOORF(a.y))
  * @category math
  * @brief    Returns the component-wise ceil of a vector.
  * @remarks  Ceil means the number is clamped up to the next whole-number.
- * @related  CF_V2 cf_round cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel cf_floor cf_ceil
+ * @related  cf_round cf_lesser_v2 cf_greater_v2
  */
 CF_INLINE CF_V2 cf_ceil(CF_V2 a) { return cf_v2(CF_CEILF(a.x), CF_CEILF(a.y)); }
 
@@ -1078,7 +1078,7 @@ CF_INLINE CF_V2 cf_ceil(CF_V2 a) { return cf_v2(CF_CEILF(a.x), CF_CEILF(a.y)); }
  * @category math
  * @brief    Returns the component-wise round of a vector.
  * @remarks  Rounding means clamping the float to the nearest whole integer value.
- * @related  CF_V2 cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel
+ * @related  cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2
  */
 CF_INLINE CF_V2 cf_round(CF_V2 a) { return cf_v2(CF_ROUNDF(a.x), CF_ROUNDF(a.y)); }
 
@@ -1086,7 +1086,7 @@ CF_INLINE CF_V2 cf_round(CF_V2 a) { return cf_v2(CF_ROUNDF(a.x), CF_ROUNDF(a.y))
  * @function cf_safe_invert_v2
  * @category math
  * @brief    Returns the component-wise safe inversion of a vector.
- * @related  CF_V2 cf_safe_invert
+ * @related  cf_safe_invert CF_V2
  */
 CF_INLINE CF_V2 cf_safe_invert_v2(CF_V2 a) { return cf_v2(cf_safe_invert(a.x), cf_safe_invert(a.y)); }
 
@@ -1094,7 +1094,7 @@ CF_INLINE CF_V2 cf_safe_invert_v2(CF_V2 a) { return cf_v2(cf_safe_invert(a.x), c
  * @function cf_sign_v2
  * @category math
  * @brief    Returns the component-wise sign of a vector.
- * @related  CF_V2 cf_sign
+ * @related  cf_sign CF_V2
  */
 CF_INLINE CF_V2 cf_sign_v2(CF_V2 a) { return cf_v2(cf_sign(a.x), cf_sign(a.y)); }
 
@@ -1105,7 +1105,7 @@ CF_INLINE CF_V2 cf_sign_v2(CF_V2 a) { return cf_v2(cf_sign(a.x), cf_sign(a.y)); 
  * @function cf_sincos_f
  * @category math
  * @brief    Returns an initialized `CF_SinCos` from `radians`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_x_axis cf_y_axis cf_mul_sc_v2
  */
 CF_INLINE CF_SinCos cf_sincos_f(float radians) { CF_SinCos r; r.s = CF_SINF(radians); r.c = CF_COSF(radians); return r; }
 CF_INLINE CF_SinCos cf_sincos(void) { CF_SinCos r; r.c = 1.0f; r.s = 0; return r; }
@@ -1114,7 +1114,7 @@ CF_INLINE CF_SinCos cf_sincos(void) { CF_SinCos r; r.c = 1.0f; r.s = 0; return r
  * @function cf_x_axis
  * @category math
  * @brief    Returns the x-axis of the 2x2 rotation matrix represented by `CF_SinCos`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_sincos_f cf_y_axis cf_mul_sc_v2
  */
 CF_INLINE CF_V2 cf_x_axis(CF_SinCos r) { return cf_v2(r.c, r.s); }
 
@@ -1122,7 +1122,7 @@ CF_INLINE CF_V2 cf_x_axis(CF_SinCos r) { return cf_v2(r.c, r.s); }
  * @function cf_y_axis
  * @category math
  * @brief    Returns the y-axis of the 2x2 rotation matrix represented by `CF_SinCos`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_sincos_f cf_x_axis cf_mul_sc_v2
  */
 CF_INLINE CF_V2 cf_y_axis(CF_SinCos r) { return cf_v2(-r.s, r.c); }
 
@@ -1130,7 +1130,7 @@ CF_INLINE CF_V2 cf_y_axis(CF_SinCos r) { return cf_v2(-r.s, r.c); }
  * @function cf_mul_sc_v2
  * @category math
  * @brief    Returns a vector rotated by `a`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_mul_sc cf_mulT_sc_v2 cf_mulT_sc
  */
 CF_INLINE CF_V2 cf_mul_sc_v2(CF_SinCos a, CF_V2 b) { return cf_v2(a.c * b.x - a.s * b.y, a.s * b.x + a.c * b.y); }
 
@@ -1138,7 +1138,7 @@ CF_INLINE CF_V2 cf_mul_sc_v2(CF_SinCos a, CF_V2 b) { return cf_v2(a.c * b.x - a.
  * @function cf_mulT_sc_v2
  * @category math
  * @brief    Returns a vector inverse-rotated by `a`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_mulT_sc cf_mul_sc_v2 cf_mul_sc
  */
 CF_INLINE CF_V2 cf_mulT_sc_v2(CF_SinCos a, CF_V2 b) { return cf_v2(a.c * b.x + a.s * b.y, -a.s * b.x + a.c * b.y); }
 
@@ -1146,7 +1146,7 @@ CF_INLINE CF_V2 cf_mulT_sc_v2(CF_SinCos a, CF_V2 b) { return cf_v2(a.c * b.x + a
  * @function cf_mul_sc
  * @category math
  * @brief    Returns the composition of `a` multiplied by `b`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_mul_sc_v2 cf_mulT_sc_v2 cf_mulT_sc
  */
 CF_INLINE CF_SinCos cf_mul_sc(CF_SinCos a, CF_SinCos b) { CF_SinCos c; c.c = a.c * b.c - a.s * b.s; c.s = a.s * b.c + a.c * b.s; return c; }
 
@@ -1154,7 +1154,7 @@ CF_INLINE CF_SinCos cf_mul_sc(CF_SinCos a, CF_SinCos b) { CF_SinCos c; c.c = a.c
  * @function cf_mulT_sc
  * @category math
  * @brief    Returns the composition of `a` multiplied by inverse of `b`.
- * @related  CF_SinCos cf_sincos_f cf_x_axis cf_y_axis cf_mul_sc_v2 cf_mulT_sc_v2 cf_mul_sc cf_mulT_sc
+ * @related  cf_mulT_sc_v2 cf_mul_sc_v2 cf_mul_sc
  */
 CF_INLINE CF_SinCos cf_mulT_sc(CF_SinCos a, CF_SinCos b) { CF_SinCos c; c.c = a.c * b.c + a.s * b.s; c.s = a.c * b.s - a.s * b.c; return c; }
 
@@ -1162,7 +1162,7 @@ CF_INLINE CF_SinCos cf_mulT_sc(CF_SinCos a, CF_SinCos b) { CF_SinCos c; c.c = a.
  * @function cf_atan2_360
  * @category math
  * @brief    Returns a remap'd result from atan2f to the continuous range of 0, 2*PI.
- * @related  cf_atan2_360 cf_atan2_360_sc cf_atan2_360_v2
+ * @related  cf_atan2_360_sc cf_atan2_360_v2
  */
 CF_INLINE float cf_atan2_360(float y, float x) { return CF_ATAN2F(-y, -x) + CF_PI; }
 
@@ -1170,7 +1170,7 @@ CF_INLINE float cf_atan2_360(float y, float x) { return CF_ATAN2F(-y, -x) + CF_P
  * @function cf_atan2_360_sc
  * @category math
  * @brief    Returns a remap'd result from atan2f to the continuous range of 0, 2*PI.
- * @related  cf_atan2_360 cf_atan2_360_sc cf_atan2_360_v2
+ * @related  cf_atan2_360_v2 cf_atan2_360
  */
 CF_INLINE float cf_atan2_360_sc(CF_SinCos r) { return cf_atan2_360(r.s, r.c); }
 
@@ -1178,7 +1178,7 @@ CF_INLINE float cf_atan2_360_sc(CF_SinCos r) { return cf_atan2_360(r.s, r.c); }
  * @function cf_atan2_360_v2
  * @category math
  * @brief    Returns a remap'd result from atan2f to the continuous range of 0, 2*PI.
- * @related  cf_atan2_360 cf_atan2_360_sc cf_atan2_360_v2
+ * @related  cf_atan2_360_sc cf_atan2_360
  */
 CF_INLINE float cf_atan2_360_v2(CF_V2 v) { return CF_ATAN2F(-v.y, -v.x) + CF_PI; }
 
@@ -1186,7 +1186,7 @@ CF_INLINE float cf_atan2_360_v2(CF_V2 v) { return CF_ATAN2F(-v.y, -v.x) + CF_PI;
  * @function cf_shortest_arc
  * @category math
  * @brief    Returns the shortest angle to rotate the vector `a` to the vector `b`.
- * @related  cf_shortest_arc cf_angle_diff cf_from_angle
+ * @related  cf_angle_diff cf_from_angle
  */
 CF_INLINE float cf_shortest_arc(CF_V2 a, CF_V2 b)
 {
@@ -1204,7 +1204,7 @@ CF_INLINE float cf_shortest_arc(CF_V2 a, CF_V2 b)
  * @function cf_angle_diff
  * @category math
  * @brief    Returns the difference of two angles (b - a) in the range of -`CF_PI` to `CF_PI`.
- * @related  cf_shortest_arc cf_angle_diff cf_from_angle
+ * @related  cf_shortest_arc cf_from_angle
  */
 CF_INLINE float cf_angle_diff(float radians_a, float radians_b)
 {
@@ -1216,7 +1216,7 @@ CF_INLINE float cf_angle_diff(float radians_a, float radians_b)
  * @function cf_from_angle
  * @category math
  * @brief    returns a vector according to the sin/cos of `radians`.
- * @related  cf_shortest_arc cf_angle_diff cf_from_angle
+ * @related  cf_shortest_arc cf_angle_diff
  */
 CF_INLINE CF_V2 cf_from_angle(float radians) { return cf_v2(CF_COSF(radians), CF_SINF(radians)); }
 
@@ -1228,7 +1228,7 @@ CF_INLINE CF_V2 cf_from_angle(float radians) { return cf_v2(CF_COSF(radians), CF
  * @function cf_mul_m2_f
  * @category math
  * @brief    Multiplies a `CF_M2x2` by a float.
- * @related  CF_M2x2 cf_mul_m2_f cf_mul_m2_v2 cf_mul_m2
+ * @related  cf_mul_m2_v2 cf_mul_m2 CF_M2x2
  */
 CF_INLINE CF_M2x2 cf_mul_m2_f(CF_M2x2 a, float b) { CF_M2x2 c; c.x = cf_mul_v2_f(a.x, b); c.y = cf_mul_v2_f(a.y, b); return c; }
 
@@ -1236,7 +1236,7 @@ CF_INLINE CF_M2x2 cf_mul_m2_f(CF_M2x2 a, float b) { CF_M2x2 c; c.x = cf_mul_v2_f
  * @function cf_mul_m2_v2
  * @category math
  * @brief    Multiplies a vector by a `CF_M2x2`.
- * @related  CF_M2x2 CF_V2 cf_mul_m2_f cf_mul_m2_v2 cf_mul_m2
+ * @related  cf_mul_m2_f cf_mul_m2 CF_M2x2
  */
 CF_INLINE CF_V2 cf_mul_m2_v2(CF_M2x2 a, CF_V2 b) { CF_V2 c; c.x = a.x.x * b.x + a.y.x * b.y; c.y = a.x.y * b.x + a.y.y * b.y; return c; }
 
@@ -1244,7 +1244,7 @@ CF_INLINE CF_V2 cf_mul_m2_v2(CF_M2x2 a, CF_V2 b) { CF_V2 c; c.x = a.x.x * b.x + 
  * @function cf_mul_m2
  * @category math
  * @brief    Returns the composition of `a` times `b`.
- * @related  CF_M2x2 cf_mul_m2_f cf_mul_m2_v2 cf_mul_m2
+ * @related  cf_mul_m2_f cf_mul_m2_v2 CF_M2x2
  */
 CF_INLINE CF_M2x2 cf_mul_m2(CF_M2x2 a, CF_M2x2 b) { CF_M2x2 c; c.x = cf_mul_m2_v2(a, b.x); c.y = cf_mul_m2_v2(a, b.y); return c; }
 
@@ -1256,7 +1256,7 @@ CF_INLINE CF_M2x2 cf_mul_m2(CF_M2x2 a, CF_M2x2 b) { CF_M2x2 c; c.x = cf_mul_m2_v
  * @function cf_mul_m32_v2
  * @category math
  * @brief    Returns a vector multiplied by a `CF_M3x2`.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_mul_m32 cf_make_identity cf_make_translation
  */
 CF_INLINE CF_V2 cf_mul_m32_v2(CF_M3x2 a, CF_V2 b) { return cf_add_v2(cf_mul_m2_v2(a.m, b), a.p); }
 
@@ -1264,7 +1264,7 @@ CF_INLINE CF_V2 cf_mul_m32_v2(CF_M3x2 a, CF_V2 b) { return cf_add_v2(cf_mul_m2_v
  * @function cf_mul_m32
  * @category math
  * @brief    Returns the composition of two `CF_M3x2`s multiplied together.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_mul_m32_v2 cf_make_identity cf_make_translation
  */
 CF_INLINE CF_M3x2 cf_mul_m32(CF_M3x2 a, CF_M3x2 b) { CF_M3x2 c; c.m = cf_mul_m2(a.m, b.m); c.p = cf_add_v2(cf_mul_m2_v2(a.m, b.p), a.p); return c; }
 
@@ -1272,7 +1272,7 @@ CF_INLINE CF_M3x2 cf_mul_m32(CF_M3x2 a, CF_M3x2 b) { CF_M3x2 c; c.m = cf_mul_m2(
  * @function cf_make_identity
  * @category math
  * @brief    Returns an identity `CF_M3x2`.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_translation cf_make_scale cf_make_scale_translation
  */
 CF_INLINE CF_M3x2 cf_make_identity(void) { CF_M3x2 m; m.m.x = cf_v2(1, 0); m.m.y = cf_v2(0, 1); m.p = cf_v2(0, 0); return m; }
 
@@ -1280,7 +1280,7 @@ CF_INLINE CF_M3x2 cf_make_identity(void) { CF_M3x2 m; m.m.x = cf_v2(1, 0); m.m.y
  * @function cf_make_translation_f
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a translation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_translation cf_make_transform_TSR cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_make_translation_f(float x, float y) { CF_M3x2 m; m.m.x = cf_v2(1, 0); m.m.y = cf_v2(0, 1); m.p = cf_v2(x, y); return m; }
 
@@ -1288,7 +1288,7 @@ CF_INLINE CF_M3x2 cf_make_translation_f(float x, float y) { CF_M3x2 m; m.m.x = c
  * @function cf_make_translation
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a translation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_transform_TSR cf_make_identity cf_make_scale
  */
 CF_INLINE CF_M3x2 cf_make_translation(CF_V2 p) { return cf_make_translation_f(p.x, p.y); }
 
@@ -1296,7 +1296,7 @@ CF_INLINE CF_M3x2 cf_make_translation(CF_V2 p) { return cf_make_translation_f(p.
  * @function cf_make_scale
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a scale.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_scale_translation cf_make_identity cf_make_translation
  */
 CF_INLINE CF_M3x2 cf_make_scale(CF_V2 s) { CF_M3x2 m; m.m.x = cf_v2(s.x, 0); m.m.y = cf_v2(0, s.y); m.p = cf_v2(0, 0); return m; }
 
@@ -1304,7 +1304,7 @@ CF_INLINE CF_M3x2 cf_make_scale(CF_V2 s) { CF_M3x2 m; m.m.x = cf_v2(s.x, 0); m.m
  * @function cf_make_scale_f
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a scale.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_scale_translation cf_make_scale cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_make_scale_f(float s) { return cf_make_scale(cf_v2(s, s)); }
 
@@ -1312,7 +1312,7 @@ CF_INLINE CF_M3x2 cf_make_scale_f(float s) { return cf_make_scale(cf_v2(s, s)); 
  * @function cf_make_scale_translation
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a scale + translation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_scale cf_make_identity cf_make_translation
  */
 CF_INLINE CF_M3x2 cf_make_scale_translation(CF_V2 s, CF_V2 p) { CF_M3x2 m; m.m.x = cf_v2(s.x, 0); m.m.y = cf_v2(0, s.y); m.p = p; return m; }
 
@@ -1320,7 +1320,7 @@ CF_INLINE CF_M3x2 cf_make_scale_translation(CF_V2 s, CF_V2 p) { CF_M3x2 m; m.m.x
  * @function cf_make_scale_translation_f
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a scale + translation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_scale_translation cf_make_scale cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_make_scale_translation_f(float s, CF_V2 p) { return cf_make_scale_translation(cf_v2(s, s), p); }
 
@@ -1328,7 +1328,7 @@ CF_INLINE CF_M3x2 cf_make_scale_translation_f(float s, CF_V2 p) { return cf_make
  * @function cf_make_scale_translation_f_f
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a scale + translation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_scale_translation cf_make_scale cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_make_scale_translation_f_f(float sx, float sy, CF_V2 p) { return cf_make_scale_translation(cf_v2(sx, sy), p); }
 
@@ -1336,7 +1336,7 @@ CF_INLINE CF_M3x2 cf_make_scale_translation_f_f(float sx, float sy, CF_V2 p) { r
  * @function cf_make_rotation
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a rotation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_identity cf_make_translation cf_make_scale
  */
 CF_INLINE CF_M3x2 cf_make_rotation(float radians) { CF_SinCos sc = cf_sincos_f(radians); CF_M3x2 m; m.m.x = cf_v2(sc.c, -sc.s); m.m.y = cf_v2(sc.s, sc.c); m.p = cf_v2(0, 0); return m; }
 
@@ -1344,7 +1344,7 @@ CF_INLINE CF_M3x2 cf_make_rotation(float radians) { CF_SinCos sc = cf_sincos_f(r
  * @function cf_make_transform_TSR
  * @category math
  * @brief    Returns a `CF_M3x2` that represents a translation + scale + rotation.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_make_translation cf_make_identity cf_make_scale
  */
 CF_INLINE CF_M3x2 cf_make_transform_TSR(CF_V2 p, CF_V2 s, float radians) { CF_SinCos sc = cf_sincos_f(radians); CF_M3x2 m; m.m.x = cf_mul_v2_f(cf_v2(sc.c, -sc.s), s.x); m.m.y = cf_mul_v2_f(cf_v2(sc.s, sc.c), s.y); m.p = p; return m; }
 
@@ -1353,7 +1353,7 @@ CF_INLINE CF_M3x2 cf_make_transform_TSR(CF_V2 p, CF_V2 s, float radians) { CF_Si
  * @category math
  * @brief    Returns a `CF_M3x2` inverted.
  * @remarks  If the determinant is zero, the returned matrix is also zero.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_mul_m32_v2 cf_mul_m32 cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_invert(CF_M3x2 a)
 {
@@ -1370,7 +1370,7 @@ CF_INLINE CF_M3x2 cf_invert(CF_M3x2 a)
  * @function cf_ortho_2d
  * @category math
  * @brief    Constructs an orthographic projection matrix given position and scaling values.
- * @related  CF_M3x2 cf_mul_m32_v2 cf_mul_m32 cf_make_identity cf_make_translation cf_make_scale cf_make_scale_translation cf_make_rotation cf_make_transform_TSR cf_invert
+ * @related  cf_mul_m32_v2 cf_mul_m32 cf_make_identity
  */
 CF_INLINE CF_M3x2 cf_ortho_2d(float x, float y, float scale_x, float scale_y)
 {
@@ -1392,7 +1392,7 @@ CF_INLINE CF_M3x2 cf_ortho_2d(float x, float y, float scale_x, float scale_y)
  * @function cf_make_transform
  * @category math
  * @brief    Returns an identity `CF_Transform`.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2
  */
 CF_INLINE CF_Transform cf_make_transform(void) { CF_Transform x; x.p = cf_v2(0, 0); x.r = cf_sincos(); return x; }
 
@@ -1400,7 +1400,7 @@ CF_INLINE CF_Transform cf_make_transform(void) { CF_Transform x; x.p = cf_v2(0, 
  * @function cf_make_transform_TR
  * @category math
  * @brief    Returns a `CF_Transform` that represents a translation + rotation.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_make_transform cf_mul_tf_v2 cf_mulT_tf_v2
  */
 CF_INLINE CF_Transform cf_make_transform_TR(CF_V2 p, float radians) { CF_Transform x; x.r = cf_sincos_f(radians); x.p = p; return x; }
 
@@ -1408,7 +1408,7 @@ CF_INLINE CF_Transform cf_make_transform_TR(CF_V2 p, float radians) { CF_Transfo
  * @function cf_mul_tf_v2
  * @category math
  * @brief    Returns a vector multiplied by a `CF_Transform`.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_mul_tf cf_mulT_tf_v2 cf_mulT_tf
  */
 CF_INLINE CF_V2 cf_mul_tf_v2(CF_Transform a, CF_V2 b) { return cf_add_v2(cf_mul_sc_v2(a.r, b), a.p); }
 
@@ -1416,7 +1416,7 @@ CF_INLINE CF_V2 cf_mul_tf_v2(CF_Transform a, CF_V2 b) { return cf_add_v2(cf_mul_
  * @function cf_mulT_tf_v2
  * @category math
  * @brief    Returns a vector multiplied by an inverted `CF_Transform`.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_mulT_tf cf_mul_tf_v2 cf_mul_tf
  */
 CF_INLINE CF_V2 cf_mulT_tf_v2(CF_Transform a, CF_V2 b) { return cf_mulT_sc_v2(a.r, cf_sub_v2(b, a.p)); }
 
@@ -1424,7 +1424,7 @@ CF_INLINE CF_V2 cf_mulT_tf_v2(CF_Transform a, CF_V2 b) { return cf_mulT_sc_v2(a.
  * @function cf_mul_tf
  * @category math
  * @brief    Returns a the composition of multiplying two `CF_Transform`s.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_mul_tf_v2 cf_mulT_tf_v2 cf_mulT_tf
  */
 CF_INLINE CF_Transform cf_mul_tf(CF_Transform a, CF_Transform b) { CF_Transform c; c.r = cf_mul_sc(a.r, b.r); c.p = cf_add_v2(cf_mul_sc_v2(a.r, b.p), a.p); return c; }
 
@@ -1433,7 +1433,7 @@ CF_INLINE CF_Transform cf_mul_tf(CF_Transform a, CF_Transform b) { CF_Transform 
  * @function cf_mulT_tf
  * @category math
  * @brief    Returns `a` multiplied by inverse `b`.
- * @related  CF_Transform cf_make_transform cf_make_transform_TR cf_mul_tf_v2 cf_mulT_tf_v2 cf_mul_tf cf_mulT_tf
+ * @related  cf_mulT_tf_v2 cf_mul_tf_v2 cf_mul_tf
  */
 CF_INLINE CF_Transform cf_mulT_tf(CF_Transform a, CF_Transform b) { CF_Transform c; c.r = cf_mulT_sc(a.r, b.r); c.p = cf_mulT_sc_v2(a.r, cf_sub_v2(b.p, a.p)); return c; }
 
@@ -1445,7 +1445,7 @@ CF_INLINE CF_Transform cf_mulT_tf(CF_Transform a, CF_Transform b) { CF_Transform
  * @function cf_plane
  * @category math
  * @brief    Returns an initialized `CF_Halfpsace` (a 2-dimensional plane, aka line).
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_project cf_origin cf_distance_hs
  */
 CF_INLINE CF_Halfspace cf_plane(CF_V2 n, float d) { CF_Halfspace h; h.n = n; h.d = d; return h; }
 
@@ -1453,7 +1453,7 @@ CF_INLINE CF_Halfspace cf_plane(CF_V2 n, float d) { CF_Halfspace h; h.n = n; h.d
  * @function cf_plane2
  * @category math
  * @brief    Returns an initialized `CF_Halfpsace` (a 2-dimensional plane, aka line).
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_plane cf_project cf_origin
  */
 CF_INLINE CF_Halfspace cf_plane2(CF_V2 n, CF_V2 p) { CF_Halfspace h; h.n = n; h.d = cf_dot(n, p); return h; }
 
@@ -1461,7 +1461,7 @@ CF_INLINE CF_Halfspace cf_plane2(CF_V2 n, CF_V2 p) { CF_Halfspace h; h.n = n; h.
  * @function cf_origin
  * @category math
  * @brief    Returns the origin projected onto the plane.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_plane cf_distance_hs cf_project
  */
 CF_INLINE CF_V2 cf_origin(CF_Halfspace h) { return cf_mul_v2_f(h.n, h.d); }
 
@@ -1469,7 +1469,7 @@ CF_INLINE CF_V2 cf_origin(CF_Halfspace h) { return cf_mul_v2_f(h.n, h.d); }
  * @function cf_distance_hs
  * @category math
  * @brief    Returns distance of a point to the plane.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_plane cf_origin cf_project
  */
 CF_INLINE float cf_distance_hs(CF_Halfspace h, CF_V2 p) { return cf_dot(h.n, p) - h.d; }
 
@@ -1477,7 +1477,7 @@ CF_INLINE float cf_distance_hs(CF_Halfspace h, CF_V2 p) { return cf_dot(h.n, p) 
  * @function cf_project
  * @category math
  * @brief    Projects a point onto the surface of the plane.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_plane cf_origin cf_distance_hs
  */
 CF_INLINE CF_V2 cf_project(CF_Halfspace h, CF_V2 p) { return cf_sub_v2(p, cf_mul_v2_f(h.n, cf_distance_hs(h, p))); }
 
@@ -1485,7 +1485,7 @@ CF_INLINE CF_V2 cf_project(CF_Halfspace h, CF_V2 p) { return cf_sub_v2(p, cf_mul
  * @function cf_mul_tf_hs
  * @category math
  * @brief    Transforms a plane by a `CF_Transform`.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_mulT_tf_hs cf_plane cf_origin
  */
 CF_INLINE CF_Halfspace cf_mul_tf_hs(CF_Transform a, CF_Halfspace b) { CF_Halfspace c; c.n = cf_mul_sc_v2(a.r, b.n); c.d = cf_dot(cf_mul_tf_v2(a, cf_origin(b)), c.n); return c; }
 
@@ -1493,7 +1493,7 @@ CF_INLINE CF_Halfspace cf_mul_tf_hs(CF_Transform a, CF_Halfspace b) { CF_Halfspa
  * @function cf_mulT_tf_hs
  * @category math
  * @brief    Transforms a plane by an inverted `CF_Transform`.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace
+ * @related  cf_mul_tf_hs cf_plane cf_origin
  */
 CF_INLINE CF_Halfspace cf_mulT_tf_hs(CF_Transform a, CF_Halfspace b) { CF_Halfspace c; c.n = cf_mulT_sc_v2(a.r, b.n); c.d = cf_dot(cf_mulT_tf_v2(a, cf_origin(b)), c.n); return c; }
 
@@ -1503,7 +1503,7 @@ CF_INLINE CF_Halfspace cf_mulT_tf_hs(CF_Transform a, CF_Halfspace b) { CF_Halfsp
  * @brief    Returns the intersection point of two points to a plane.
  * @remarks  The distance to the plane are provided as `da` and `db`. You can compute these with e.g. `cf_distance_hs`, or instead
  *           call the similar function `cf_intersect_halfspace2`.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
+ * @related  cf_intersect_haflspace2 cf_intersect_haflspace3 cf_plane
  */
 CF_INLINE CF_V2 cf_intersect_halfspace(CF_V2 a, CF_V2 b, float da, float db) { return cf_add_v2(a, cf_mul_v2_f(cf_sub_v2(b, a), (da / (da - db)))); }
 
@@ -1511,7 +1511,7 @@ CF_INLINE CF_V2 cf_intersect_halfspace(CF_V2 a, CF_V2 b, float da, float db) { r
  * @function cf_intersect_halfspace2
  * @category math
  * @brief    Returns the intersection point of two points to a plane.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
+ * @related  cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
  */
 CF_INLINE CF_V2 cf_intersect_halfspace2(CF_Halfspace h, CF_V2 a, CF_V2 b) { return cf_intersect_halfspace(a, b, cf_distance_hs(h, a), cf_distance_hs(h, b)); }
 
@@ -1519,7 +1519,7 @@ CF_INLINE CF_V2 cf_intersect_halfspace2(CF_Halfspace h, CF_V2 a, CF_V2 b) { retu
  * @function cf_intersect_halfspace3
  * @category math
  * @brief    Returns the intersection point of two planes.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
+ * @related  cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
  */
 CF_INLINE CF_V2 cf_intersect_halfspace3(CF_Halfspace ha, CF_Halfspace hb) { CF_V2 a = {ha.n.x, hb.n.x}, b = {ha.n.y, hb.n.y}, c = {ha.d, hb.d}; float x = cf_det2(c, b) / cf_det2(a, b); float y = cf_det2(a, c) / cf_det2(a, b); return cf_v2(x, y); }
 
@@ -1527,7 +1527,7 @@ CF_INLINE CF_V2 cf_intersect_halfspace3(CF_Halfspace ha, CF_Halfspace hb) { CF_V
  * @function cf_shift
  * @category math
  * @brief    Returns a plane shifted along it's normal by distance `d`.
- * @related  CF_Halfspace cf_plane cf_origin cf_distance_hs cf_project cf_mul_tf_hs cf_mulT_tf_hs cf_intersect_halfspace cf_intersect_haflspace2 cf_intersect_haflspace3
+ * @related  cf_plane cf_origin cf_distance_hs
  */
 CF_INLINE CF_Halfspace cf_shift(CF_Halfspace h, float d) { h.d += d; return h; }
 
@@ -1538,7 +1538,7 @@ CF_INLINE CF_Halfspace cf_shift(CF_Halfspace h, float d) { h.d += d; return h; }
  * @remarks  You should experiment to find a good `tol` value, such as commonly used values like 1.0e-3f, 1.0e-6f, or 1.0e-8f.
  *           Different orders of magnitude are suitable for different tasks, so it may take some experience to figure out
  *           what a good tolerance is for your situation.
- * @related  CF_V2 cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel cf_parallel2
+ * @related  cf_parallel2 cf_lesser_v2 cf_greater_v2
  */
 CF_INLINE bool cf_parallel(CF_V2 a, CF_V2 b, float tol)
 {
@@ -1558,7 +1558,7 @@ CF_INLINE bool cf_parallel(CF_V2 a, CF_V2 b, float tol)
  * @remarks  You should experiment to find a good `tol` value, such as commonly used values like 1.0e-3f, 1.0e-6f, or 1.0e-8f.
  *           Different orders of magnitude are suitable for different tasks, so it may take some experience to figure out
  *           what a good tolerance is for your situation.
- * @related  CF_V2 cf_lesser_v2 cf_greater_v2 cf_lesser_equal_v2 cf_greater_equal_v2 cf_parallel cf_parallel2
+ * @related  cf_parallel cf_lesser_v2 cf_greater_v2
  */
 CF_INLINE bool cf_parallel2(CF_V2 a, CF_V2 b, CF_V2 c, float tol)
 {
@@ -1620,7 +1620,7 @@ CF_INLINE CF_Capsule cf_make_capsule2(CF_V2 p, float height, float radius)
  * @function cf_make_aabb
  * @category math
  * @brief    Returns an AABB (axis-aligned bounding box) from min/max points (bottom-left and top-right).
- * @related  CF_Aabb cf_make_aabb cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb_from_top_left
+ * @related  cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb_from_top_left
  */
 CF_INLINE CF_Aabb cf_make_aabb(CF_V2 min, CF_V2 max) { CF_Aabb bb; bb.min = min; bb.max = max; return bb; }
 
@@ -1628,7 +1628,7 @@ CF_INLINE CF_Aabb cf_make_aabb(CF_V2 min, CF_V2 max) { CF_Aabb bb; bb.min = min;
  * @function cf_make_aabb_pos_w_h
  * @category math
  * @brief    Returns an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb_from_top_left
+ * @related  cf_make_aabb_center_half_extents cf_make_aabb_from_top_left cf_make_aabb
  */
 CF_INLINE CF_Aabb cf_make_aabb_pos_w_h(CF_V2 pos, float w, float h) { CF_Aabb bb; CF_V2 he = cf_mul_v2_f(cf_v2(w, h), 0.5f); bb.min = cf_sub_v2(pos, he); bb.max = cf_add_v2(pos, he); return bb; }
 
@@ -1637,7 +1637,7 @@ CF_INLINE CF_Aabb cf_make_aabb_pos_w_h(CF_V2 pos, float w, float h) { CF_Aabb bb
  * @category math
  * @brief    Returns an AABB (axis-aligned bounding box).
  * @remarks  Half-extents refer to half-width and height-height: `half_extents = { half_width, half_height }`.
- * @related  CF_Aabb cf_make_aabb cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb_from_top_left
+ * @related  cf_make_aabb_pos_w_h cf_make_aabb_from_top_left cf_make_aabb
  */
 CF_INLINE CF_Aabb cf_make_aabb_center_half_extents(CF_V2 center, CF_V2 half_extents) { CF_Aabb bb; bb.min = cf_sub_v2(center, half_extents); bb.max = cf_add_v2(center, half_extents); return bb; }
 
@@ -1645,7 +1645,7 @@ CF_INLINE CF_Aabb cf_make_aabb_center_half_extents(CF_V2 center, CF_V2 half_exte
  * @function cf_make_aabb_from_top_left
  * @category math
  * @brief    Returns an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb_from_top_left
+ * @related  cf_make_aabb_pos_w_h cf_make_aabb_center_half_extents cf_make_aabb
  */
 CF_INLINE CF_Aabb cf_make_aabb_from_top_left(CF_V2 top_left, float w, float h) { return cf_make_aabb(cf_add_v2(top_left, cf_v2(0, -h)), cf_add_v2(top_left, cf_v2(w, 0))); }
 
@@ -1653,7 +1653,7 @@ CF_INLINE CF_Aabb cf_make_aabb_from_top_left(CF_V2 top_left, float w, float h) {
  * @function cf_width
  * @category math
  * @brief    Returns the width of an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_make_aabb cf_height cf_half_width
  */
 CF_INLINE float cf_width(CF_Aabb bb) { return bb.max.x - bb.min.x; }
 
@@ -1661,7 +1661,7 @@ CF_INLINE float cf_width(CF_Aabb bb) { return bb.max.x - bb.min.x; }
  * @function cf_height
  * @category math
  * @brief    Returns the height of an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_half_width cf_half_height cf_half_extents
  */
 CF_INLINE float cf_height(CF_Aabb bb) { return bb.max.y - bb.min.y; }
 
@@ -1669,7 +1669,7 @@ CF_INLINE float cf_height(CF_Aabb bb) { return bb.max.y - bb.min.y; }
  * @function cf_half_width
  * @category math
  * @brief    Returns the half-width of an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_half_height cf_half_extents cf_height
  */
 CF_INLINE float cf_half_width(CF_Aabb bb) { return cf_width(bb) * 0.5f; }
 
@@ -1677,7 +1677,7 @@ CF_INLINE float cf_half_width(CF_Aabb bb) { return cf_width(bb) * 0.5f; }
  * @function cf_half_height
  * @category math
  * @brief    Returns the half-height of an AABB (axis-aligned bounding box).
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_half_width cf_half_extents cf_height
  */
 CF_INLINE float cf_half_height(CF_Aabb bb) { return cf_height(bb) * 0.5f; }
 
@@ -1686,7 +1686,7 @@ CF_INLINE float cf_half_height(CF_Aabb bb) { return cf_height(bb) * 0.5f; }
  * @category math
  * @brief    Returns the half-extents of an AABB (axis-aligned bounding box).
  * @remarks  Half-extents refer to half-width and height-height: `half_extents = { half_width, half_height }`.
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_half_width cf_half_height cf_height
  */
 CF_INLINE CF_V2 cf_half_extents(CF_Aabb bb) { return (cf_mul_v2_f(cf_sub_v2(bb.max, bb.min), 0.5f)); }
 
@@ -1695,7 +1695,7 @@ CF_INLINE CF_V2 cf_half_extents(CF_Aabb bb) { return (cf_mul_v2_f(cf_sub_v2(bb.m
  * @category math
  * @brief    Returns the extents of an AABB (axis-aligned bounding box).
  * @remarks  Extents refer to width and height: `extents = { width, height }`.
- * @related  CF_Aabb cf_make_aabb cf_width cf_height cf_half_width cf_half_height cf_half_extents cf_extents
+ * @related  cf_make_aabb cf_width cf_height
  */
 CF_INLINE CF_V2 cf_extents(CF_Aabb aabb) { return cf_sub_v2(aabb.max, aabb.min); }
 
@@ -1704,7 +1704,7 @@ CF_INLINE CF_V2 cf_extents(CF_Aabb aabb) { return cf_sub_v2(aabb.max, aabb.min);
  * @category math
  * @brief    Expands an AABB (axis-aligned bounding box).
  * @param    v      A vector of `{ half_width, half_height }` to expand by.
- * @related  CF_Aabb cf_make_aabb cf_expand_aabb cf_expand_aabb_f
+ * @related  cf_expand_aabb_f cf_make_aabb CF_Aabb
  */
 CF_INLINE CF_Aabb cf_expand_aabb(CF_Aabb aabb, CF_V2 v) { return cf_make_aabb(cf_sub_v2(aabb.min, v), cf_add_v2(aabb.max, v)); }
 
@@ -1713,7 +1713,7 @@ CF_INLINE CF_Aabb cf_expand_aabb(CF_Aabb aabb, CF_V2 v) { return cf_make_aabb(cf
  * @category math
  * @brief    Expands an AABB (axis-aligned bounding box).
  * @remarks  `v` is added to to `max.x` and `max.y` of `aabb`, and subtracted from `min.x` and `min.y` of `aabb`.
- * @related  CF_Aabb cf_make_aabb cf_expand_aabb cf_expand_aabb_f
+ * @related  cf_expand_aabb cf_make_aabb CF_Aabb
  */
 CF_INLINE CF_Aabb cf_expand_aabb_f(CF_Aabb aabb, float v) { CF_V2 factor = cf_v2(v, v); return cf_make_aabb(cf_sub_v2(aabb.min, factor), cf_add_v2(aabb.max, factor)); }
 
@@ -1721,7 +1721,7 @@ CF_INLINE CF_Aabb cf_expand_aabb_f(CF_Aabb aabb, float v) { CF_V2 factor = cf_v2
  * @function cf_min_aabb
  * @category math
  * @brief    Returns `bb.min`.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_midpoint cf_max_aabb cf_center
  */
 CF_INLINE CF_V2 cf_min_aabb(CF_Aabb bb) { return bb.min; }
 
@@ -1729,7 +1729,7 @@ CF_INLINE CF_V2 cf_min_aabb(CF_Aabb bb) { return bb.min; }
  * @function cf_max_aabb
  * @category math
  * @brief    Returns `bb.max`.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_min_aabb cf_midpoint cf_center
  */
 CF_INLINE CF_V2 cf_max_aabb(CF_Aabb bb) { return bb.max; }
 
@@ -1737,7 +1737,7 @@ CF_INLINE CF_V2 cf_max_aabb(CF_Aabb bb) { return bb.max; }
  * @function cf_midpoint
  * @category math
  * @brief    Returns the center of `bb`.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_min_aabb cf_max_aabb cf_center
  */
 CF_INLINE CF_V2 cf_midpoint(CF_Aabb bb) { return cf_mul_v2_f(cf_add_v2(bb.min, bb.max), 0.5f); }
 
@@ -1745,7 +1745,7 @@ CF_INLINE CF_V2 cf_midpoint(CF_Aabb bb) { return cf_mul_v2_f(cf_add_v2(bb.min, b
  * @function cf_center
  * @category math
  * @brief    Returns the center of `bb`.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_min_aabb cf_max_aabb cf_midpoint
  */
 CF_INLINE CF_V2 cf_center(CF_Aabb bb) { return cf_mul_v2_f(cf_add_v2(bb.min, bb.max), 0.5f); }
 
@@ -1753,7 +1753,7 @@ CF_INLINE CF_V2 cf_center(CF_Aabb bb) { return cf_mul_v2_f(cf_add_v2(bb.min, bb.
  * @function cf_top_left
  * @category math
  * @brief    Returns the top-left corner of bb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_top_right cf_min_aabb cf_max_aabb
  */
 CF_INLINE CF_V2 cf_top_left(CF_Aabb bb) { return cf_v2(bb.min.x, bb.max.y); }
 
@@ -1761,7 +1761,7 @@ CF_INLINE CF_V2 cf_top_left(CF_Aabb bb) { return cf_v2(bb.min.x, bb.max.y); }
  * @function cf_top_right
  * @category math
  * @brief    Returns the top-right corner of bb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_top_left cf_min_aabb cf_max_aabb
  */
 CF_INLINE CF_V2 cf_top_right(CF_Aabb bb) { return cf_v2(bb.max.x, bb.max.y); }
 
@@ -1769,7 +1769,7 @@ CF_INLINE CF_V2 cf_top_right(CF_Aabb bb) { return cf_v2(bb.max.x, bb.max.y); }
  * @function cf_bottom_left
  * @category math
  * @brief    Returns the bottom-left corner of bb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_bottom_right cf_min_aabb cf_max_aabb
  */
 CF_INLINE CF_V2 cf_bottom_left(CF_Aabb bb) { return cf_v2(bb.min.x, bb.min.y); }
 
@@ -1777,7 +1777,7 @@ CF_INLINE CF_V2 cf_bottom_left(CF_Aabb bb) { return cf_v2(bb.min.x, bb.min.y); }
  * @function cf_bottom_right
  * @category math
  * @brief    Returns the bottom-right corner of bb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_bottom_left cf_min_aabb cf_max_aabb
  */
 CF_INLINE CF_V2 cf_bottom_right(CF_Aabb bb) { return cf_v2(bb.max.x, bb.min.y); }
 
@@ -1785,7 +1785,7 @@ CF_INLINE CF_V2 cf_bottom_right(CF_Aabb bb) { return cf_v2(bb.max.x, bb.min.y); 
  * @function cf_top
  * @category math
  * @brief    Returns the top of the aabb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_top_left cf_top_right cf_min_aabb
  */
 CF_INLINE CF_V2 cf_top(CF_Aabb bb) { return cf_v2((bb.min.x + bb.max.x) * 0.5f, bb.max.y); }
 
@@ -1793,7 +1793,7 @@ CF_INLINE CF_V2 cf_top(CF_Aabb bb) { return cf_v2((bb.min.x + bb.max.x) * 0.5f, 
  * @function cf_left
  * @category math
  * @brief    Returns the left of the aabb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_min_aabb cf_max_aabb cf_midpoint
  */
 CF_INLINE CF_V2 cf_left(CF_Aabb bb) { return cf_v2(bb.min.x, (bb.min.y + bb.max.y) * 0.5f); }
 
@@ -1801,7 +1801,7 @@ CF_INLINE CF_V2 cf_left(CF_Aabb bb) { return cf_v2(bb.min.x, (bb.min.y + bb.max.
  * @function cf_bottom
  * @category math
  * @brief    Returns the bottom of the aabb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_bottom_left cf_bottom_right cf_min_aabb
  */
 CF_INLINE CF_V2 cf_bottom(CF_Aabb bb) { return cf_v2((bb.min.x + bb.max.x) * 0.5f, bb.min.y); }
 
@@ -1809,7 +1809,7 @@ CF_INLINE CF_V2 cf_bottom(CF_Aabb bb) { return cf_v2((bb.min.x + bb.max.x) * 0.5
  * @function cf_right
  * @category math
  * @brief    Returns the bottom of the aabb.
- * @related  CF_Aabb cf_min_aabb cf_max_aabb cf_midpoint cf_center cf_top_left cf_top_right cf_bottom_left cf_bottom_right
+ * @related  cf_min_aabb cf_max_aabb cf_midpoint
  */
 CF_INLINE CF_V2 cf_right(CF_Aabb bb) { return cf_v2(bb.max.x, (bb.min.y + bb.max.y) * 0.5f); }
 
@@ -1817,7 +1817,7 @@ CF_INLINE CF_V2 cf_right(CF_Aabb bb) { return cf_v2(bb.max.x, (bb.min.y + bb.max
  * @function cf_contains_point
  * @category math
  * @brief    Returns true if `p` is contained within `b`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_contains_aabb cf_combine cf_clamp_aabb_v2
  */
 CF_INLINE bool cf_contains_point(CF_Aabb bb, CF_V2 p) { return cf_greater_equal_v2(p, bb.min) && cf_lesser_equal_v2(p, bb.max); }
 
@@ -1825,7 +1825,7 @@ CF_INLINE bool cf_contains_point(CF_Aabb bb, CF_V2 p) { return cf_greater_equal_
  * @function cf_contains_aabb
  * @category math
  * @brief    Returns true if `a` is _fully_ contained within `b`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_contains_point cf_combine cf_clamp_aabb_v2
  */
 CF_INLINE bool cf_contains_aabb(CF_Aabb a, CF_Aabb b) { return cf_lesser_equal_v2(a.min, b.min) && cf_greater_equal_v2(a.max, b.max); }
 
@@ -1833,7 +1833,7 @@ CF_INLINE bool cf_contains_aabb(CF_Aabb a, CF_Aabb b) { return cf_lesser_equal_v
  * @function cf_surface_area_aabb
  * @category math
  * @brief    Returns the surface area of a `CF_Aabb`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_contains_point cf_contains_aabb cf_area_aabb
  */
 CF_INLINE float cf_surface_area_aabb(CF_Aabb bb) { return 2.0f * cf_width(bb) * cf_height(bb); }
 
@@ -1841,7 +1841,7 @@ CF_INLINE float cf_surface_area_aabb(CF_Aabb bb) { return 2.0f * cf_width(bb) * 
  * @function cf_area_aabb
  * @category math
  * @brief    Returns the area of a `CF_Aabb`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_contains_point cf_contains_aabb cf_surface_area_aabb
  */
 CF_INLINE float cf_area_aabb(CF_Aabb bb) { return cf_width(bb) * cf_height(bb); }
 
@@ -1849,7 +1849,7 @@ CF_INLINE float cf_area_aabb(CF_Aabb bb) { return cf_width(bb) * cf_height(bb); 
  * @function cf_clamp_aabb_v2
  * @category math
  * @brief    Returns a point clamped within a `CF_Aabb`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_clamp_aabb cf_contains_point cf_contains_aabb
  */
 CF_INLINE CF_V2 cf_clamp_aabb_v2(CF_Aabb bb, CF_V2 p) { return cf_clamp_v2(p, bb.min, bb.max); }
 
@@ -1857,7 +1857,7 @@ CF_INLINE CF_V2 cf_clamp_aabb_v2(CF_Aabb bb, CF_V2 p) { return cf_clamp_v2(p, bb
  * @function cf_clamp_aabb
  * @category math
  * @brief    Returns `a` clamped within `b`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_clamp_aabb_v2 cf_contains_point cf_contains_aabb
  */
 CF_INLINE CF_Aabb cf_clamp_aabb(CF_Aabb a, CF_Aabb b) { return cf_make_aabb(cf_clamp_v2(a.min, b.min, b.max), cf_clamp_v2(a.max, b.min, b.max)); }
 
@@ -1865,7 +1865,7 @@ CF_INLINE CF_Aabb cf_clamp_aabb(CF_Aabb a, CF_Aabb b) { return cf_make_aabb(cf_c
  * @function cf_combine
  * @category math
  * @brief    Returns a `CF_Aabb` that tightly contains both `a` and `b`.
- * @related  CF_Aabb cf_contains_point cf_contains_aabb cf_surface_area_aabb cf_area_aabb cf_clamp_aabb_v2 cf_clamp_aabb cf_combine cf_overlaps
+ * @related  cf_contains_point cf_contains_aabb cf_clamp_aabb_v2
  */
 CF_INLINE CF_Aabb cf_combine(CF_Aabb a, CF_Aabb b) { return cf_make_aabb(cf_min_v2(a.min, b.min), cf_max_v2(a.max, b.max)); }
 
@@ -1873,7 +1873,7 @@ CF_INLINE CF_Aabb cf_combine(CF_Aabb a, CF_Aabb b) { return cf_make_aabb(cf_min_
  * @function cf_overlaps
  * @category math
  * @brief    Returns true if `a` and `b` intersect.
- * @related  CF_Aabb cf_overlaps cf_collide_aabb
+ * @related  cf_collide_aabb CF_Aabb
  */
 CF_INLINE int cf_overlaps(CF_Aabb a, CF_Aabb b)
 {
@@ -1888,7 +1888,7 @@ CF_INLINE int cf_overlaps(CF_Aabb a, CF_Aabb b)
  * @function cf_collide_aabb
  * @category math
  * @brief    Returns true if `a` and `b` intersect.
- * @related  CF_Aabb cf_overlaps cf_collide_aabb
+ * @related  cf_overlaps CF_Aabb
  */
 CF_INLINE int cf_collide_aabb(CF_Aabb a, CF_Aabb b) { return cf_overlaps(a, b); }
 
@@ -1896,7 +1896,7 @@ CF_INLINE int cf_collide_aabb(CF_Aabb a, CF_Aabb b) { return cf_overlaps(a, b); 
  * @function cf_make_aabb_verts
  * @category math
  * @brief    Returns a `CF_Aabb` that tightly contains all input verts.
- * @related  CF_Aabb cf_make_aabb_verts cf_aabb_verts
+ * @related  cf_aabb_verts CF_Aabb
  */
 CF_INLINE CF_Aabb cf_make_aabb_verts(const CF_V2* verts, int count)
 {
@@ -1913,7 +1913,7 @@ CF_INLINE CF_Aabb cf_make_aabb_verts(const CF_V2* verts, int count)
  * @function cf_aabb_verts
  * @category math
  * @brief    Fills in `out` with four vertices, one for each corner of `bb`, in counter-clockwise order.
- * @related  CF_Aabb cf_make_aabb_verts cf_aabb_verts
+ * @related  cf_make_aabb_verts CF_Aabb
  */
 CF_INLINE void cf_aabb_verts(CF_V2* out, CF_Aabb bb)
 {
@@ -1930,7 +1930,7 @@ CF_INLINE void cf_aabb_verts(CF_V2* out, CF_Aabb bb)
  * @function cf_area_circle
  * @category math
  * @brief    Returns the area of a `CF_Circle`.
- * @related  CF_Circle cf_area_circle cf_surface_area_circle
+ * @related  cf_surface_area_circle CF_Circle
  */
 CF_INLINE float cf_area_circle(CF_Circle c) { return 3.14159265f * c.r * c.r; }
 
@@ -1938,7 +1938,7 @@ CF_INLINE float cf_area_circle(CF_Circle c) { return 3.14159265f * c.r * c.r; }
  * @function cf_surface_area_circle
  * @category math
  * @brief    Returns the surface area of a `CF_Circle`.
- * @related  CF_Circle cf_area_circle cf_surface_area_circle
+ * @related  cf_area_circle CF_Circle
  */
 CF_INLINE float cf_surface_area_circle(CF_Circle c) { return 2.0f * 3.14159265f * c.r; }
 
@@ -1946,7 +1946,7 @@ CF_INLINE float cf_surface_area_circle(CF_Circle c) { return 2.0f * 3.14159265f 
  * @function cf_mul_tf_circle
  * @category math
  * @brief    Transforms a `CF_Circle`.
- * @related  CF_Circle cf_mul_tf_circle
+ * @related  CF_Circle
  */
 CF_INLINE CF_Circle cf_mul_tf_circle(CF_Transform tx, CF_Circle a) { CF_Circle b; b.p = cf_mul_tf_v2(tx, a.p); b.r = a.r; return b; }
 
@@ -1966,7 +1966,7 @@ CF_INLINE CF_Ray cf_make_ray(CF_V2 start, CF_V2 direction_normalized, float leng
  * @function cf_impact
  * @category collision
  * @brief    Returns the impact point of a ray, given the time of impact `t`.
- * @related  CF_Ray cf_impact cf_endpoint
+ * @related  cf_endpoint CF_Ray
  */
 CF_INLINE CF_V2 cf_impact(CF_Ray r, float t) { return cf_add_v2(r.p, cf_mul_v2_f(r.d, t)); }
 
@@ -1976,7 +1976,7 @@ CF_INLINE CF_V2 cf_impact(CF_Ray r, float t) { return cf_add_v2(r.p, cf_mul_v2_f
  * @brief    Returns the endpoint of a ray.
  * @remarks  Rays are defined to have an endpoint as an optimization. Usually infinite rays are not needed in games, and cause
  *           unnecessarily large computations when doing raycasts.
- * @related  CF_Ray cf_impact cf_endpoint
+ * @related  cf_impact CF_Ray
  */
 CF_INLINE CF_V2 cf_endpoint(CF_Ray r) { return cf_add_v2(r.p, cf_mul_v2_f(r.d, r.t)); }
 
@@ -2076,7 +2076,7 @@ CF_API CF_SliceOutput CF_CALL cf_slice(CF_Halfspace slice_plane, CF_Poly slice_m
  * @enum     CF_ShapeType
  * @category collision
  * @brief    Various types of supported collision shapes.
- * @related  CF_ShapeType cf_shape_type_to_string cf_gjk cf_toi cf_inflate cf_collide cf_collided cf_cast_ray
+ * @related  cf_shape_type_to_string cf_gjk cf_toi
  */
 #define CF_SHAPE_TYPE_DEFS \
 	/* @entry Unknown shape type. */      \
@@ -2103,7 +2103,7 @@ typedef enum CF_ShapeType
  * @category collision
  * @brief    Converts a `CF_ShapeType` to a C string.
  * @param    type       The string to convert.
- * @related  CF_ShapeType cf_shape_type_to_string
+ * @related  CF_ShapeType
  */
 CF_INLINE const char* cf_shape_type_to_string(CF_ShapeType type)
 {
@@ -2165,7 +2165,7 @@ CF_API void CF_CALL cf_norms(CF_V2* verts, CF_V2* norms, int count);
  * @category collision
  * @brief    Fills out the polygon with values.
  * @remarks  Runs `cf_hull` and `cf_norms`, assumes p->verts and p->count are both set to valid values.
- * @related  CF_Poly cf_hull cf_norms
+ * @related  cf_hull cf_norms CF_Poly
  */
 CF_API void CF_CALL cf_make_poly(CF_Poly* p);
 
@@ -2187,7 +2187,7 @@ CF_API CF_V2 CF_CALL cf_centroid(const CF_V2* verts, int count);
  * @category collision
  * @brief    Returns true if two circles are intersecting.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_circle_to_circle_manifold`.
- * @related  CF_Circle cf_circle_to_circle cf_circle_to_circle_manifold
+ * @related  cf_circle_to_circle_manifold CF_Circle
  */
 CF_API bool CF_CALL cf_circle_to_circle(CF_Circle A, CF_Circle B);
 
@@ -2196,7 +2196,7 @@ CF_API bool CF_CALL cf_circle_to_circle(CF_Circle A, CF_Circle B);
  * @category collision
  * @brief    Returns true if a circle is intersecting with an Aabb.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_circle_to_aabb_manifold`.
- * @related  CF_Circle CF_Aabb cf_circle_to_aabb cf_circle_to_aabb_manifold
+ * @related  cf_circle_to_aabb_manifold CF_Circle CF_Aabb
  */
 CF_API bool CF_CALL cf_circle_to_aabb(CF_Circle A, CF_Aabb B);
 
@@ -2205,7 +2205,7 @@ CF_API bool CF_CALL cf_circle_to_aabb(CF_Circle A, CF_Aabb B);
  * @category collision
  * @brief    Returns true if a circle is intersecting with an capsule.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_circle_to_capsule_manifold`.
- * @related  CF_Circle CF_Capsule cf_circle_to_capsule cf_circle_to_capsule_manifold
+ * @related  cf_circle_to_capsule_manifold CF_Circle CF_Capsule
  */
 CF_API bool CF_CALL cf_circle_to_capsule(CF_Circle A, CF_Capsule B);
 
@@ -2214,7 +2214,7 @@ CF_API bool CF_CALL cf_circle_to_capsule(CF_Circle A, CF_Capsule B);
  * @category collision
  * @brief    Returns true two Aabb's are intersecting.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_aabb_to_aabb_manifold`.
- * @related  CF_Aabb cf_aabb_to_aabb cf_aabb_to_aabb_manifold
+ * @related  cf_aabb_to_aabb_manifold CF_Aabb
  */
 CF_API bool CF_CALL cf_aabb_to_aabb(CF_Aabb A, CF_Aabb B);
 
@@ -2223,7 +2223,7 @@ CF_API bool CF_CALL cf_aabb_to_aabb(CF_Aabb A, CF_Aabb B);
  * @category collision
  * @brief    Returns true if an Aabb is intersecting a capsule.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_aabb_to_capsule_manifold`.
- * @related  CF_Aabb CF_Capsule cf_aabb_to_capsule cf_aabb_to_capsule_manifold
+ * @related  cf_aabb_to_capsule_manifold CF_Aabb CF_Capsule
  */
 CF_API bool CF_CALL cf_aabb_to_capsule(CF_Aabb A, CF_Capsule B);
 
@@ -2232,7 +2232,7 @@ CF_API bool CF_CALL cf_aabb_to_capsule(CF_Aabb A, CF_Capsule B);
  * @category collision
  * @brief    Returns true if two capsules are intersecting.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_capsule_to_capsule_manifold`.
- * @related  CF_Capsule cf_capsule_to_capsule cf_capsule_to_capsule_manifold
+ * @related  cf_capsule_to_capsule_manifold CF_Capsule
  */
 CF_API bool CF_CALL cf_capsule_to_capsule(CF_Capsule A, CF_Capsule B);
 
@@ -2241,7 +2241,7 @@ CF_API bool CF_CALL cf_capsule_to_capsule(CF_Capsule A, CF_Capsule B);
  * @category collision
  * @brief    Returns true if a circle is intersecting a polygon.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_circle_to_poly_manifold`.
- * @related  CF_Circle CF_Poly cf_circle_to_poly cf_circle_to_poly_manifold
+ * @related  cf_circle_to_poly_manifold CF_Circle CF_Poly
  */
 CF_API bool CF_CALL cf_circle_to_poly(CF_Circle A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2250,7 +2250,7 @@ CF_API bool CF_CALL cf_circle_to_poly(CF_Circle A, const CF_Poly* B, const CF_Tr
  * @category collision
  * @brief    Returns true an Aabb is intersecting a polygon.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_aabb_to_poly_manifold`.
- * @related  CF_Aabb CF_Poly cf_aabb_to_poly cf_aabb_to_poly_manifold
+ * @related  cf_aabb_to_poly_manifold CF_Aabb CF_Poly
  */
 CF_API bool CF_CALL cf_aabb_to_poly(CF_Aabb A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2259,7 +2259,7 @@ CF_API bool CF_CALL cf_aabb_to_poly(CF_Aabb A, const CF_Poly* B, const CF_Transf
  * @category collision
  * @brief    Returns true an capsule is intersecting a polygon.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_capsule_to_poly_manifold`.
- * @related  CF_Capsule CF_Poly cf_capsule_to_poly cf_capsule_to_poly_manifold
+ * @related  cf_capsule_to_poly_manifold CF_Capsule CF_Poly
  */
 CF_API bool CF_CALL cf_capsule_to_poly(CF_Capsule A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2268,7 +2268,7 @@ CF_API bool CF_CALL cf_capsule_to_poly(CF_Capsule A, const CF_Poly* B, const CF_
  * @category collision
  * @brief    Returns true if two polygons are intersecting.
  * @remarks  For information about _how_ two shapes are intersecting (and not just boolean result), see `cf_poly_to_poly_manifold`.
- * @related  CF_Poly cf_poly_to_poly cf_poly_to_poly_manifold
+ * @related  cf_poly_to_poly_manifold CF_Poly
  */
 CF_API bool CF_CALL cf_poly_to_poly(const CF_Poly* A, const CF_Transform* ax, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2279,7 +2279,7 @@ CF_API bool CF_CALL cf_poly_to_poly(const CF_Poly* A, const CF_Transform* ax, co
  * @param    A          The ray.
  * @param    B          The circle.
  * @return   `CF_Raycast` results are placed here. See `CF_RayCast`.
- * @related  CF_Ray CF_Circle CF_Raycast cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_capsule cf_ray_to_aabb cf_ray_to_poly
  */
 CF_API CF_Raycast CF_CALL cf_ray_to_circle(CF_Ray A, CF_Circle B);
 
@@ -2290,7 +2290,7 @@ CF_API CF_Raycast CF_CALL cf_ray_to_circle(CF_Ray A, CF_Circle B);
  * @param    A          The ray.
  * @param    B          The Aabb.
  * @return   `CF_Raycast` results are placed here. See `CF_RayCast`.
- * @related  CF_Ray CF_Aabb CF_Raycast cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_circle cf_ray_to_capsule cf_ray_to_poly
  */
 CF_API CF_Raycast CF_CALL cf_ray_to_aabb(CF_Ray A, CF_Aabb B);
 
@@ -2301,7 +2301,7 @@ CF_API CF_Raycast CF_CALL cf_ray_to_aabb(CF_Ray A, CF_Aabb B);
  * @param    A          The ray.
  * @param    B          The capsule.
  * @return   `CF_Raycast` results are placed here. See `CF_RayCast`.
- * @related  CF_Ray CF_Capsule CF_Raycast cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_circle cf_ray_to_aabb cf_ray_to_poly
  */
 CF_API CF_Raycast CF_CALL cf_ray_to_capsule(CF_Ray A, CF_Capsule B);
 
@@ -2312,7 +2312,7 @@ CF_API CF_Raycast CF_CALL cf_ray_to_capsule(CF_Ray A, CF_Capsule B);
  * @param    A          The ray.
  * @param    B          The polygon.
  * @return   `CF_Raycast` results are placed here. See `CF_RayCast`.
- * @related  CF_Ray CF_Poly CF_Raycast cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule cf_ray_to_poly
+ * @related  cf_ray_to_circle cf_ray_to_aabb cf_ray_to_capsule
  */
 CF_API CF_Raycast CF_CALL cf_ray_to_poly(CF_Ray A, const CF_Poly* B, const CF_Transform* bx_ptr);
 
@@ -2324,7 +2324,7 @@ CF_API CF_Raycast CF_CALL cf_ray_to_poly(CF_Ray A, const CF_Poly* B, const CF_Tr
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_circle_to_circle`.
- * @related  CF_Manifold CF_Circle cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_capsule_manifold cf_circle_to_aabb_manifold cf_circle_to_poly_manifold
  */
 CF_API CF_Manifold CF_CALL cf_circle_to_circle_manifold(CF_Circle A, CF_Circle B);
 
@@ -2336,7 +2336,7 @@ CF_API CF_Manifold CF_CALL cf_circle_to_circle_manifold(CF_Circle A, CF_Circle B
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_circle_to_aabb`.
- * @related  CF_Manifold CF_Circle CF_Aabb cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_circle_manifold cf_circle_to_capsule_manifold cf_circle_to_poly_manifold
  */
 CF_API CF_Manifold CF_CALL cf_circle_to_aabb_manifold(CF_Circle A, CF_Aabb B);
 
@@ -2348,7 +2348,7 @@ CF_API CF_Manifold CF_CALL cf_circle_to_aabb_manifold(CF_Circle A, CF_Aabb B);
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_circle_to_capsule`.
- * @related  CF_Manifold CF_Circle CF_Capsule cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_poly_manifold
  */
 CF_API CF_Manifold CF_CALL cf_circle_to_capsule_manifold(CF_Circle A, CF_Capsule B);
 
@@ -2360,7 +2360,7 @@ CF_API CF_Manifold CF_CALL cf_circle_to_capsule_manifold(CF_Circle A, CF_Capsule
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_aabb_to_aabb`.
- * @related  CF_Manifold CF_Aabb cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_aabb_to_capsule_manifold cf_aabb_to_poly_manifold cf_circle_to_circle_manifold
  */
 CF_API CF_Manifold CF_CALL cf_aabb_to_aabb_manifold(CF_Aabb A, CF_Aabb B);
 
@@ -2372,7 +2372,7 @@ CF_API CF_Manifold CF_CALL cf_aabb_to_aabb_manifold(CF_Aabb A, CF_Aabb B);
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_aabb_to_capsule`.
- * @related  CF_Manifold CF_Aabb CF_Capsule cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_aabb_to_aabb_manifold cf_aabb_to_poly_manifold cf_circle_to_circle_manifold
  */
 CF_API CF_Manifold CF_CALL cf_aabb_to_capsule_manifold(CF_Aabb A, CF_Capsule B);
 
@@ -2384,7 +2384,7 @@ CF_API CF_Manifold CF_CALL cf_aabb_to_capsule_manifold(CF_Aabb A, CF_Capsule B);
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_capsule_to_capsule`.
- * @related  CF_Manifold CF_Capsule cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_capsule_to_poly_manifold cf_circle_to_circle_manifold cf_circle_to_aabb_manifold
  */
 CF_API CF_Manifold CF_CALL cf_capsule_to_capsule_manifold(CF_Capsule A, CF_Capsule B);
 
@@ -2396,7 +2396,7 @@ CF_API CF_Manifold CF_CALL cf_capsule_to_capsule_manifold(CF_Capsule A, CF_Capsu
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_circle_to_poly`.
- * @related  CF_Manifold CF_Circle CF_Poly cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold
  */
 CF_API CF_Manifold CF_CALL cf_circle_to_poly_manifold(CF_Circle A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2408,7 +2408,7 @@ CF_API CF_Manifold CF_CALL cf_circle_to_poly_manifold(CF_Circle A, const CF_Poly
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_aabb_to_poly`.
- * @related  CF_Manifold CF_Aabb CF_Poly cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_circle_manifold
  */
 CF_API CF_Manifold CF_CALL cf_aabb_to_poly_manifold(CF_Aabb A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2420,7 +2420,7 @@ CF_API CF_Manifold CF_CALL cf_aabb_to_poly_manifold(CF_Aabb A, const CF_Poly* B,
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_capsule_to_poly`.
- * @related  CF_Manifold CF_Capsule CF_Poly cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold
  */
 CF_API CF_Manifold CF_CALL cf_capsule_to_poly_manifold(CF_Capsule A, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2432,7 +2432,7 @@ CF_API CF_Manifold CF_CALL cf_capsule_to_poly_manifold(CF_Capsule A, const CF_Po
  * @param    B          The second shape.
  * @return   Returns a `CF_Manifold` containing information about the intersection. See `CF_Manifold` for details.
  * @remarks  This function is slightly slower than the boolean version `cf_poly_to_poly`.
- * @related  CF_Manifold CF_Poly cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold cf_aabb_to_aabb_manifold cf_aabb_to_capsule_manifold cf_circle_to_poly_manifold cf_aabb_to_poly_manifold cf_capsule_to_poly_manifold cf_poly_to_poly_manifold
+ * @related  cf_circle_to_circle_manifold cf_circle_to_aabb_manifold cf_circle_to_capsule_manifold
  */
 CF_API CF_Manifold CF_CALL cf_poly_to_poly_manifold(const CF_Poly* A, const CF_Transform* ax, const CF_Poly* B, const CF_Transform* bx);
 
@@ -2442,7 +2442,7 @@ CF_API CF_Manifold CF_CALL cf_poly_to_poly_manifold(const CF_Poly* A, const CF_T
  * @brief    This struct is only for advanced usage of the `cf_gjk` function. See comments inside of the `cf_gjk` function for more details.
  * @remarks  Contains cached geometric information to speed up successive calls to `cf_gjk` where the shapes don't move much relatie to
  *           one other from one call to the next.
- * @related  CF_GjkCache cf_gjk
+ * @related  cf_gjk
  */
 typedef struct CF_GjkCache
 {
@@ -2485,7 +2485,7 @@ typedef struct CF_GjkCache
  *           this file in many ways, so try to make sure all of your collision shapes are not gigantic. For example, try to keep the volume of
  *           all your shapes less than 100.0f. If you need large shapes, you should use tiny collision geometry for all function here, and simply
  *           render the geometry larger on-screen by scaling it up.
- * @related  cf_gjk CF_GjkCache CF_ShapeType
+ * @related  CF_GjkCache CF_ShapeType
  */
 CF_API float CF_CALL cf_gjk(const void* A, CF_ShapeType typeA, const CF_Transform* ax_ptr, const void* B, CF_ShapeType typeB, const CF_Transform* bx_ptr, CF_V2* outA, CF_V2* outB, bool use_radius, int* iterations, CF_GjkCache* cache);
 
@@ -2494,7 +2494,7 @@ CF_API float CF_CALL cf_gjk(const void* A, CF_ShapeType typeA, const CF_Transfor
  * @category collision
  * @brief    Stores results of a time of impact calculation done by `cf_toi`.
  * @remarks  This is an advanced struct, intended to be used by people who know what they're doing.
- * @related  CF_ToiResult cf_toi
+ * @related  cf_toi
  */
 typedef struct CF_ToiResult
 {
@@ -2551,7 +2551,7 @@ typedef struct CF_ToiResult
  *              See the function `cf_inflate` for some more details.
  *           4. Compute the collision manifold between the inflated shapes (for example, use `cf_poly_to_poly_manifold`).
  *           5. Gently push the shapes apart. This will give the next call to `cf_toi` some breathing room.
- * @related  CF_ToiResult cf_toi CF_ShapeType
+ * @related  CF_ToiResult CF_ShapeType
  */
 CF_API CF_ToiResult CF_CALL cf_toi(const void* A, CF_ShapeType typeA, const CF_Transform* ax_ptr, CF_V2 vA, const void* B, CF_ShapeType typeB, const CF_Transform* bx_ptr, CF_V2 vB, int use_radius);
 
@@ -2566,7 +2566,7 @@ CF_API CF_ToiResult CF_CALL cf_toi(const void* A, CF_ShapeType typeA, const CF_T
  * @param    B           The second shape.
  * @param    typeA       The `CF_ShapeType` of the second shape `B`.
  * @param    bx_ptr      Can be `NULL` to represent an identity transform. An optional pointer to a `CF_Transform` to transform `B`.
- * @related  cf_collided cf_collide CF_Transform CF_ShapeType
+ * @related  cf_collide CF_Transform CF_ShapeType
  */
 CF_API int CF_CALL cf_collided(const void* A, const CF_Transform* ax, CF_ShapeType typeA, const void* B, const CF_Transform* bx, CF_ShapeType typeB);
 
@@ -2581,7 +2581,7 @@ CF_API int CF_CALL cf_collided(const void* A, const CF_Transform* ax, CF_ShapeTy
  * @param    bx          Can be `NULL` to represent an identity transform. An optional pointer to a `CF_Transform` to transform `B`.
  * @param    typeA       The `CF_ShapeType` of the second shape `B`.
  * @param    m           Contains information about the intersection. `m->count` is set to zero for no-intersection. See `CF_Manifold` for details.
- * @related  cf_collided cf_collide CF_Transform CF_ShapeType CF_Manifold
+ * @related  cf_collided CF_Transform CF_ShapeType
  */
 CF_API void CF_CALL cf_collide(const void* A, const CF_Transform* ax, CF_ShapeType typeA, const void* B, const CF_Transform* bx, CF_ShapeType typeB, CF_Manifold* m);
 
@@ -2595,7 +2595,7 @@ CF_API void CF_CALL cf_collide(const void* A, const CF_Transform* ax, CF_ShapeTy
  * @param    bx_ptr      Can be `NULL` to represent an identity transform. An optional pointer to a `CF_Transform` to transform `B`.
  * @param    out         Can be `NULL`. `CF_Raycast` results are placed here (contains normal + time of impact).
  * @return   Returns true if the ray hit the shape.
- * @related  CF_Ray CF_Raycast CF_Transform CF_ShapeType cf_cast_ray
+ * @related  CF_Ray CF_Raycast CF_Transform
  */
 CF_API bool CF_CALL cf_cast_ray(CF_Ray A, const void* B, const CF_Transform* bx, CF_ShapeType typeB, CF_Raycast* out);
 

--- a/include/cute_multithreading.h
+++ b/include/cute_multithreading.h
@@ -24,7 +24,7 @@ extern "C" {
  * @struct   CF_Mutex
  * @category multithreading
  * @brief    An opaque handle representing a mutex.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
  */
 typedef cute_mutex_t CF_Mutex;
 // @end
@@ -33,7 +33,7 @@ typedef cute_mutex_t CF_Mutex;
  * @struct   CF_ConditionVariable
  * @category multithreading
  * @brief    An opaque handle representing a condition variable.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_cv_wake_all cf_cv_wake_one cf_cv_wait
  */
 typedef cute_cv_t CF_ConditionVariable;
 // @end
@@ -43,7 +43,7 @@ typedef cute_cv_t CF_ConditionVariable;
  * @category atomic
  * @brief    An opaque handle representing an atomic integer.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  CF_AtomicInt cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_zero cf_atomic_add cf_atomic_set
  */
 typedef cute_atomic_int_t CF_AtomicInt;
 // @end
@@ -52,7 +52,7 @@ typedef cute_atomic_int_t CF_AtomicInt;
  * @struct   CF_Semaphore
  * @category multithreading
  * @brief    An opaque handle representing a semaphore.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_sem_post cf_sem_try cf_sem_wait
  */
 typedef cute_semaphore_t CF_Semaphore;
 // @end
@@ -61,7 +61,7 @@ typedef cute_semaphore_t CF_Semaphore;
  * @struct   CF_Thread
  * @category multithreading
  * @brief    An opaque handle representing a thread.
- * @related  CF_Thread cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_get_id
  */
 typedef cute_thread_t CF_Thread;
 // @end
@@ -70,7 +70,7 @@ typedef cute_thread_t CF_Thread;
  * @struct   CF_ThreadId
  * @category multithreading
  * @brief    An identifier of a thread.
- * @related  CF_Thread cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_get_id
  */
 typedef cute_thread_id_t CF_ThreadId;
 // @end
@@ -85,7 +85,7 @@ typedef cute_thread_id_t CF_ThreadId;
  *         // Do work here...
  *         return 0;
  *     }
- * @related  CF_Thread cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_get_id
  */
 typedef cute_thread_fn CF_ThreadFn;
 // @end
@@ -97,7 +97,7 @@ typedef cute_thread_fn CF_ThreadFn;
  * @remarks  A read/write lock can have a large number of simultaneous readers, but only one writer at a time. This can be
  *           used as an opimization where a resources can be safely read from many threads. Then, when the resource must be
  *           modified a writer can wait for all readers to leave, and then exclusively lock to perform a write update.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_read_lock cf_read_unlock cf_make_rw_lock
  */
 typedef cute_rw_lock_t CF_ReadWriteLock;
 // @end
@@ -106,7 +106,7 @@ typedef cute_rw_lock_t CF_ReadWriteLock;
  * @struct   CF_Threadpool
  * @category multithreading
  * @brief    An opaque handle representing a threadpool.
- * @related  CF_Threadpool CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
  */
 typedef cute_threadpool_t CF_Threadpool;
 // @end
@@ -116,7 +116,7 @@ typedef cute_threadpool_t CF_Threadpool;
  * @category multithreading
  * @brief    Returns an unlocked `CF_Mutex`.
  * @remarks  Destroy the mutex with `cf_destroy_mutex` when done.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
  */
 CF_API CF_Mutex CF_CALL cf_make_mutex();
 
@@ -125,7 +125,7 @@ CF_API CF_Mutex CF_CALL cf_make_mutex();
  * @category multithreading
  * @brief    Destroys a `CF_Mutex` created with `cf_make_mutex`.
  * @param    mutex      The mutex.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_make_mutex cf_mutex_lock cf_mutex_unlock
  */
 CF_API void CF_CALL cf_destroy_mutex(CF_Mutex* mutex);
 
@@ -135,7 +135,7 @@ CF_API void CF_CALL cf_destroy_mutex(CF_Mutex* mutex);
  * @brief    Locks a `CF_Mutex`.
  * @param    mutex      The mutex.
  * @remarks  Will cause the thread to wait until the lock is available if it's currently locked.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_mutex_unlock cf_mutex_try_lock cf_make_mutex
  */
 CF_API void CF_CALL cf_mutex_lock(CF_Mutex* mutex);
 
@@ -144,7 +144,7 @@ CF_API void CF_CALL cf_mutex_lock(CF_Mutex* mutex);
  * @category multithreading
  * @brief    Unlocks a `CF_Mutex`.
  * @param    mutex      The mutex.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_mutex_lock cf_mutex_try_lock cf_make_mutex
  */
 CF_API void CF_CALL cf_mutex_unlock(CF_Mutex* mutex);
 
@@ -154,7 +154,7 @@ CF_API void CF_CALL cf_mutex_unlock(CF_Mutex* mutex);
  * @brief    Attempts to lock a `CF_Mutex` without waiting.
  * @param    mutex      The mutex.
  * @return   Returns true if the lock was acquired, and false if the lock was already locked.
- * @related  CF_Mutex cf_make_mutex cf_destroy_mutex cf_mutex_lock cf_mutex_unlock cf_mutex_try_lock
+ * @related  cf_mutex_lock cf_mutex_unlock cf_make_mutex
  */
 CF_API bool CF_CALL cf_mutex_try_lock(CF_Mutex* mutex);
 
@@ -163,7 +163,7 @@ CF_API bool CF_CALL cf_mutex_try_lock(CF_Mutex* mutex);
  * @category multithreading
  * @brief    Returns an initialized `CF_ConditionVariable`, used to sleep or wake threads.
  * @remarks  Destroy the mutex with `cf_destroy_cv` when done.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_destroy_cv cf_cv_wake_all cf_cv_wake_one
  */
 CF_API CF_ConditionVariable CF_CALL cf_make_cv();
 
@@ -172,7 +172,7 @@ CF_API CF_ConditionVariable CF_CALL cf_make_cv();
  * @category multithreading
  * @brief    Destroys a `CF_ConditionVariable` created with `cf_make_cv`.
  * @param    cv         The condition variable.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_make_cv cf_cv_wake_all cf_cv_wake_one
  */
 CF_API void CF_CALL cf_destroy_cv(CF_ConditionVariable* cv);
 
@@ -182,7 +182,7 @@ CF_API void CF_CALL cf_destroy_cv(CF_ConditionVariable* cv);
  * @brief    Wakes all threads sleeping on the condition variable.
  * @param    cv         The condition variable.
  * @return   Returns any errors as a `CF_Result`.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_cv_wake_one cf_cv_wait cf_make_cv
  */
 CF_API CF_Result CF_CALL cf_cv_wake_all(CF_ConditionVariable* cv);
 
@@ -192,7 +192,7 @@ CF_API CF_Result CF_CALL cf_cv_wake_all(CF_ConditionVariable* cv);
  * @brief    Wakes a single (implementation-dependent) thread sleeping on the condition variable.
  * @param    cv         The condition variable.
  * @return   Returns any errors as a `CF_Result`.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_cv_wake_all cf_cv_wait cf_make_cv
  */
 CF_API CF_Result CF_CALL cf_cv_wake_one(CF_ConditionVariable* cv);
 
@@ -204,7 +204,7 @@ CF_API CF_Result CF_CALL cf_cv_wake_one(CF_ConditionVariable* cv);
  * @param    mutex      The mutex used to access the condition variable.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  The thread will not wake until `cf_cv_wake_all` or `cf_cv_wake_one` is called.
- * @related  CF_ConditionVariable cf_make_cv cf_destroy_cv cf_cv_wake_all cf_cv_wake_one cf_cv_wait
+ * @related  cf_cv_wake_all cf_cv_wake_one cf_make_cv
  */
 CF_API CF_Result CF_CALL cf_cv_wait(CF_ConditionVariable* cv, CF_Mutex* mutex);
 
@@ -217,7 +217,7 @@ CF_API CF_Result CF_CALL cf_cv_wait(CF_ConditionVariable* cv, CF_Mutex* mutex);
  *           common resources. Usually you'll have N resources, and initialize the semaphore to N. This is
  *           a rather advanced and low-level topic, beware. To learn more about semaphores I suggest reading
  *           the online book "The Little Book of Semaphores".
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_destroy_sem cf_sem_post cf_sem_try
  */
 CF_API CF_Semaphore CF_CALL cf_make_sem(int initial_count);
 
@@ -226,7 +226,7 @@ CF_API CF_Semaphore CF_CALL cf_make_sem(int initial_count);
  * @category multithreading
  * @brief    Destroys a `CF_Semaphore` made by `cf_make_sem`.
  * @param    semaphore  The semaphore.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_make_sem cf_sem_post cf_sem_try
  */
 CF_API void CF_CALL cf_destroy_sem(CF_Semaphore* semaphore);
 
@@ -238,7 +238,7 @@ CF_API void CF_CALL cf_destroy_sem(CF_Semaphore* semaphore);
  * @remarks  As other threads call `cf_sem_try` or `cf_sem_wait` they decrement the semaphore's counter. Eventually
  *           the counter will become zero, causing additional threads to wait (sleep). When the resources become
  *           available again, this function is used to wake one up.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_sem_try cf_sem_wait cf_sem_value
  */
 CF_API CF_Result CF_CALL cf_sem_post(CF_Semaphore* semaphore);
 
@@ -251,7 +251,7 @@ CF_API CF_Result CF_CALL cf_sem_post(CF_Semaphore* semaphore);
  *           be returned. Success is returned if the semaphore was successfully acquired and the counter was decremented.
  * @remarks  Since this function does not block/sleep, it allows the thread to continue running, even if the return
  *           value was an error. This lets a thread poll the semaphore instead of blocking/sleeping.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_sem_post cf_sem_wait cf_sem_value
  */
 CF_API CF_Result CF_CALL cf_sem_try(CF_Semaphore* semaphore);
 
@@ -263,7 +263,7 @@ CF_API CF_Result CF_CALL cf_sem_try(CF_Semaphore* semaphore);
  * @return   Returns any errors upon failure.
  * @remarks  The calling thread will sleep until the semaphore's counter is positive. When positive, the counter will be
  *           decremented once.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_sem_post cf_sem_try cf_sem_value
  */
 CF_API CF_Result CF_CALL cf_sem_wait(CF_Semaphore* semaphore);
 
@@ -273,7 +273,7 @@ CF_API CF_Result CF_CALL cf_sem_wait(CF_Semaphore* semaphore);
  * @brief    Atomically fetches the semaphore's counter.
  * @param    semaphore  The semaphore.
  * @return   Returns any errors upon failure.
- * @related  CF_Semaphore cf_make_sem cf_destroy_sem cf_sem_post cf_sem_try cf_sem_wait cf_sem_value
+ * @related  cf_sem_post cf_sem_try cf_sem_wait
  */
 CF_API CF_Result CF_CALL cf_sem_value(CF_Semaphore* semaphore);
 
@@ -293,7 +293,7 @@ CF_API CF_Result CF_CALL cf_sem_value(CF_Semaphore* semaphore);
  *     }
  * @remarks  Unless you call `cf_thread_detach` you should call `cf_thread_wait` from another thread to
  *           clean up resources and get the thread's return value back. It is considered a leak otherwise.
- * @related  CF_Thread CF_ThreadFn cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_detach cf_thread_get_id cf_thread_id
  */
 CF_API CF_Thread* CF_CALL cf_thread_create(CF_ThreadFn func, const char* name, void* udata);
 
@@ -304,7 +304,7 @@ CF_API CF_Thread* CF_CALL cf_thread_create(CF_ThreadFn func, const char* name, v
  *           for long-lived threads.
  * @param    thread  The thread.
  * @remarks  When a thread has `cf_thread_detach` called on it, it is no longer necessary to call `cf_thread_wait` on it.
- * @related  CF_Thread CF_ThreadFn cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_get_id cf_thread_id
  */
 CF_API void CF_CALL cf_thread_detach(CF_Thread* thread);
 
@@ -313,7 +313,7 @@ CF_API void CF_CALL cf_thread_detach(CF_Thread* thread);
  * @category multithreading
  * @brief    Returns the unique id of a thread.
  * @param    thread  The thread.
- * @related  CF_Thread CF_ThreadFn cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_id
  */
 CF_API CF_ThreadId CF_CALL cf_thread_get_id(CF_Thread* thread);
 
@@ -322,7 +322,7 @@ CF_API CF_ThreadId CF_CALL cf_thread_get_id(CF_Thread* thread);
  * @category multithreading
  * @brief    Returns the unique id of the calling thread.
  * @param    thread  The thread.
- * @related  CF_Thread CF_ThreadFn cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_get_id
  */
 CF_API CF_ThreadId CF_CALL cf_thread_id();
 
@@ -333,7 +333,7 @@ CF_API CF_ThreadId CF_CALL cf_thread_id();
  * @param    thread  The thread.
  * @remarks  It is invalid to call this function on a detached thread (see `cf_thread_detach`). It is invalid to
  *           call this function on a thread more than once.
- * @related  CF_Thread CF_ThreadFn cf_thread_create cf_thread_detach cf_thread_get_id cf_thread_id cf_thread_wait
+ * @related  cf_thread_create cf_thread_detach cf_thread_get_id
  */
 CF_API CF_Result CF_CALL cf_thread_wait(CF_Thread* thread);
 
@@ -341,7 +341,7 @@ CF_API CF_Result CF_CALL cf_thread_wait(CF_Thread* thread);
  * @function cf_core_count
  * @category CPU
  * @brief    Returns the number of cores on the CPU. Can be affected my machine dependent technology, such as Intel's hyperthreading.
- * @related  cf_core_count
+ * @related  cf_cacheline_size
  */
 CF_API int CF_CALL cf_core_count();
 
@@ -358,7 +358,7 @@ CF_API int CF_CALL cf_cacheline_size();
  * @category atomic
  * @brief    Returns an atomic integer of value zero.
  * @remarks  Atomics are an advanced topic. You've been warned!
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_add cf_atomic_set cf_atomic_get
  */
 CF_API CF_AtomicInt CF_CALL cf_atomic_zero();
 
@@ -369,7 +369,7 @@ CF_API CF_AtomicInt CF_CALL cf_atomic_zero();
  * @param    atomic     The integer to atomically manipulate.
  * @param    addend     A value to atomically add to `atomic`.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_zero cf_atomic_set cf_atomic_get
  */
 CF_API int CF_CALL cf_atomic_add(CF_AtomicInt* atomic, int addend);
 
@@ -380,7 +380,7 @@ CF_API int CF_CALL cf_atomic_add(CF_AtomicInt* atomic, int addend);
  * @param    atomic     The integer to atomically manipulate.
  * @param    value      A value to atomically set to `atomic`.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_zero cf_atomic_add cf_atomic_get
  */
 CF_API int CF_CALL cf_atomic_set(CF_AtomicInt* atomic, int value);
 
@@ -390,7 +390,7 @@ CF_API int CF_CALL cf_atomic_set(CF_AtomicInt* atomic, int value);
  * @brief    Atomically fetches the value at `atomic`.
  * @param    atomic     The integer to fetch from.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_zero cf_atomic_add cf_atomic_set
  */
 CF_API int CF_CALL cf_atomic_get(CF_AtomicInt* atomic);
 
@@ -403,7 +403,7 @@ CF_API int CF_CALL cf_atomic_get(CF_AtomicInt* atomic);
  * @param    value      A value to atomically set to `atomic`.
  * @return   Returns success if the value was set, error otherwise.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_zero cf_atomic_add cf_atomic_set
  */
 CF_API CF_Result CF_CALL cf_atomic_cas(CF_AtomicInt* atomic, int expected, int value);
 
@@ -414,7 +414,7 @@ CF_API CF_Result CF_CALL cf_atomic_cas(CF_AtomicInt* atomic, int expected, int v
  * @param    atomic     The pointer to atomically manipulate.
  * @param    value      A value to atomically set to `atomic`.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_ptr_get cf_atomic_ptr_cas cf_atomic_zero
  */
 CF_API void* CF_CALL cf_atomic_ptr_set(void** atomic, void* value);
 
@@ -424,7 +424,7 @@ CF_API void* CF_CALL cf_atomic_ptr_set(void** atomic, void* value);
  * @brief    Atomically fetches the value at `atomic`.
  * @param    atomic    The pointer to fetch from.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_ptr_set cf_atomic_ptr_cas cf_atomic_zero
  */
 CF_API void* CF_CALL cf_atomic_ptr_get(void** atomic);
 
@@ -437,7 +437,7 @@ CF_API void* CF_CALL cf_atomic_ptr_get(void** atomic);
  * @param    value      A value to atomically set to `atomic`.
  * @return   Returns success if the value was set, error otherwise.
  * @remarks  Atomics are an advanced topic. You've been warned! Beej has a [good article on atomics](https://beej.us/guide/bgc/html/split/chapter-atomics.html).
- * @related  cf_atomic_zero cf_atomic_add cf_atomic_set cf_atomic_get cf_atomic_cas cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_ptr_cas
+ * @related  cf_atomic_ptr_set cf_atomic_ptr_get cf_atomic_zero
  */
 CF_API CF_Result CF_CALL cf_atomic_ptr_cas(void** atomic, void* expected, void* value);
 
@@ -446,7 +446,7 @@ CF_API CF_Result CF_CALL cf_atomic_ptr_cas(void** atomic, void* expected, void* 
  * @category multithreading
  * @brief    Returns an unlocked `CF_ReadWriteLock` lock.
  * @remarks  Call `cf_destroy_rw_lock` when done.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_destroy_rw_lock cf_read_lock cf_read_unlock
  */
 CF_API CF_ReadWriteLock CF_CALL cf_make_rw_lock();
 
@@ -455,7 +455,7 @@ CF_API CF_ReadWriteLock CF_CALL cf_make_rw_lock();
  * @category multithreading
  * @brief    Destroys a `CF_ReadWriteLock` made from `cf_make_rw_lock`.
  * @param    rw         The read/write lock.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_make_rw_lock cf_read_lock cf_read_unlock
  */
 CF_API void CF_CALL cf_destroy_rw_lock(CF_ReadWriteLock* rw);
 
@@ -464,7 +464,7 @@ CF_API void CF_CALL cf_destroy_rw_lock(CF_ReadWriteLock* rw);
  * @category multithreading
  * @brief    Locks for reading. Many simultaneous readers are allowed.
  * @param    rw         The read/write lock.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_read_unlock cf_make_rw_lock cf_destroy_rw_lock
  */
 CF_API void CF_CALL cf_read_lock(CF_ReadWriteLock* rw);
 
@@ -473,7 +473,7 @@ CF_API void CF_CALL cf_read_lock(CF_ReadWriteLock* rw);
  * @category multithreading
  * @brief    Undoes one call to `cf_read_lock`.
  * @param    rw         The read/write lock.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_read_lock cf_make_rw_lock cf_destroy_rw_lock
  */
 CF_API void CF_CALL cf_read_unlock(CF_ReadWriteLock* rw);
 
@@ -484,7 +484,7 @@ CF_API void CF_CALL cf_read_unlock(CF_ReadWriteLock* rw);
  * @param    rw         The read/write lock.
  * @remarks  When locked for writing, only one writer can be present with no readers. The writer will sleep/wait for all other
  *           readers and writers to unlock before acquiring exclusive access to the lock.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_write_unlock cf_make_rw_lock cf_destroy_rw_lock
  */
 CF_API void CF_CALL cf_write_lock(CF_ReadWriteLock* rw);
 
@@ -495,7 +495,7 @@ CF_API void CF_CALL cf_write_lock(CF_ReadWriteLock* rw);
  * @param    rw         The read/write lock.
  * @remarks  When locked for writing, only one writer can be present with no readers. The writer will sleep/wait for all other
  *           readers and writers to unlock before acquiring exclusive access to the lock.
- * @related  CF_ReadWriteLock cf_make_rw_lock cf_destroy_rw_lock cf_read_lock cf_read_unlock cf_write_lock cf_write_unlock
+ * @related  cf_write_lock cf_make_rw_lock cf_destroy_rw_lock
  */
 CF_API void CF_CALL cf_write_unlock(CF_ReadWriteLock* rw);
 
@@ -507,7 +507,7 @@ CF_API void CF_CALL cf_write_unlock(CF_ReadWriteLock* rw);
  * @remarks  Threadpools are an advanced topic. You've been warned! John has a [good article on threadpools](https://nachtimwald.com/2019/04/12/thread-pool-in-c/).
  *           A task is a single function that a thread in the threadpool will run. Usually they perform one chunk of work, and then
  *           return. Often a task is defined as a bunch of processing that doesn't share any data external to the task.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
  */
 typedef void (CF_CALL CF_TaskFn)(void* param);
 
@@ -520,7 +520,7 @@ typedef void (CF_CALL CF_TaskFn)(void* param);
  *           into the threadpool (see: `CF_TaskFn`). Once the task is completed, the thread attempts to fetch another task. If no more
  *           tasks are available, the thread goes back to sleep. A common tactic is to take the number of cores in a given CPU and
  *           subtract one, then use this number for `thread_count`. We subtract one to account for the main thread.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait
  */
 CF_API CF_Threadpool* CF_CALL cf_make_threadpool(int thread_count);
 
@@ -529,7 +529,7 @@ CF_API CF_Threadpool* CF_CALL cf_make_threadpool(int thread_count);
  * @category multithreading
  * @brief    Destroys a `CF_Threadpool` created by `cf_make_threadpool`.
  * @param    pool       The pool.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_make_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait
  */
 CF_API void CF_CALL cf_destroy_threadpool(CF_Threadpool* pool);
 
@@ -542,7 +542,7 @@ CF_API void CF_CALL cf_destroy_threadpool(CF_Threadpool* pool);
  * @param    param      Can be `NULL`. This gets handed to the `CF_TaskFn` when it gets called.
  * @remarks  Once a task is added to the pool `cf_threadpool_kick_and_wait` or `cf_threadpool_kick` must be called wake threads. Once
  *           awake, threads will process the tasks. The order of start/finish for the tasks is not deterministic.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_threadpool_kick_and_wait cf_threadpool_kick cf_make_threadpool
  */
 CF_API void CF_CALL cf_threadpool_add_task(CF_Threadpool* pool, CF_TaskFn* task, void* param);
 
@@ -552,7 +552,7 @@ CF_API void CF_CALL cf_threadpool_add_task(CF_Threadpool* pool, CF_TaskFn* task,
  * @brief    Tells the internal threads to wake and start processing tasks, and blocks until all tasks are done.
  * @param    pool       The pool.
  * @remarks  This function will block until all tasks are completed.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_threadpool_kick cf_threadpool_add_task cf_make_threadpool
  */
 CF_API void CF_CALL cf_threadpool_kick_and_wait(CF_Threadpool* pool);
 
@@ -562,7 +562,7 @@ CF_API void CF_CALL cf_threadpool_kick_and_wait(CF_Threadpool* pool);
  * @brief    Tells the internal threads to wake and start processing tasks without blocking.
  * @param    pool       The pool.
  * @remarks  This function will _not_ block. It immediately returns after signaling the threads in the pool to wake.
- * @related  CF_TaskFn cf_make_threadpool cf_destroy_threadpool cf_threadpool_add_task cf_threadpool_kick_and_wait cf_threadpool_kick
+ * @related  cf_threadpool_kick_and_wait cf_threadpool_add_task cf_make_threadpool
  */
 CF_API void CF_CALL cf_threadpool_kick(CF_Threadpool* pool);
 

--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -27,7 +27,7 @@ extern "C" {
  * @struct   CF_Client
  * @category net
  * @brief    An opaque pointer representing a single networked client.
- * @related  CF_Client CF_Server cf_make_client
+ * @related  cf_make_client CF_Server
  */
 typedef struct cn_client_t CF_Client;
 // @end
@@ -36,7 +36,7 @@ typedef struct cn_client_t CF_Client;
  * @struct   CF_Server
  * @category net
  * @brief    An opaque pointer representing a single networked server.
- * @related  CF_Client CF_Server cf_make_client
+ * @related  cf_make_client CF_Client
  */
 typedef struct cn_server_t CF_Server;
 // @end
@@ -45,7 +45,7 @@ typedef struct cn_server_t CF_Server;
  * @struct   CF_CryptoKey
  * @category net
  * @brief    A chunk of bytes representing a cryptographically secure key.
- * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token
+ * @related  cf_crypto_generate_key cf_generate_connect_token
  */
 typedef struct cn_crypto_key_t CF_CryptoKey;
 // @end
@@ -54,7 +54,7 @@ typedef struct cn_crypto_key_t CF_CryptoKey;
  * @struct   CF_CryptoSignPublic
  * @category net
  * @brief    One-half of a cryptographically secure keypair. This key can be freely shared to the public.
- * @related  CF_CryptoKey CF_CryptoSignPublic CF_CryptoSignSecret cf_crypto_sign_keygen CF_ServerConfig
+ * @related  cf_crypto_sign_keygen CF_CryptoSignSecret CF_CryptoKey
  */
 typedef struct cn_crypto_sign_public_t CF_CryptoSignPublic;
 // @end
@@ -63,7 +63,7 @@ typedef struct cn_crypto_sign_public_t CF_CryptoSignPublic;
  * @struct   CF_CryptoSignSecret
  * @category net
  * @brief    One-half of a cryptographically secure keypair. This key must be kept secret and hidden with your servers.
- * @related  CF_CryptoKey CF_CryptoSignPublic CF_CryptoSignSecret cf_crypto_sign_keygen CF_ServerConfig
+ * @related  cf_crypto_sign_keygen CF_CryptoSignPublic CF_CryptoKey
  */
 typedef struct cn_crypto_sign_secret_t CF_CryptoSignSecret;
 // @end
@@ -75,7 +75,7 @@ typedef struct cn_crypto_sign_secret_t CF_CryptoSignSecret;
  * @struct   CF_Address
  * @category net
  * @brief    A network address.
- * @related  CF_Address CF_AddressType cf_address_init
+ * @related  cf_address_init CF_AddressType
  */
 typedef struct cn_endpoint_t CF_Address;
 // @end
@@ -109,7 +109,7 @@ enum
  * @category net
  * @brief    Initialze a `CF_Address` from a C string.
  * @return   Returns 0 on success, -1 on failure.
- * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
+ * @related  cf_address_to_string cf_address_equals CF_Address
  */
 CF_API int CF_CALL cf_address_init(CF_Address* endpoint, const char* address_and_port_string);
 
@@ -117,7 +117,7 @@ CF_API int CF_CALL cf_address_init(CF_Address* endpoint, const char* address_and
  * @function cf_address_to_string
  * @category net
  * @brief    Converts a `CF_Address` to a C string.
- * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
+ * @related  cf_address_init cf_address_equals CF_Address
  */
 CF_API void CF_CALL cf_address_to_string(CF_Address endpoint, char* buffer, int buffer_size);
 
@@ -125,7 +125,7 @@ CF_API void CF_CALL cf_address_to_string(CF_Address endpoint, char* buffer, int 
  * @function cf_address_equals
  * @category net
  * @brief    Tests two endpoints for equality.
- * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
+ * @related  cf_address_init cf_address_to_string CF_Address
  */
 CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
 
@@ -136,7 +136,7 @@ CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
  * @function CF_CONNECT_TOKEN_SIZE
  * @category net
  * @brief    The size of a single connect token.
- * @related  CF_CONNECT_TOKEN_SIZE CF_CONNECT_TOKEN_USER_DATA_SIZE cf_generate_connect_token cf_client_connect
+ * @related  cf_client_connect cf_generate_connect_token CF_CONNECT_TOKEN_USER_DATA_SIZE
  */
 #define CF_CONNECT_TOKEN_SIZE 1114
 
@@ -144,7 +144,7 @@ CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
  * @function CF_CONNECT_TOKEN_USER_DATA_SIZE
  * @category net
  * @brief    The size of the user data section of a connect token.
- * @related  CF_CONNECT_TOKEN_SIZE CF_CONNECT_TOKEN_USER_DATA_SIZE cf_generate_connect_token cf_client_connect
+ * @related  cf_client_connect cf_generate_connect_token CF_CONNECT_TOKEN_SIZE
  */
 #define CF_CONNECT_TOKEN_USER_DATA_SIZE 256
 
@@ -152,7 +152,7 @@ CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
  * @function cf_crypto_generate_key
  * @category net
  * @brief    Returns a cryptography key in a cryptographically secure way.
- * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token
+ * @related  cf_generate_connect_token CF_CryptoKey
  */
 CF_API CF_CryptoKey CF_CALL cf_crypto_generate_key(void);
 
@@ -169,7 +169,7 @@ CF_API void CF_CALL cf_crypto_random_bytes(void* data, int byte_count);
  * @brief    Generates a cryptographically secure keypair, used for facilitating connect tokens.
  * @param    public_key     The public key of the keypair. Freely share this publicy.
  * @param    secret_key     The secret key of the keypair. Keep this safe and hidden within your servers.
- * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token
+ * @related  cf_crypto_generate_key cf_generate_connect_token CF_CryptoKey
  */
 CF_API void CF_CALL cf_crypto_sign_keygen(CF_CryptoSignPublic* public_key, CF_CryptoSignSecret* secret_key);
 
@@ -207,7 +207,7 @@ CF_API void CF_CALL cf_crypto_sign_keygen(CF_CryptoSignPublic* public_key, CF_Cr
  *           which means the token cannot be modified or forged as long as the `cf_shared_secret_key` is
  *           not leaked. In the event your secret key is accidentally leaked, you can always roll a
  *           new one and distribute it to your webservice and game servers.
- * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token cf_client_connect
+ * @related  cf_crypto_generate_key cf_client_connect CF_CryptoKey
  */
 CF_API CF_Result CF_CALL cf_generate_connect_token(uint64_t application_id, uint64_t creation_timestamp, const CF_CryptoKey* client_to_server_key, const CF_CryptoKey* server_to_client_key, uint64_t expiration_timestamp, uint32_t handshake_timeout, int address_count, const char** address_list, uint64_t client_id, const uint8_t* user_data, const CF_CryptoSignSecret* shared_secret_key, uint8_t* token_ptr_out);
 
@@ -221,7 +221,7 @@ CF_API CF_Result CF_CALL cf_generate_connect_token(uint64_t application_id, uint
  * @param    port            Port for opening a UDP socket.
  * @param    application_id  A unique number to identify your game, can be whatever value you like. This must be the same number as in `cf_server_create`.
  * @param    use_ipv6        Whether or not the socket should turn on ipv6. Some users will not have ipv6 enabled, so consider setting to `false`.
- * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_generate_connect_token
+ * @related  cf_destroy_client cf_client_connect cf_generate_connect_token
  */
 CF_API CF_Client* CF_CALL cf_make_client(uint16_t port, uint64_t application_id, bool use_ipv6);
 
@@ -230,7 +230,7 @@ CF_API CF_Client* CF_CALL cf_make_client(uint16_t port, uint64_t application_id,
  * @category net
  * @brief    Destroys a client created by `cf_make_client`.
  * @remarks  Does not send out any disconnect packets. Call `cf_client_disconnect` first.
- * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect
+ * @related  cf_make_client cf_client_connect cf_client_disconnect
  */
 CF_API void CF_CALL cf_destroy_client(CF_Client* client);
 
@@ -244,7 +244,7 @@ CF_API void CF_CALL cf_destroy_client(CF_Client* client);
  *           `cf_client_state_get` to get the client's state. Once `cf_client_connect` is called then successive calls to
  *           `cf_client_update` is expected, where `cf_client_update` will perform the connection handshake and make
  *           connection attempts to your servers.
- * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect cf_client_update
+ * @related  cf_client_disconnect cf_client_update cf_make_client
  */
 CF_API CF_Result CF_CALL cf_client_connect(CF_Client* client, const uint8_t* connect_token);
 
@@ -252,7 +252,7 @@ CF_API CF_Result CF_CALL cf_client_connect(CF_Client* client, const uint8_t* con
  * @function cf_client_disconnect
  * @category net
  * @brief    Attempts to gracefully disconnect a `CF_Client` from a `CF_Server`.
- * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect cf_client_update
+ * @related  cf_client_connect cf_client_update cf_make_client
  */
 CF_API void CF_CALL cf_client_disconnect(CF_Client* client);
 
@@ -261,7 +261,7 @@ CF_API void CF_CALL cf_client_disconnect(CF_Client* client);
  * @category net
  * @brief    Updates the client.
  * @remarks  You should call this one per game loop after calling `cf_client_connect`.
- * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect cf_client_update
+ * @related  cf_client_connect cf_client_disconnect cf_make_client
  */
 CF_API void CF_CALL cf_client_update(CF_Client* client, double dt, uint64_t current_time);
 
@@ -275,7 +275,7 @@ CF_API void CF_CALL cf_client_update(CF_Client* client, double dt, uint64_t curr
  * @param    was_sent_reliably  `true` if the packet was a reliable packet.
  * @return   Returns `true` if a packet was popped.
  * @remarks  You must free this packet when you're done by calling `cf_client_free_packet`.
- * @related  CF_Client cf_client_pop_packet cf_client_free_packet cf_client_send
+ * @related  cf_client_free_packet cf_client_send CF_Client
  */
 CF_API bool CF_CALL cf_client_pop_packet(CF_Client* client, void** packet, int* size, bool* was_sent_reliably);
 
@@ -283,7 +283,7 @@ CF_API bool CF_CALL cf_client_pop_packet(CF_Client* client, void** packet, int* 
  * @function cf_client_free_packet
  * @category net
  * @brief    Free's a packet created by `cf_client_pop_packet`.
- * @related  CF_Client cf_client_pop_packet cf_client_free_packet cf_client_send
+ * @related  cf_client_pop_packet cf_client_send CF_Client
  */
 CF_API void CF_CALL cf_client_free_packet(CF_Client* client, void* packet);
 
@@ -308,7 +308,7 @@ CF_API void CF_CALL cf_client_free_packet(CF_Client* client, void* packet);
  *           that can be lost due to packet loss as an unreliable packet. Of course, some packets are required
  *           to be sent, and so reliable is appropriate. As an optimization some kinds of data, such as frequent
  *           transform updates, can be sent unreliably.
- * @related  CF_Client cf_client_pop_packet cf_client_free_packet cf_client_send
+ * @related  cf_client_pop_packet cf_client_free_packet CF_Client
  */
 CF_API CF_Result CF_CALL cf_client_send(CF_Client* client, const void* packet, int size, bool send_reliably);
 
@@ -317,7 +317,7 @@ CF_API CF_Result CF_CALL cf_client_send(CF_Client* client, const void* packet, i
  * @category net
  * @brief    The various states of a `CF_Client`.
  * @remarks  Anything less than or equal to 0 is an error.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @related  cf_client_state_to_string cf_client_state_get
  */
 #define CF_CLIENT_STATE_DEFS \
 	/* @entry */ \
@@ -354,7 +354,7 @@ typedef enum CF_ClientState
  * @category net
  * @brief    Convert an enum `CF_ClientState` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @related  cf_client_state_get CF_ClientState
  */
 CF_INLINE const char* cf_client_state_to_string(CF_ClientState state)
 {
@@ -370,7 +370,7 @@ CF_INLINE const char* cf_client_state_to_string(CF_ClientState state)
  * @function cf_client_state_get
  * @category net
  * @brief    Returns the `CF_ClientState` of a `CF_Client`.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @related  cf_client_state_to_string CF_ClientState
  */
 CF_API CF_ClientState CF_CALL cf_client_state_get(const CF_Client* client);
 
@@ -398,7 +398,7 @@ CF_API void CF_CALL cf_client_enable_network_simulator(CF_Client* client, double
  * @category net
  * @brief    Parameters for calling `cf_make_server`.
  * @remarks  Call `cf_server_config_defaults` to get a good set of default parameters.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server
+ * @related  cf_server_config_defaults cf_make_server
  */
 typedef struct CF_ServerConfig
 {
@@ -429,7 +429,7 @@ typedef struct CF_ServerConfig
  * @function cf_server_config_defaults
  * @category net
  * @brief    Returns a good set of default parameters for `cf_make_server`.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server
+ * @related  cf_make_server CF_ServerConfig
  */
 CF_INLINE CF_ServerConfig CF_CALL cf_server_config_defaults(void)
 {
@@ -447,7 +447,7 @@ CF_INLINE CF_ServerConfig CF_CALL cf_server_config_defaults(void)
  * @category net
  * @brief    Returns a new `CF_Server`.
  * @param    config      The server settings `CF_ServerConfig`.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
+ * @related  cf_server_config_defaults cf_destroy_server cf_server_start
  */
 CF_API CF_Server* CF_CALL cf_make_server(CF_ServerConfig config);
 
@@ -455,7 +455,7 @@ CF_API CF_Server* CF_CALL cf_make_server(CF_ServerConfig config);
  * @function cf_destroy_server
  * @category net
  * @brief    Destroys a `CF_Server` created by `cf_make_server`.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
+ * @related  cf_server_config_defaults cf_make_server cf_server_start
  */
 CF_API void CF_CALL cf_destroy_server(CF_Server* server);
 
@@ -465,7 +465,7 @@ CF_API void CF_CALL cf_destroy_server(CF_Server* server);
  * @brief    Starts up the server connection, ready to receive new client connections.
  * @param    address_and_port  The address and port combo to start the server upon.
  * @remarks  Please note that not all users will be able to access an ipv6 server address, so it might be good to also provide a way to connect through ipv4.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
+ * @related  cf_server_config_defaults cf_server_update cf_make_server
  */
 CF_API CF_Result cf_server_start(CF_Server* server, const char* address_and_port);
 
@@ -473,7 +473,7 @@ CF_API CF_Result cf_server_start(CF_Server* server, const char* address_and_port
  * @function cf_server_stop
  * @category net
  * @brief    Stops the server.
- * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
+ * @related  cf_server_start cf_server_config_defaults cf_server_update
  */
 CF_API void cf_server_stop(CF_Server* server);
 
@@ -481,7 +481,7 @@ CF_API void cf_server_stop(CF_Server* server);
  * @enum     CF_ServerEventType
  * @category net
  * @brief    The various possible `CF_ServerEvent` types.
- * @related  CF_ServerEventType cf_server_event_type_to_string CF_ServerEvent cf_server_pop_event
+ * @related  cf_server_event_type_to_string cf_server_pop_event
  */
 #define CF_SERVER_EVENT_TYPE_DEFS \
 	/* @entry A new incoming connection. */         \
@@ -504,7 +504,7 @@ typedef enum CF_ServerEventType
  * @category net
  * @brief    Convert an enum `CF_ServerEventType` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_ServerEventType cf_server_event_type_to_string CF_ServerEvent cf_server_pop_event
+ * @related  cf_server_pop_event CF_ServerEventType CF_ServerEvent
  */
 CF_INLINE const char* cf_server_event_type_to_string(CF_ServerEventType type)
 {
@@ -520,7 +520,7 @@ CF_INLINE const char* cf_server_event_type_to_string(CF_ServerEventType type)
  * @struct   CF_ServerEvent
  * @category net
  * @brief    An event from the server, likely a client payload packet.
- * @related  CF_ServerEvent CF_ServerEvent cf_server_update cf_server_pop_event cf_server_free_packet
+ * @related  cf_server_update cf_server_pop_event cf_server_free_packet
  */
 typedef struct CF_ServerEvent
 {
@@ -568,7 +568,7 @@ typedef struct CF_ServerEvent
  * @return   Returns true if an event was popped.
  * @remarks  Server events notify of when a client connects/disconnects, or has sent a payload packet.
  *           You must free the payload packets with `cf_server_free_packet` when done.
- * @related  CF_ServerEventType cf_server_event_type_to_string CF_ServerEvent cf_server_pop_event cf_server_update cf_server_send
+ * @related  cf_server_event_type_to_string cf_server_update cf_server_send
  */
 CF_API bool CF_CALL cf_server_pop_event(CF_Server* server, CF_ServerEvent* event);
 
@@ -576,7 +576,7 @@ CF_API bool CF_CALL cf_server_pop_event(CF_Server* server, CF_ServerEvent* event
  * @function cf_server_free_packet
  * @category net
  * @brief    Frees a payload packet from a `CF_ServerEvent`.
- * @related  CF_ServerEventType cf_server_event_type_to_string CF_ServerEvent cf_server_pop_event
+ * @related  cf_server_event_type_to_string cf_server_pop_event CF_ServerEventType
  */
 CF_API void CF_CALL cf_server_free_packet(CF_Server* server, int client_index, void* data);
 
@@ -585,7 +585,7 @@ CF_API void CF_CALL cf_server_free_packet(CF_Server* server, int client_index, v
  * @category net
  * @brief    Updates the server.
  * @remarks  Call this once per game tick.
- * @related  cf_server_update CF_ServerEvent cf_server_pop_event
+ * @related  cf_server_pop_event CF_ServerEvent
  */
 CF_API void CF_CALL cf_server_update(CF_Server* server, double dt, uint64_t current_time);
 
@@ -593,7 +593,7 @@ CF_API void CF_CALL cf_server_update(CF_Server* server, double dt, uint64_t curr
  * @function cf_server_disconnect_client
  * @category net
  * @brief    Disconnects a client from the server.
- * @related  cf_server_update CF_ServerEvent cf_server_pop_event cf_server_send
+ * @related  cf_server_update cf_server_pop_event cf_server_send
  */
 CF_API void CF_CALL cf_server_disconnect_client(CF_Server* server, int client_index, bool notify_client /* = true */);
 
@@ -607,7 +607,7 @@ CF_API void CF_CALL cf_server_disconnect_client(CF_Server* server, int client_in
  * @param    client_index   An index representing a particular client, from `CF_ServerEvent`.
  * @param    send_reliably  If `true` the packet will be sent reliably and in order. If false the packet will be sent just once, and may
  *                          arrive out of order or not at all.
- * @related  cf_server_update CF_ServerEvent cf_server_pop_event cf_server_send
+ * @related  cf_server_update cf_server_pop_event CF_ServerEvent
  */
 CF_API void CF_CALL cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably);
 
@@ -615,7 +615,7 @@ CF_API void CF_CALL cf_server_send(CF_Server* server, const void* packet, int si
  * @function cf_server_is_client_connected
  * @category net
  * @brief    Returns true if a client is still connected.
- * @related  cf_server_update CF_ServerEvent cf_server_pop_event cf_server_send
+ * @related  cf_server_update cf_server_pop_event cf_server_send
  */
 CF_API bool CF_CALL cf_server_is_client_connected(CF_Server* server, int client_index);
 

--- a/include/cute_noise.h
+++ b/include/cute_noise.h
@@ -24,7 +24,7 @@ extern "C" {
  * @brief    Used to generate noise at specified points.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           struct is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_noise2 cf_noise3 cf_noise4
  */
 typedef struct CF_Noise { uint64_t id; } CF_Noise;
 // @end
@@ -36,7 +36,7 @@ typedef struct CF_Noise { uint64_t id; } CF_Noise;
  * @param    seed        Used to seed the sequence of numbers generated. Default 0.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           function is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_make_noise_fbm cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_make_noise_fbm cf_destroy_noise cf_noise2
  */
 CF_API CF_Noise CF_CALL cf_make_noise(uint64_t seed);
 
@@ -51,7 +51,7 @@ CF_API CF_Noise CF_CALL cf_make_noise(uint64_t seed);
  * @param    falloff     How much contribution higher octaves have compared to lower ones. Default 0.5f.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           function is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_make_noise cf_destroy_noise cf_noise2
  */
 CF_API CF_Noise CF_CALL cf_make_noise_fbm(uint64_t seed, float scale, float lacunarity, int octaves, float falloff);
 
@@ -60,7 +60,7 @@ CF_API CF_Noise CF_CALL cf_make_noise_fbm(uint64_t seed, float scale, float lacu
  * @category noise
  * @brief    Destroys a `CF_Noise` created by `cf_make_noise` or `cf_make_noise_fbm`.
  * @param    CF_Noise    The `CF_Noise` to destroy.
- * @related  CF_Noise cf_make_noise cf_make_noise_fbm cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_make_noise cf_make_noise_fbm cf_noise2
  */
 CF_API void CF_CALL cf_destroy_noise(CF_Noise noise);
 
@@ -74,7 +74,7 @@ CF_API void CF_CALL cf_destroy_noise(CF_Noise noise);
  * @return   Returns a random value at the specified point.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           function is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_noise3 cf_noise4 cf_make_noise
  */
 CF_API float CF_CALL cf_noise2(CF_Noise noise, float x, float y);
 
@@ -89,7 +89,7 @@ CF_API float CF_CALL cf_noise2(CF_Noise noise, float x, float y);
  * @return   Returns a random value at the specified point.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           function is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_noise2 cf_noise4 cf_make_noise
  */
 CF_API float CF_CALL cf_noise3(CF_Noise noise, float x, float y, float z);
 
@@ -105,7 +105,7 @@ CF_API float CF_CALL cf_noise3(CF_Noise noise, float x, float y, float z);
  * @return   Returns a random value at the specified point.
  * @remarks  You're probably looking for image generation functions such as `cf_noise_pixels` or `cf_noise_fbm_pixels`. This
  *           function is fairly low-level and intended for those who know what they're doing.
- * @related  CF_Noise cf_make_noise cf_destroy_noise cf_noise2 cf_noise3 cf_noise4
+ * @related  cf_noise2 cf_noise3 cf_make_noise
  */
 CF_API float CF_CALL cf_noise4(CF_Noise noise, float x, float y, float z, float w);
 
@@ -119,7 +119,7 @@ CF_API float CF_CALL cf_noise4(CF_Noise noise, float x, float y, float z, float 
  * @param    scale      Scales up or down the noise in the image, like zooming in or out. Default 1.0f.
  * @return   Returns a generated image filled with noise.
  * @remarks  The generated noise is quite simple -- you're probably looking for the more advanced `cf_noise_fbm_pixels`, or `cf_noise_fbm_pixels_wrapped`.
- * @related  cf_noise_pixels cf_noise_pixels_wrapped cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
+ * @related  cf_noise_pixels_wrapped cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
  */
 CF_API CF_Pixel* CF_CALL cf_noise_pixels(int w, int h, uint64_t seed, float scale);
 
@@ -140,7 +140,7 @@ CF_API CF_Pixel* CF_CALL cf_noise_pixels(int w, int h, uint64_t seed, float scal
  *           
  *           If you want the animation to move faster without adjusting the loop time, then adjust `time_amplitude`. This scales how
  *           much the animation will evolve over time. Higher values will have faster and more volatile looking motions.
- * @related  cf_noise_pixels cf_noise_pixels_wrapped cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
+ * @related  cf_noise_pixels cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
  */
 CF_API CF_Pixel* CF_CALL cf_noise_pixels_wrapped(int w, int h, uint64_t seed, float scale, float time, float time_amplitude);
 
@@ -157,7 +157,7 @@ CF_API CF_Pixel* CF_CALL cf_noise_pixels_wrapped(int w, int h, uint64_t seed, fl
  * @param    falloff     How much contribution higher octaves have compared to lower ones. Default 0.5f.
  * @return   Returns a generated image filled with noise.
  * @remarks  If you want the image to animate over a loop, or tile seamlessly, then check out `cf_noise_fbm_pixels_wrapped`.
- * @related  cf_noise_pixels cf_noise_pixels_wrapped cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
+ * @related  cf_noise_fbm_pixels_wrapped cf_noise_pixels cf_noise_pixels_wrapped
  */
 CF_API CF_Pixel* CF_CALL cf_noise_fbm_pixels(int w, int h, uint64_t seed, float scale, float lacunarity, int octaves, float falloff);
 
@@ -179,7 +179,7 @@ CF_API CF_Pixel* CF_CALL cf_noise_fbm_pixels(int w, int h, uint64_t seed, float 
  *           
  *           If you want the animation to move faster without adjusting the loop time, then adjust `time_amplitude`. This scales how
  *           much the animation will evolve over time. Higher values will have faster and more volatile looking motions.
- * @related  cf_noise_pixels cf_noise_pixels_wrapped cf_noise_fbm_pixels cf_noise_fbm_pixels_wrapped
+ * @related  cf_noise_fbm_pixels cf_noise_pixels cf_noise_pixels_wrapped
  */
 CF_API CF_Pixel* CF_CALL cf_noise_fbm_pixels_wrapped(int w, int h, uint64_t seed, float scale, float lacunarity, int octaves, float falloff, float time, float time_amplitude);
 

--- a/include/cute_png_cache.h
+++ b/include/cute_png_cache.h
@@ -41,7 +41,7 @@ extern "C" {
  *           It's a cache, which means it actually caches images loaded in RAM, so subsequent
  *           calls to `cf_png_cache_load` won't have to fetch the image off of disk, as long as
  *           the image is currently cached in RAM.
- * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
+ * @related  cf_png_defaults cf_png_cache_load cf_make_png_cache_animation
  */
 typedef struct CF_Png
 {
@@ -67,7 +67,7 @@ typedef struct CF_Png
  * @category png_cache
  * @brief    Initialize an empty `CF_Png` struct.
  * @return   Returns an empty `CF_Png` struct.
- * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
+ * @related  cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
  */
 CF_INLINE CF_Png cf_png_defaults(void)
 {
@@ -81,7 +81,7 @@ CF_INLINE CF_Png cf_png_defaults(void)
  * @category png_cache
  * @brief    Returns an image `CF_Png` from the cache.
  * @remarks  If it does not exist in the cache, it is loaded from disk and placed into the cache.
- * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
+ * @related  cf_png_defaults cf_make_png_cache_animation cf_make_png_cache_sprite
  */
 CF_API CF_Result CF_CALL cf_png_cache_load(const char* png_path, CF_Png* png /*= NULL*/);
 
@@ -90,7 +90,7 @@ CF_API CF_Result CF_CALL cf_png_cache_load(const char* png_path, CF_Png* png /*=
  * @category png_cache
  * @brief    Returns an image `CF_Png` from the cache.
  * @remarks  If it does not exist in the cache, it is loaded from memory and placed into the cache.
- * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
+ * @related  cf_png_cache_load cf_png_defaults cf_make_png_cache_animation
  */
 CF_API CF_Result CF_CALL cf_png_cache_load_from_memory(const char* png_path, const void* memory, size_t size, CF_Png* png /*= NULL*/);
 
@@ -98,7 +98,7 @@ CF_API CF_Result CF_CALL cf_png_cache_load_from_memory(const char* png_path, con
  * @function cf_png_cache_unload
  * @category png_cache
  * @brief    Unloads an image from the cache.
- * @related  CF_Png cf_png_defaults cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_sprite
+ * @related  cf_png_cache_load cf_png_defaults cf_make_png_cache_animation
  */
 CF_API void CF_CALL cf_png_cache_unload(CF_Png png);
 
@@ -116,7 +116,7 @@ CF_API void CF_CALL cf_png_cache_unload(CF_Png png);
  *           you must specify all of the animation data yourself in order to make sprites. To flip between different
  *           animations you can construct an animation table with `cf_make_png_cache_animation_table`, which returns
  *           a table of unique animation names to individual `CF_Animation`'s.
- * @related  CF_Png cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table cf_make_png_cache_sprite
+ * @related  cf_make_png_cache_animation_table cf_make_png_cache_sprite cf_png_cache_load
  */
 CF_API const CF_Animation* CF_CALL cf_make_png_cache_animation(const char* name, const CF_Png* pngs, int pngs_count, const float* delays, int delays_count);
 
@@ -128,7 +128,7 @@ CF_API const CF_Animation* CF_CALL cf_make_png_cache_animation(const char* name,
  * @return   Returns a `CF_Animation`.
  * @remarks  You may use this function if you wish to implement your own sprites. However, it's recommended to instead use
  *           `cf_make_png_cache_sprite` and `CF_Sprite`.
- * @related  CF_Png cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table cf_make_png_cache_sprite
+ * @related  cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table
  */
 CF_API const CF_Animation* CF_CALL cf_png_cache_get_animation(const char* name);
 
@@ -141,7 +141,7 @@ CF_API const CF_Animation* CF_CALL cf_png_cache_get_animation(const char* name);
  * @remarks  The table returned is a map of animation names to individual `CF_Animation`'s. This is represents the guts of a sprite
  *           implementation. You may use this function if you wish to implement your own sprites. However, it's recommended to instead use
  *           `cf_make_png_cache_sprite` and `CF_Sprite`.
- * @related  CF_Png cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table cf_make_png_cache_sprite
+ * @related  cf_make_png_cache_animation cf_make_png_cache_sprite cf_png_cache_load
  */
 CF_API const htbl CF_Animation** CF_CALL cf_make_png_cache_animation_table(const char* sprite_name, const CF_Animation* const* animations, int animations_count);
 
@@ -151,7 +151,7 @@ CF_API const htbl CF_Animation** CF_CALL cf_make_png_cache_animation_table(const
  * @brief    Looks up an animation table within the png cache by name.
  * @param    sprite_name  A unique name for the animation table.
  * @return   Returns a hashtable of unique sprite names to `CF_Animation`'s, see `cf_make_png_cache_sprite`.
- * @related  CF_Png cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table cf_make_png_cache_sprite
+ * @related  cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table
  */
 CF_API const htbl CF_Animation** CF_CALL cf_png_cache_get_animation_table(const char* sprite_name);
 
@@ -167,7 +167,7 @@ CF_API const htbl CF_Animation** CF_CALL cf_png_cache_get_animation_table(const 
  * @param    sprite_name  A unique name for the sprite.
  * @param    table        An animation table.
  * @return   Returns a `CF_Sprite`, ready to use in e.g. `draw_sprite`.
- * @related  CF_Png cf_png_cache_load cf_make_png_cache_animation cf_make_png_cache_animation_table cf_make_png_cache_sprite
+ * @related  cf_make_png_cache_animation cf_make_png_cache_animation_table cf_png_cache_load
  */
 CF_API CF_Sprite CF_CALL cf_make_png_cache_sprite(const char* sprite_name, const CF_Animation** table /*= NULL*/);
 

--- a/include/cute_result.h
+++ b/include/cute_result.h
@@ -33,7 +33,7 @@ enum
  * @category utility
  * @brief    Information about the result of a function, containing any potential error details.
  * @remarks  Check if a result is an error or not with `cf_is_error`.
- * @related  CF_Result cf_is_error cf_result_make cf_result_error cf_result_success
+ * @related  cf_result_make cf_result_error cf_result_success
  */
 typedef struct CF_Result
 {
@@ -50,7 +50,7 @@ typedef struct CF_Result
  * @category utility
  * @brief    Returns true if a `CF_Result` contains an error.
  * @param    result       The result.
- * @related  CF_Result cf_is_error cf_result_make cf_result_error cf_result_success
+ * @related  cf_result_make cf_result_error cf_result_success
  */
 CF_INLINE bool cf_is_error(CF_Result result) { return result.code == CF_RESULT_ERROR; }
 
@@ -59,7 +59,7 @@ CF_INLINE bool cf_is_error(CF_Result result) { return result.code == CF_RESULT_E
  * @category utility
  * @brief    Returns a `CF_Result` containing an error.
  * @param    details      Details about the error.
- * @related  CF_Result cf_is_error cf_result_make cf_result_error cf_result_success
+ * @related  cf_result_make cf_result_success cf_is_error
  */
 CF_INLINE CF_Result cf_result_error(const char* details) { CF_Result result; result.code = CF_RESULT_ERROR; result.details = details; return result; }
 
@@ -67,7 +67,7 @@ CF_INLINE CF_Result cf_result_error(const char* details) { CF_Result result; res
  * @function cf_result_success
  * @category utility
  * @brief    Returns a `CF_Result` as a success, containing no error information.
- * @related  CF_Result cf_is_error cf_result_make cf_result_error cf_result_success
+ * @related  cf_result_make cf_result_error cf_is_error
  */
 CF_INLINE CF_Result cf_result_success(void) { CF_Result result; result.code = CF_RESULT_SUCCESS; result.details = NULL; return result; }
 
@@ -75,7 +75,7 @@ CF_INLINE CF_Result cf_result_success(void) { CF_Result result; result.code = CF
  * @enum     CF_MessageBoxType
  * @category utility
  * @brief    Types of supported message boxes.
- * @related  CF_MessageBoxType cf_message_box_type_to_string cf_message_box
+ * @related  cf_message_box_type_to_string cf_message_box
  */
 #define CF_MESSAGE_BOX_TYPE_DEFS \
 	/* @entry An error message box. */         \
@@ -98,7 +98,7 @@ typedef enum CF_MessageBoxType
  * @category utility
  * @brief    Convert an enum `CF_MessageBoxType` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_MessageBoxType cf_message_box_type_to_string cf_message_box
+ * @related  cf_message_box CF_MessageBoxType
  */
 CF_INLINE const char* cf_message_box_type_to_string(CF_MessageBoxType type)
 {
@@ -117,7 +117,7 @@ CF_INLINE const char* cf_message_box_type_to_string(CF_MessageBoxType type)
  * @param    type       The type of the message box. See `CF_MessageBoxType`.
  * @param    title      Title string of the window.
  * @param    text       Text to display as the window's message.
- * @related  CF_MessageBoxType cf_message_box_type_to_string cf_message_box
+ * @related  cf_message_box_type_to_string CF_MessageBoxType
  */
 CF_API void CF_CALL cf_message_box(CF_MessageBoxType type, const char* title, const char* text);
 

--- a/include/cute_rnd.h
+++ b/include/cute_rnd.h
@@ -28,7 +28,7 @@ extern "C" {
  *           
  *           This implementation comes from Mattias Gustavsson's single-file header collection.
  *           https://github.com/mattiasgustavsson/libs/blob/main/rnd.h
- * @related  CF_Rnd cf_rnd_seed cf_rnd
+ * @related  cf_rnd_seed cf_rnd
  */
 typedef struct CF_Rnd
 {
@@ -44,7 +44,7 @@ typedef struct CF_Rnd
  * @param    seed         The initial seed value for the random number generator.
  * @remarks  The `seed` is used to control which set of random numbers get generated. The numbers are generated in a completely
  *           deterministic way, so it's often important for many games to control or note which seed is used.
- * @related  CF_Rnd cf_rnd_seed cf_rnd
+ * @related  cf_rnd CF_Rnd
  */
 CF_INLINE CF_Rnd CF_CALL cf_rnd_seed(uint64_t seed);
 
@@ -53,7 +53,7 @@ CF_INLINE CF_Rnd CF_CALL cf_rnd_seed(uint64_t seed);
  * @category random
  * @brief    Returns a random `uint64_t`.
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_seed cf_rnd_float cf_rnd_double
  */
 CF_INLINE uint64_t CF_CALL cf_rnd_uint64(CF_Rnd* rnd);
 
@@ -62,7 +62,7 @@ CF_INLINE uint64_t CF_CALL cf_rnd_uint64(CF_Rnd* rnd);
  * @category random
  * @brief    Returns a random `float`.
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_seed cf_rnd_double cf_rnd_range_int
  */
 CF_INLINE float    CF_CALL cf_rnd_float(CF_Rnd* rnd);
 
@@ -71,7 +71,7 @@ CF_INLINE float    CF_CALL cf_rnd_float(CF_Rnd* rnd);
  * @category random
  * @brief    Returns a random `double`.
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_seed cf_rnd_float cf_rnd_range_int
  */
 CF_INLINE double   CF_CALL cf_rnd_double(CF_Rnd* rnd);
 
@@ -80,7 +80,7 @@ CF_INLINE double   CF_CALL cf_rnd_double(CF_Rnd* rnd);
  * @category random
  * @brief    Returns a random `int` from the range `min` to `max` (inclusive).
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
  */
 CF_INLINE int      CF_CALL cf_rnd_range_int(CF_Rnd* rnd, int min, int max);
 
@@ -89,7 +89,7 @@ CF_INLINE int      CF_CALL cf_rnd_range_int(CF_Rnd* rnd, int min, int max);
  * @category random
  * @brief    Returns a random `uint64_t` from the range `min` to `max` (inclusive).
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_range_int cf_rnd_range_float cf_rnd_range_double
  */
 CF_INLINE uint64_t CF_CALL cf_rnd_range_uint64(CF_Rnd* rnd, uint64_t min, uint64_t max);
 
@@ -98,7 +98,7 @@ CF_INLINE uint64_t CF_CALL cf_rnd_range_uint64(CF_Rnd* rnd, uint64_t min, uint64
  * @category random
  * @brief    Returns a random `float` from the range `min` to `max` (inclusive).
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_double
  */
 CF_INLINE float    CF_CALL cf_rnd_range_float(CF_Rnd* rnd, float min, float max);
 
@@ -107,7 +107,7 @@ CF_INLINE float    CF_CALL cf_rnd_range_float(CF_Rnd* rnd, float min, float max)
  * @category random
  * @brief    Returns a random `double` from the range `min` to `max` (inclusive).
  * @param    rnd          The random number generator state.
- * @related  CF_Rnd cf_rnd_seed cf_rnd cf_rnd_float cf_rnd_double cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float cf_rnd_range_double
+ * @related  cf_rnd_range_int cf_rnd_range_uint64 cf_rnd_range_float
  */
 CF_INLINE double   CF_CALL cf_rnd_range_double(CF_Rnd* rnd, double min, double max);
 

--- a/include/cute_shader_bytecode.h
+++ b/include/cute_shader_bytecode.h
@@ -65,7 +65,7 @@ typedef enum CF_ShaderInfoDataType
  * @struct   CF_ShaderUniformMemberInfo
  * @category graphics
  * @brief    Information about a uniform block member.
- * @related  CF_ShaderBytecode CF_ShaderUniformInfo
+ * @related  CF_ShaderUniformInfo CF_ShaderBytecode
  */
 typedef struct CF_ShaderUniformMemberInfo
 {
@@ -101,7 +101,7 @@ typedef struct CF_ShaderUniformMemberInfo
  *               members += uniform_info->num_members;
  *           }
  *           ```
- * @related  CF_ShaderBytecode CF_ShaderUniformMemberInfo
+ * @related  CF_ShaderUniformMemberInfo CF_ShaderBytecode
  */
 typedef struct CF_ShaderUniformInfo
 {
@@ -175,7 +175,7 @@ typedef struct CF_ShaderInfo
  * @category graphics
  * @brief    A SPIR-V shader bytecode blob.
  * @remarks  This can be created either through `cf_compile_shader_to_bytecode` or the `cute-shaderc` compiler.
- * @related  CF_Shader cf_make_shader_from_bytecode cf_compile_shader_to_bytecode
+ * @related  cf_make_shader_from_bytecode cf_compile_shader_to_bytecode CF_Shader
  */
 typedef struct CF_ShaderBytecode
 {

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -30,7 +30,7 @@ extern "C" {
  * @struct   CF_Frame
  * @category sprite
  * @brief    Represents one frame of animation within a sprite.
- * @related  CF_Frame CF_Animation CF_Sprite
+ * @related  CF_Animation CF_Sprite
  */
 typedef struct CF_Frame
 {
@@ -46,7 +46,7 @@ typedef struct CF_Frame
  * @enum     CF_PlayDirection
  * @category sprite
  * @brief    The direction a sprite plays frames.
- * @related  CF_PlayDirection cf_play_direction_to_string CF_Animation
+ * @related  cf_play_direction_to_string CF_Animation
  */
 #define CF_PLAY_DIRECTION_DEFS \
 	/* @entry Flips through the frames of an animation forwards. */ \
@@ -68,7 +68,7 @@ typedef enum CF_PlayDirection
  * @function cf_play_direction_to_string
  * @category sprite
  * @brief    Returns a `CF_PlayDirection` converted to a C string.
- * @related  CF_PlayDirection cf_play_direction_to_string CF_Animation
+ * @related  CF_PlayDirection CF_Animation
  */
 CF_INLINE const char* cf_play_direction_to_string(CF_PlayDirection dir)
 {
@@ -84,7 +84,7 @@ CF_INLINE const char* cf_play_direction_to_string(CF_PlayDirection dir)
  * @struct   CF_Animation
  * @category sprite
  * @brief    A named set of frames in sequence.
- * @related  CF_Frame CF_Animation CF_Sprite
+ * @related  CF_Frame CF_Sprite
  */
 typedef struct CF_Animation
 {
@@ -107,7 +107,7 @@ typedef struct CF_Animation
  * @category sprite
  * @brief    A box defined within a .ase file.
  * @remarks  Each frame can have different slices.
- * @related  CF_Frame CF_Animation CF_Sprite
+ * @related  CF_Sprite CF_Frame CF_Animation
  */
 typedef struct CF_SpriteSlice
 {
@@ -128,7 +128,7 @@ typedef struct CF_SpriteSlice
  * @brief    A sprite represents a drawable entity, made of 2D animations/images.
  * @remarks  Sprites can be drawn by `cf_draw_sprite`. Since sprites are [plain old data POD](https://stackoverflow.com/questions/146452/what-are-pod-types-in-c) you may create one on the stack anywhere
  *           and freely copy it around. In C++ you may simply draw via `sprite.draw()`.
- * @related  CF_Frame CF_Animation CF_Sprite cf_make_easy_sprite cf_make_sprite
+ * @related  cf_make_easy_sprite cf_make_sprite CF_Frame
  */
 typedef struct CF_Sprite
 {
@@ -197,7 +197,7 @@ typedef struct CF_Sprite
  * @brief    Returns an empty sprite.
  * @remarks  Empty sprites can not be drawn. You probably don't want this function unless you know what you're doing, instead,
  *           you may be looking for `cf_make_sprite` or `cf_make_easy_sprite`.
- * @related  CF_Sprite cf_sprite_defaults cf_make_easy_sprite cf_make_sprite
+ * @related  cf_make_easy_sprite cf_make_sprite CF_Sprite
  */
 CF_INLINE CF_Sprite cf_sprite_defaults(void)
 {
@@ -219,7 +219,7 @@ CF_INLINE CF_Sprite cf_sprite_defaults(void)
  *           as it's only a single-frame made from a png file.
  * @remarks  The preferred way to make a sprite is `cf_make_sprite`, but this function provides a very simple way to get started
  *           by merely loading a single .png image, or for games that don't require animations. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
+ * @related  cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
  */
 CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_png(const char* png_path, CF_Result* result_out);
 
@@ -227,7 +227,7 @@ CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_png(const char* png_path, CF_R
  * @function cf_make_easy_sprite_from_pixels
  * @category sprite
  * @brief    Constructs a sprite from an array of pixels.
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
+ * @related  cf_make_easy_sprite_from_png cf_easy_sprite_update_pixels cf_easy_sprite_unload
  */
 CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_pixels(const CF_Pixel* pixels, int w, int h);
 
@@ -236,7 +236,7 @@ CF_API CF_Sprite CF_CALL cf_make_easy_sprite_from_pixels(const CF_Pixel* pixels,
  * @category sprite
  * @brief    Updates the pixels of a sprite created from `cf_make_easy_sprite_from_pixels`.
  * @remarks  This is not a particularly fast function - you've been warned.
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
+ * @related  cf_easy_sprite_unload cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels
  */
 CF_API void CF_CALL cf_easy_sprite_update_pixels(CF_Sprite* sprite, const CF_Pixel* pixels);
 
@@ -245,7 +245,7 @@ CF_API void CF_CALL cf_easy_sprite_update_pixels(CF_Sprite* sprite, const CF_Pix
  * @category sprite
  * @brief    Unloads an easy sprite's image resources.
  * @param    sprite The `CF_Sprite` to unload. This `CF_Sprite` should have been created by a `cf_make_easy_sprite_*` function.
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_easy_sprite_unload
+ * @related  cf_easy_sprite_update_pixels cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels
  */
 CF_API void CF_CALL cf_easy_sprite_unload(CF_Sprite *sprite);
 
@@ -259,7 +259,7 @@ CF_API void CF_CALL cf_easy_sprite_unload(CF_Sprite *sprite);
  *           this function directly to fetch sprites that were already loaded. If you want to load sprites with your own custom
  *           animation data, instead of using the .ase/.aseprite format, you can try out `cf_png_cache_load` for a more low-level option.
  *           See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels cf_make_sprite_from_memory
+ * @related  cf_make_sprite_from_memory cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels
  */
 CF_API CF_Sprite CF_CALL cf_make_sprite(const char* aseprite_path);
 
@@ -273,7 +273,7 @@ CF_API CF_Sprite CF_CALL cf_make_sprite(const char* aseprite_path);
  *           this function directly to fetch sprites that were already loaded. If you want to load sprites with your own custom
  *           animation data, instead of using the .ase/.aseprite format, you can try out `cf_png_cache_load` for a more low-level option.
  *           See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
+ * @related  cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
  */
 CF_API CF_Sprite CF_CALL cf_make_sprite_from_memory(const char* unique_name, const void* aseprite_data, int size);
 
@@ -282,7 +282,7 @@ CF_API CF_Sprite CF_CALL cf_make_sprite_from_memory(const char* unique_name, con
  * @category sprite
  * @brief    Loads a pixel sprite of a girl, used for testing/learning purposes.
  * @return   The sprite contains a few animations called "up", "side", "hold_down", "hold_side", "hold_up", "idle" you may try out.
- * @related  CF_Sprite cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
+ * @related  cf_make_easy_sprite_from_png cf_make_easy_sprite_from_pixels cf_easy_sprite_update_pixels
  */
 CF_API CF_Sprite CF_CALL cf_make_demo_sprite(void);
 
@@ -292,7 +292,7 @@ CF_API CF_Sprite CF_CALL cf_make_demo_sprite(void);
  * @brief    Unloads the sprite's image resources from the internal cache.
  * @param    aseprite_path  Virtual path to a .ase file.
  * @remarks  Any live `CF_Sprite` instances for `aseprite_path` will now by "dangling". See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  CF_Sprite cf_make_sprite cf_sprite_unload cf_sprite_reload
+ * @related  cf_sprite_reload cf_make_sprite CF_Sprite
  */
 CF_API void CF_CALL cf_sprite_unload(const char* aseprite_path);
 
@@ -305,7 +305,7 @@ CF_API void CF_CALL cf_sprite_unload(const char* aseprite_path);
  * @remarks  This function is designed to help support asset or image hotloading/reloading during development.
  *           This function is *not* designed to be called once you ship your game.
  *           All old instances of the sprite are now invalid and should be reset to this return value.
- * @related  CF_Sprite cf_make_sprite cf_sprite_unload cf_sprite_reload
+ * @related  cf_sprite_unload cf_make_sprite CF_Sprite
  */
 CF_API CF_Sprite CF_CALL cf_sprite_reload(const CF_Sprite* sprite);
 
@@ -323,7 +323,7 @@ CF_INLINE void cf_sprite_draw(CF_Sprite* sprite)
  * @function cf_sprite_width
  * @category sprite
  * @brief    Returns the sprite's width in pixels.
- * @related  CF_Sprite cf_sprite_width cf_sprite_height
+ * @related  cf_sprite_height CF_Sprite
  */
 CF_INLINE int cf_sprite_width(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->w; }
 
@@ -331,7 +331,7 @@ CF_INLINE int cf_sprite_width(CF_Sprite* sprite) { CF_ASSERT(sprite); return spr
  * @function cf_sprite_height
  * @category sprite
  * @brief    Returns the sprite's height in pixels.
- * @related  CF_Sprite cf_sprite_width cf_sprite_height
+ * @related  cf_sprite_width CF_Sprite
  */
 CF_INLINE int cf_sprite_height(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->h; }
 
@@ -339,7 +339,7 @@ CF_INLINE int cf_sprite_height(CF_Sprite* sprite) { CF_ASSERT(sprite); return sp
  * @function cf_sprite_get_scale_x
  * @category sprite
  * @brief    Returns the sprite's scale on the x-axis.
- * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
+ * @related  cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y
  */
 CF_INLINE float cf_sprite_get_scale_x(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->scale.x; }
 
@@ -347,7 +347,7 @@ CF_INLINE float cf_sprite_get_scale_x(CF_Sprite* sprite) { CF_ASSERT(sprite); re
  * @function cf_sprite_get_scale_y
  * @category sprite
  * @brief    Returns the sprite's scale on the y-axis.
- * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
+ * @related  cf_sprite_get_scale_x cf_sprite_set_scale_x cf_sprite_set_scale_y
  */
 CF_INLINE float cf_sprite_get_scale_y(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->scale.y; }
 
@@ -355,7 +355,7 @@ CF_INLINE float cf_sprite_get_scale_y(CF_Sprite* sprite) { CF_ASSERT(sprite); re
  * @function cf_sprite_set_scale
  * @category sprite
  * @brief    Returns the sprite's scale on the x-axis.
- * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
+ * @related  cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_get_scale_x
  */
 CF_INLINE void cf_sprite_set_scale(CF_Sprite* sprite, CF_V2 scale) { CF_ASSERT(sprite); sprite->scale = scale; }
 
@@ -363,7 +363,7 @@ CF_INLINE void cf_sprite_set_scale(CF_Sprite* sprite, CF_V2 scale) { CF_ASSERT(s
  * @function cf_sprite_set_scale_x
  * @category sprite
  * @brief    Returns the sprite's scale on the x-axis.
- * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
+ * @related  cf_sprite_set_scale_y cf_sprite_set_scale cf_sprite_get_scale_x
  */
 CF_INLINE void cf_sprite_set_scale_x(CF_Sprite* sprite, float x) { CF_ASSERT(sprite); sprite->scale.x = x; }
 
@@ -371,7 +371,7 @@ CF_INLINE void cf_sprite_set_scale_x(CF_Sprite* sprite, float x) { CF_ASSERT(spr
  * @function cf_sprite_set_scale_y
  * @category sprite
  * @brief    Returns the sprite's scale on the y-axis.
- * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
+ * @related  cf_sprite_set_scale_x cf_sprite_set_scale cf_sprite_get_scale_x
  */
 CF_INLINE void cf_sprite_set_scale_y(CF_Sprite* sprite, float y) { CF_ASSERT(sprite); sprite->scale.y = y; }
 
@@ -379,7 +379,7 @@ CF_INLINE void cf_sprite_set_scale_y(CF_Sprite* sprite, float y) { CF_ASSERT(spr
  * @function cf_sprite_get_offset_x
  * @category sprite
  * @brief    Returns the sprite's local offset on the x-axis.
- * @related  CF_Sprite cf_sprite_get_offset_x cf_sprite_get_offset_y cf_sprite_set_offset_x cf_sprite_set_offset_y
+ * @related  cf_sprite_get_offset_y cf_sprite_set_offset_x cf_sprite_set_offset_y
  */
 CF_INLINE float cf_sprite_get_offset_x(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->offset.x; }
 
@@ -387,7 +387,7 @@ CF_INLINE float cf_sprite_get_offset_x(CF_Sprite* sprite) { CF_ASSERT(sprite); r
  * @function cf_sprite_get_offset_y
  * @category sprite
  * @brief    Returns the sprite's local offset on the y-axis.
- * @related  CF_Sprite cf_sprite_get_offset_x cf_sprite_get_offset_y cf_sprite_set_offset_x cf_sprite_set_offset_y
+ * @related  cf_sprite_get_offset_x cf_sprite_set_offset_x cf_sprite_set_offset_y
  */
 CF_INLINE float cf_sprite_get_offset_y(CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->offset.y; }
 
@@ -395,7 +395,7 @@ CF_INLINE float cf_sprite_get_offset_y(CF_Sprite* sprite) { CF_ASSERT(sprite); r
  * @function cf_sprite_set_offset_x
  * @category sprite
  * @brief    Returns the sprite's local offset on the x-axis.
- * @related  CF_Sprite cf_sprite_get_offset_x cf_sprite_get_offset_y cf_sprite_set_offset_x cf_sprite_set_offset_y
+ * @related  cf_sprite_set_offset_y cf_sprite_get_offset_x cf_sprite_get_offset_y
  */
 CF_INLINE void cf_sprite_set_offset_x(CF_Sprite* sprite, float offset) { CF_ASSERT(sprite); sprite->offset.x = offset; }
 
@@ -403,7 +403,7 @@ CF_INLINE void cf_sprite_set_offset_x(CF_Sprite* sprite, float offset) { CF_ASSE
  * @function cf_sprite_set_offset_y
  * @category sprite
  * @brief    Returns the sprite's local offset on the y-axis.
- * @related  CF_Sprite cf_sprite_get_offset_x cf_sprite_get_offset_y cf_sprite_set_offset_x cf_sprite_set_offset_y
+ * @related  cf_sprite_set_offset_x cf_sprite_get_offset_x cf_sprite_get_offset_y
  */
 CF_INLINE void cf_sprite_set_offset_y(CF_Sprite* sprite, float offset) { CF_ASSERT(sprite); sprite->offset.y = offset; }
 
@@ -489,7 +489,7 @@ CF_INLINE CF_V2 cf_sprite_get_local_offset(CF_Sprite* sprite) { CF_ASSERT(sprite
  * @brief    Updates a sprite's animation.
  * @param    sprite     The sprite.
  * @remarks  Call this once per frame.
- * @related  CF_Sprite cf_make_sprite cf_sprite_update cf_sprite_play cf_sprite_pause
+ * @related  cf_sprite_play cf_sprite_pause cf_make_sprite
  */
 CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
 {
@@ -555,7 +555,7 @@ CF_INLINE void cf_sprite_update(CF_Sprite* sprite)
  * @category sprite
  * @brief    Resets the currently playing animation and unpauses the animation.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play
+ * @related  cf_sprite_update cf_sprite_play CF_Sprite
  */
 CF_INLINE void cf_sprite_reset(CF_Sprite* sprite)
 {
@@ -573,7 +573,7 @@ CF_INLINE void cf_sprite_reset(CF_Sprite* sprite)
  * @brief    Switches to a new aninmation and starts playing it from the beginning.
  * @param    sprite     The sprite.
  * @param    animation  Name of the animation to switch to and start playing.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play cf_sprite_is_playing
+ * @related  cf_sprite_update cf_sprite_is_playing CF_Sprite
  */
 CF_INLINE void cf_sprite_play(CF_Sprite* sprite, const char* animation)
 {
@@ -590,7 +590,7 @@ CF_INLINE void cf_sprite_play(CF_Sprite* sprite, const char* animation)
  * @brief    Returns true if `animation` the is currently playing animation.
  * @param    sprite     The sprite.
  * @param    animation  Name of the animation.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play cf_sprite_is_playing
+ * @related  cf_sprite_update cf_sprite_play CF_Sprite
  */
 CF_INLINE bool cf_sprite_is_playing(CF_Sprite* sprite, const char* animation)
 {
@@ -604,7 +604,7 @@ CF_INLINE bool cf_sprite_is_playing(CF_Sprite* sprite, const char* animation)
  * @category sprite
  * @brief    Pauses the sprite's animation.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play cf_sprite_pause cf_sprite_unpause cf_sprite_toggle_pause
+ * @related  cf_sprite_play cf_sprite_update cf_sprite_unpause
  */
 CF_INLINE void cf_sprite_pause(CF_Sprite* sprite)
 {
@@ -617,7 +617,7 @@ CF_INLINE void cf_sprite_pause(CF_Sprite* sprite)
  * @category sprite
  * @brief    Unpauses the sprite's animation.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play cf_sprite_pause cf_sprite_unpause cf_sprite_toggle_pause
+ * @related  cf_sprite_update cf_sprite_play cf_sprite_pause
  */
 CF_INLINE void cf_sprite_unpause(CF_Sprite* sprite)
 {
@@ -630,7 +630,7 @@ CF_INLINE void cf_sprite_unpause(CF_Sprite* sprite)
  * @category sprite
  * @brief    Toggles the sprite's pause state.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_update cf_sprite_play cf_sprite_pause cf_sprite_unpause cf_sprite_toggle_pause
+ * @related  cf_sprite_update cf_sprite_play cf_sprite_pause
  */
 CF_INLINE void cf_sprite_toggle_pause(CF_Sprite* sprite)
 {
@@ -644,7 +644,7 @@ CF_INLINE void cf_sprite_toggle_pause(CF_Sprite* sprite)
  * @brief    Flip's the sprite on the x-axis.
  * @param    sprite     The sprite.
  * @remarks  Works by flipping the sign of the sprite's scale on the x-axis.
- * @related  CF_Sprite cf_sprite_flip_x cf_sprite_flip_y
+ * @related  cf_sprite_flip_y CF_Sprite
  */
 CF_INLINE void cf_sprite_flip_x(CF_Sprite* sprite)
 {
@@ -658,7 +658,7 @@ CF_INLINE void cf_sprite_flip_x(CF_Sprite* sprite)
  * @brief    Flip's the sprite on the y-axis.
  * @param    sprite     The sprite.
  * @remarks  Works by flipping the sign of the sprite's scale on the y-axis.
- * @related  CF_Sprite cf_sprite_flip_x cf_sprite_flip_y
+ * @related  cf_sprite_flip_x CF_Sprite
  */
 CF_INLINE void cf_sprite_flip_y(CF_Sprite* sprite)
 {
@@ -671,7 +671,7 @@ CF_INLINE void cf_sprite_flip_y(CF_Sprite* sprite)
  * @category sprite
  * @brief    Returns the number of frames in the sprite's currently playing animation.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay
+ * @related  cf_sprite_frame_delay cf_sprite_current_frame cf_sprite_animation_delay
  */
 CF_INLINE int cf_sprite_frame_count(const CF_Sprite* sprite)
 {
@@ -685,7 +685,7 @@ CF_INLINE int cf_sprite_frame_count(const CF_Sprite* sprite)
  * @category sprite
  * @brief    Returns the index of the currently playing frame.
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay
+ * @related  cf_sprite_frame_count cf_sprite_frame_delay cf_sprite_animation_delay
  */
 CF_INLINE int cf_sprite_current_frame(const CF_Sprite* sprite)
 {
@@ -698,7 +698,7 @@ CF_INLINE int cf_sprite_current_frame(const CF_Sprite* sprite)
  * @category sprite
  * @brief    Returns the index of the currently playing frame, relative to the whole aseprite file (not the current animation).
  * @param    sprite     The sprite.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay
+ * @related  cf_sprite_current_frame cf_sprite_frame_count cf_sprite_frame_delay
  */
 CF_INLINE int cf_sprite_current_global_frame(const CF_Sprite* sprite)
 {
@@ -712,7 +712,7 @@ CF_INLINE int cf_sprite_current_global_frame(const CF_Sprite* sprite)
  * @brief    Sets the frame of the sprite.
  * @param    sprite     The sprite.
  * @param    frame      The frame number to set.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay
+ * @related  cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay
  */
 CF_INLINE void cf_sprite_set_frame(CF_Sprite* sprite, int frame)
 {
@@ -729,7 +729,7 @@ CF_INLINE void cf_sprite_set_frame(CF_Sprite* sprite, int frame)
  * @category sprite
  * @brief    Returns the `delay` member of the currently playing frame, in milliseconds.
  * @param    sprite     The sprite.
- * @related  CF_Sprite CF_Frame cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay cf_sprite_animation_interpolant
+ * @related  cf_sprite_frame_count cf_sprite_current_frame cf_sprite_animation_delay
  */
 CF_INLINE float cf_sprite_frame_delay(CF_Sprite* sprite)
 {
@@ -743,7 +743,7 @@ CF_INLINE float cf_sprite_frame_delay(CF_Sprite* sprite)
  * @category sprite
  * @brief    Sums all the delays of each frame in the animation, and returns the total, in milliseconds.
  * @param    sprite     The sprite.
- * @related  CF_Sprite CF_Frame CF_Animation cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay cf_sprite_animation_interpolant
+ * @related  cf_sprite_animation_interpolant cf_sprite_frame_count cf_sprite_current_frame
  */
 CF_INLINE float cf_sprite_animation_delay(CF_Sprite* sprite)
 {
@@ -763,7 +763,7 @@ CF_INLINE float cf_sprite_animation_delay(CF_Sprite* sprite)
  * @brief    Returns a value from 0 to 1 representing how far along the animation has played.
  * @param    sprite     The sprite.
  * @remarks  0 means just started, while 1 means finished.
- * @related  CF_Sprite CF_Frame CF_Animation cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay
+ * @related  cf_sprite_animation_delay cf_sprite_frame_count cf_sprite_current_frame
  */
 CF_INLINE float cf_sprite_animation_interpolant(CF_Sprite* sprite)
 {
@@ -781,7 +781,7 @@ CF_INLINE float cf_sprite_animation_interpolant(CF_Sprite* sprite)
  * @brief    Returns true if the animation will loop around and finish if `cf_sprite_update` is called.
  * @param    sprite     The sprite.
  * @remarks  This is useful to see if you're currently on the last frame of animation, and will finish in this particular update.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay cf_sprite_will_finish
+ * @related  cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay
  */
 CF_INLINE bool cf_sprite_will_finish(CF_Sprite* sprite)
 {
@@ -801,7 +801,7 @@ CF_INLINE bool cf_sprite_will_finish(CF_Sprite* sprite)
  * @brief    Returns true whenever at the very beginning of the animation sequence.
  * @param    sprite     The sprite.
  * @remarks  This is useful for polling on when the animation restarts itself, for example, polling within an if-statement each game tick.
- * @related  CF_Sprite cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay cf_sprite_animation_delay cf_sprite_will_finish
+ * @related  cf_sprite_frame_count cf_sprite_current_frame cf_sprite_frame_delay
  */
 CF_INLINE bool cf_sprite_on_loop(CF_Sprite* sprite)
 {
@@ -821,7 +821,7 @@ CF_INLINE bool cf_sprite_on_loop(CF_Sprite* sprite)
  * @param    frame       The frame.
  * @remarks  You can use this function to build your own animations in a custom manner. It's recommend to just use `cf_make_sprite`, which
  *           loads a full sprite out of a .ase file. But, this function provides another low-level option if desired.
- * @related  CF_Sprite CF_Animation CF_Frame dyna htbl
+ * @related  dyna htbl CF_Animation
  */
 CF_INLINE void cf_animation_add_frame(CF_Animation* animation, CF_Frame frame) { CF_ASSERT(animation); apush(animation->frames, frame); }
 

--- a/include/cute_string.h
+++ b/include/cute_string.h
@@ -42,7 +42,7 @@ extern "C" {
  * @brief    An empty macro used in the C API to markup dynamic strings.
  * @remarks  This is an optional and _completely_ empty macro. It's only purpose is to provide a bit of visual indication a type is a
  *           dynamic string.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset sdup smake
+ * @related  sset sfree smake
  */
 #define sdyna
 
@@ -51,7 +51,7 @@ extern "C" {
  * @category string
  * @brief    Returns the number of characters in the string, not counting the nul-terminator.
  * @param    s            The string. Can be `NULL`.
- * @related  sdyna slen scount scap sempty
+ * @related  scount sempty sset
  */
 #define slen(s) cf_string_len(s)
 
@@ -61,7 +61,7 @@ extern "C" {
  * @brief    Returns whether or not the string is empty.
  * @param    s            The string. Can be `NULL`.
  * @remarks  Both "" and NULL count as empty.
- * @related  sdyna slen scount scap sempty
+ * @related  slen scount sset
  */
 #define sempty(s) cf_string_empty(s)
 
@@ -72,7 +72,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character to push onto the end of the string.
  * @remarks  Does not overwite the nul-byte. If the string is empty a nul-byte is pushed afterwards. Can be NULL, will create a new string and assign `s` if so.
- * @related  sdyna spush spop sfit sfree sset
+ * @related  spop sset sfit
  */
 #define spush(s, ch) cf_string_push(s, ch)
 
@@ -81,7 +81,7 @@ extern "C" {
  * @category string
  * @brief    Frees up all resources used by the string and sets it to `NULL`.
  * @param    s            The string. Can be `NULL`.
- * @related  sdyna spush spop sfit sfree sset
+ * @related  sset smake sdyna
  */
 #define sfree(s) cf_string_free(s)
 
@@ -90,7 +90,7 @@ extern "C" {
  * @category string
  * @brief    Returns the number of characters in the string, including the nul-terminator.
  * @param    s            The string.
- * @related  sdyna slen scount scap sempty
+ * @related  slen scap sempty
  */
 #define scount(s) cf_string_count(s)
 
@@ -101,7 +101,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @remarks  This is not the number of characters, but the size of the internal buffer. The capacity automatically grows as necessary, but
  *           you can use `sfit` to ensure a minimum capacity manually, as an optimization.
- * @related  sdyna slen scount scap sempty
+ * @related  sfit slen sset
  */
 #define scap(s) cf_string_cap(s)
 
@@ -111,7 +111,7 @@ extern "C" {
  * @brief    Returns the first character in the string.
  * @param    s            The string. Can be `NULL`.
  * @return   Returns '\0' if `s` is `NULL`.
- * @related  sdyna spush spop sfirst slast sclear
+ * @related  slast spush spop
  */
 #define sfirst(s) cf_string_first(s)
 
@@ -121,7 +121,7 @@ extern "C" {
  * @brief    Returns the last character in the string. Not the nul-byte.
  * @param    s            The string. Can be `NULL`.
  * @return   Returns '\0' if `s` is `NULL`.
- * @related  sdyna spush spop sfirst slast sclear
+ * @related  sfirst spush spop
  */
 #define slast(s) cf_string_last(s)
 
@@ -131,7 +131,7 @@ extern "C" {
  * @brief    Sets the string size to zero.
  * @param    s            The string. Can be `NULL`.
  * @remarks  Does not free up any resources.
- * @related  sdyna spush spop sfirst slast sclear
+ * @related  sset sfree spush
  */
 #define sclear(s) cf_string_clear(s)
 
@@ -142,7 +142,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    n            The number of elements for the new internal capacity.
  * @remarks  Does not change the size/count of the string, or the len. This function is just here for optimization purposes.
- * @related  sdyna sfit scap sclear
+ * @related  scap spush slen
  */
 #define sfit(s, n) cf_string_fit(s, n)
 
@@ -154,7 +154,7 @@ extern "C" {
  * @param    fmt          The format string.
  * @param    ...          The parameters for the format string.
  * @remarks  The string will be overwritten from the beginning. Will automatically adjust capacity as needed.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset
+ * @related  sfmt_append svfmt sset
  */
 #define sfmt(s, fmt, ...) cf_string_fmt(s, fmt, __VA_ARGS__)
 
@@ -166,7 +166,7 @@ extern "C" {
  * @param    fmt          The format string.
  * @param    ...          The parameters for the format string.
  * @remarks  All printed data is appended to the end of the string. Will automatically adjust it's capacity as needed.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset
+ * @related  sfmt svfmt_append sappend
  */
 #define sfmt_append(s, fmt, ...) cf_string_fmt_append(s, fmt, __VA_ARGS__)
 
@@ -179,7 +179,7 @@ extern "C" {
  * @param    ...          The parameters for the format string.
  * @remarks  You probably are looking for `sfmt` instead. The string will be overwritten from the beginning. Will automatically adjust it's
  *           capacity as needed. args must be a `va_list`.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset
+ * @related  sfmt svfmt_append sset
  */
 #define svfmt(s, fmt, args) cf_string_vfmt(s, fmt, args)
 
@@ -192,7 +192,7 @@ extern "C" {
  * @param    ...          The parameters for the format string.
  * @remarks  You probably are looking for `sfmt_append` instead. The string will be overwritten from the beginning. Will automatically adjust it's
  *           capacity as needed. args must be a `va_list`.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset
+ * @related  sfmt_append sfmt svfmt
  */
 #define svfmt_append(s, fmt, args) cf_string_vfmt_append(s, fmt, args)
 
@@ -202,7 +202,7 @@ extern "C" {
  * @brief    Copies the string `b` into string `a`.
  * @param    a            Destination for copying. Can be `NULL`.
  * @param    b            Source for copying.
- * @related  sdyna sfmt sfmt_append svfmt svfmt_append sset sdup smake
+ * @related  sdup smake sfree
  */
 #define sset(a, b) cf_string_set(a, b)
 
@@ -212,7 +212,7 @@ extern "C" {
  * @brief    Returns a completely new string copy.
  * @param    s            The string to duplicate.
  * @remarks  You must free the copy with `sfree` when done. Does the same thing as `smake`.
- * @related  sdyna sset sdup smake
+ * @related  sset smake sfree
  */
 #define sdup(s) cf_string_dup(s)
 
@@ -223,7 +223,7 @@ extern "C" {
  * @param    s            The string to duplicate.
  * @param    b            Source for copying.
  * @remarks  You must free the copy with `sfree` when done. Does the same thing as `sdup`.
- * @related  sdyna sset sdup smake
+ * @related  sdup sset sfree
  */
 #define smake(s) cf_string_make(s)
 
@@ -234,7 +234,7 @@ extern "C" {
  * @param    a            The first string.
  * @param    b            The second string.
  * @remarks  Returns 0 if the two strings are equivalent. Otherwise returns 1 if a[i] > b[i], or -1 if a[i] < b[i].
- * @related  sdyna scmp sicmp sequ siequ
+ * @related  sequ sicmp siequ
  */
 #define scmp(a, b) cf_string_cmp(a, b)
 
@@ -245,7 +245,7 @@ extern "C" {
  * @param    a            The first string.
  * @param    b            The second string.
  * @remarks  Returns 0 if the two strings are equivalent. Otherwise returns 1 if a[i] > b[i], or -1 if a[i] < b[i].
- * @related  sdyna scmp sicmp sequ siequ
+ * @related  siequ scmp sequ
  */
 #define sicmp(a, b) cf_string_icmp(a, b)
 
@@ -255,7 +255,7 @@ extern "C" {
  * @brief    Returns true if the two strings are equivalent, false otherwise.
  * @param    a            The first string.
  * @param    b            The second string.
- * @related  sdyna scmp sicmp sequ siequ
+ * @related  scmp siequ sicmp
  */
 #define sequ(a, b) cf_string_equ(a, b)
 
@@ -265,7 +265,7 @@ extern "C" {
  * @brief    Returns true if the two strings are equivalent, ignoring case, false otherwise.
  * @param    a            The first string.
  * @param    b            The second string.
- * @related  sdyna scmp sicmp sequ siequ
+ * @related  sicmp sequ scmp
  */
 #define siequ(a, b) cf_string_iequ(a, b)
 
@@ -276,7 +276,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    prefix       A string to compare against the beginning of `s`.
  * @return   Returns true if `prefix` is the prefix of `s`, false otherwise.
- * @related  sdyna sprefix ssuffix scontains sfirst_index_of slast_index_of sfind
+ * @related  ssuffix scontains sfind
  */
 #define sprefix(s, prefix) cf_string_prefix(s, prefix)
 
@@ -287,7 +287,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    prefix       A string to compare against the end of `s`.
  * @return   Returns true if `suffix` is the suffix of `s`, false otherwise.
- * @related  sdyna sprefix ssuffix scontains sfirst_index_of slast_index_of sfind
+ * @related  sprefix scontains sfind
  */
 #define ssuffix(s, suffix) cf_string_suffix(s, suffix)
 
@@ -297,7 +297,7 @@ extern "C" {
  * @brief    Returns true if s contains a certain substring.
  * @param    s            The string. Can be `NULL`.
  * @param    contains_me  A substring to search for.
- * @related  sdyna sprefix ssuffix scontains sfirst_index_of slast_index_of sfind
+ * @related  sfind sprefix ssuffix
  */
 #define scontains(s, contains_me) cf_string_contains(s, contains_me)
 
@@ -306,7 +306,7 @@ extern "C" {
  * @category string
  * @brief    Sets all characters in the string to upper case.
  * @param    s            The string. Can be `NULL`.
- * @related  sdyna stoupper stolower siequ sicmp
+ * @related  stolower sicmp siequ
  */
 #define stoupper(s) cf_string_toupper(s)
 
@@ -315,7 +315,7 @@ extern "C" {
  * @category string
  * @brief    Sets all characters in the string to lower case.
  * @param    s            The string. Can be `NULL`.
- * @related  sdyna stoupper stolower siequ sicmp
+ * @related  stoupper sicmp siequ
  */
 #define stolower(s) cf_string_tolower(s)
 
@@ -334,7 +334,7 @@ extern "C" {
  * @param    a            The string to modify. Can be `NULL`.
  * @param    b            Used to append onto `a`.
  * @remarks  You can technically do this with `sfmt`, but this function is optimized much faster. Does the same thing as `scat`.
- * @related  sdyna sappend scat sappend_range scat_range sfmt sfmt_append
+ * @related  scat sappend_range sfmt_append
  */
 #define sappend(a, b) cf_string_append(a, b)
 
@@ -345,7 +345,7 @@ extern "C" {
  * @param    a            The string to modify. Can be `NULL`.
  * @param    b            Used to append onto `a`.
  * @remarks  You can technically do this with `sfmt`, but this function is optimized much faster. Does the same thing as `sappend`.
- * @related  sdyna sappend scat sappend_range scat_range sfmt sfmt_append
+ * @related  sappend scat_range sfmt_append
  */
 #define scat(a, b) cf_string_append(a, b)
 
@@ -356,7 +356,7 @@ extern "C" {
  * @param    a            The string to modify. Can be `NULL`.
  * @param    b            Used to append onto `a`.
  * @remarks  You can technically do this with `sfmt`, but this function is optimized much faster. Does the same thing as `scat_range`.
- * @related  sdyna sappend scat sappend_range scat_range sfmt sfmt_append
+ * @related  sappend scat_range sfmt_append
  */
 #define sappend_range(a, b, b_end) cf_string_append_range(a, b, b_end)
 
@@ -367,7 +367,7 @@ extern "C" {
  * @param    a            The string to modify. Can be `NULL`.
  * @param    b            Used to append onto `a`.
  * @remarks  You can technically do this with `sfmt`, but this function is optimized much faster. Does the same thing as `sappend_range`.
- * @related  sdyna sappend scat sappend_range scat_range sfmt sfmt_append
+ * @related  scat sappend_range sfmt_append
  */
 #define scat_range(a, b, b_end) cf_string_append_range(a, b, b_end)
 
@@ -376,7 +376,7 @@ extern "C" {
  * @category string
  * @brief    Removes all whitespace from the beginning and end of the string.
  * @param    s            The string.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  sdyna sltrim srtrim
  */
 #define strim(s) cf_string_trim(s)
 
@@ -385,7 +385,7 @@ extern "C" {
  * @category string
  * @brief    Removes all whitespace from the beginning of the string.
  * @param    s            The string.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  slpad sdyna strim
  */
 #define sltrim(s) cf_string_ltrim(s)
 
@@ -394,7 +394,7 @@ extern "C" {
  * @category string
  * @brief    Removes all whitespace from the end of the string.
  * @param    s            The string.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  srpad sreplace sdyna
  */
 #define srtrim(s) cf_string_rtrim(s)
 
@@ -405,7 +405,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character to insert.
  * @param    n            Number of times to insert `ch`.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  sltrim sdyna strim
  */
 #define slpad(s, ch, n) cf_string_lpad(s, ch, n)
 
@@ -416,7 +416,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character to insert.
  * @param    n            Number of times to insert `ch`.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  srtrim sreplace sdyna
  */
 #define srpad(s, ch, n) cf_string_rpad(s, ch, n)
 
@@ -435,7 +435,7 @@ extern "C" {
  *           This function is intended to be used in a loop, successively chopping off pieces of `s`.
  *           A much easier, but slightly slower, version of this function is `ssplit`, which returns
  *           an array of strings.
- * @related  sdyna ssplit_once ssplit
+ * @related  ssplit sfind scontains
  */
 #define ssplit_once(s, ch) cf_string_split_once(s, ch)
 
@@ -464,7 +464,7 @@ extern "C" {
  *     }
  *     afree(array_of_splits);
  * @remarks  `s` is not modified. You must call `sfree` on the returned strings and `afree` on the returned array.
- * @related  sdyna ssplit_once ssplit
+ * @related  ssplit_once sfind scontains
  */
 #define ssplit(s, ch) cf_string_split(s, ch)
 
@@ -475,7 +475,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character to search for.
  * @return   Returns -1 if none are found.
- * @related  sdyna sfirst_index_of slast_index_of sfind
+ * @related  sfind slast_index_of scontains
  */
 #define sfirst_index_of(s, ch) cf_string_first_index_of(s, ch)
 
@@ -486,7 +486,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character to search for.
  * @return   Returns -1 if none are found.
- * @related  sdyna sfirst_index_of slast_index_of sfind
+ * @related  sfind sfirst_index_of scontains
  */
 #define slast_index_of(s, ch) cf_string_last_index_of(s, ch)
 
@@ -497,7 +497,7 @@ extern "C" {
  * @param    s            The string.
  * @param    find         A substring to search for.
  * @return   Returns `NULL` if not found.
- * @related  sdyna sfirst_index_of slast_index_of sfind
+ * @related  scontains sfirst_index_of slast_index_of
  */
 #define sfind(s, find) cf_string_find(s, find)
 
@@ -507,7 +507,7 @@ extern "C" {
  * @brief    Converts an int64_t to a string and assigns `s` to it.
  * @param    s            The string.
  * @param    i            The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna suint sfloat
  */
 #define sint(s, i) cf_string_int(s, i)
 
@@ -517,7 +517,7 @@ extern "C" {
  * @brief    Converts a uint64_t to a string and assigns `s` to it.
  * @param    s            The string.
  * @param    uint         The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna sint sfloat
  */
 #define suint(s, uint) cf_string_uint(s, uint)
 
@@ -527,7 +527,7 @@ extern "C" {
  * @brief    Converts a float to a string and assigns `s` to it.
  * @param    s            The string.
  * @param    f            The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna sint suint
  */
 #define sfloat(s, f) cf_string_float(s, f)
 
@@ -537,7 +537,7 @@ extern "C" {
  * @brief    Converts a double to a string and assigns `s` to it.
  * @param    s            The string.
  * @param    f            The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna sint suint
  */
 #define sdouble(s, f) cf_string_double(s, f)
 
@@ -547,7 +547,7 @@ extern "C" {
  * @brief    Converts a uint64_t to a hex-string and assigns `s` to it.
  * @param    s            The string.
  * @param    uint         The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna sint suint
  */
 #define shex(s, uint) cf_string_hex(s, uint)
 
@@ -557,7 +557,7 @@ extern "C" {
  * @brief    Converts a bool to a string and assigns `s` to it.
  * @param    s            The string.
  * @param    uint         The value to convert.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  sdyna sint suint
  */
 #define sbool(s, b) cf_string_bool(s, b)
 
@@ -566,7 +566,7 @@ extern "C" {
  * @category string
  * @brief    Converts a string to an int64_t and returns it.
  * @param    s            The string.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stouint stofloat stodouble
  */
 #define stoint(s) cf_string_toint(s)
 
@@ -575,7 +575,7 @@ extern "C" {
  * @category string
  * @brief    Converts a string to an uint64_t and returns it.
  * @param    s            The string.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stofloat stodouble stohex
  */
 #define stouint(s) cf_string_touint(s)
 
@@ -584,7 +584,7 @@ extern "C" {
  * @category string
  * @brief    Converts a string to a float and returns it.
  * @param    s            The string.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stouint stodouble stohex
  */
 #define stofloat(s) cf_string_tofloat(s)
 
@@ -593,7 +593,7 @@ extern "C" {
  * @category string
  * @brief    Converts a string to a double and returns it.
  * @param    s            The string.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stouint stofloat stohex
  */
 #define stodouble(s) cf_string_todouble(s)
 
@@ -603,7 +603,7 @@ extern "C" {
  * @brief    Converts a hex-string to a uint64_t and returns it.
  * @param    s            The string.
  * @remarks  Supports srings that start with "0x", "#", or no prefix.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stouint stofloat stodouble
  */
 #define stohex(s) cf_string_tohex(s)
 
@@ -613,7 +613,7 @@ extern "C" {
  * @brief    Converts a string to a bool and returns it.
  * @param    s            The string.
  * @remarks  Supports srings that start with "0x", "#", or no prefix.
- * @related  sdyna sint suint sfloat sdouble shex sbool stint stouint stofloat stodouble stohex stobool
+ * @related  stouint stofloat stodouble
  */
 #define stobool(s) cf_string_tobool(s)
 
@@ -625,7 +625,7 @@ extern "C" {
  * @param    replace_me   Substring to replace.
  * @param    with_me      The replacement string.
  * @remarks  Supports srings that start with "0x", "#", or no prefix.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  serase sfind sinsert
  */
 #define sreplace(s, replace_me, with_me) cf_string_replace(s, replace_me, with_me)
 
@@ -635,7 +635,7 @@ extern "C" {
  * @brief    Removes all consecutive occurances of `ch` from the string.
  * @param    s            The string. Can be `NULL`.
  * @param    ch           A character.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  sdyna strim sltrim
  */
 #define sdedup(s, ch) cf_string_dedup(s, ch)
 
@@ -646,7 +646,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @param    index        Index in the string to start deleting from.
  * @param    count        Number of character to delete.
- * @related  sdyna strim sltrim srtrim slpad srpad sdedup sreplace serase
+ * @related  sreplace spop spopn
  */
 #define serase(s, index, count) cf_string_erase(s, index, count)
 
@@ -655,7 +655,7 @@ extern "C" {
  * @category string
  * @brief    Removes a character from the end of the string.
  * @param    s            The string. Can be `NULL`.
- * @related  sdyna spop spopn serase slast
+ * @related  spopn sdyna serase
  */
 #define spop(s) (s = cf_string_pop(s))
 
@@ -665,7 +665,7 @@ extern "C" {
  * @brief    Removes n characters from the back of a string.
  * @param    s            The string. Can be `NULL`.
  * @param    n            Number of characters to pop.
- * @related  sdyna spop spopn serase slast
+ * @related  spop sdyna serase
  */
 #define spopn(s, n) (s = cf_string_pop_n(s, n))
 
@@ -677,7 +677,7 @@ extern "C" {
  * @param    buffer       Pointer to a static memory buffer.
  * @param    buffer_size  The size of `buffer` in bytes.
  * @remarks  Will grow onto the heap if the size becomes too large. Call `sfree` when done.
- * @related  sdyna sstatic sisdyna spush sset
+ * @related  sset sdyna sisdyna
  */
 #define sstatic(s, buffer, buffer_size) cf_string_static(s, buffer, buffer_size)
 
@@ -688,7 +688,7 @@ extern "C" {
  * @param    s            The string. Can be `NULL`.
  * @return   Returns true if `s` is a dynamically alloced string from this C string API.
  * @remarks  This can be evaluated at compile time for string literals.
- * @related  sdyna sstatic sisdyna spush sset
+ * @related  sdyna sstatic spush
  */
 #define sisdyna(s) cf_string_is_dynamic(s)
 
@@ -714,7 +714,7 @@ extern "C" {
  *           
  *           If an invalid codepoint is found the "replacement character" 0xFFFD will be appended instead, which
  *           looks like question mark inside of a dark diamond.
- * @related  sappend_UTF8 cf_decode_UTF8 cf_decode_UTF16
+ * @related  cf_decode_UTF8 cf_decode_UTF16 sdecode_UTF8
  */
 #define sappend_UTF8(s, codepoint) cf_string_append_UTF8(s, codepoint)
 
@@ -735,7 +735,7 @@ extern "C" {
  * @remarks  You can use this function in a loop to decode one codepoint at a time, where each codepoint
  *           represents a single UTF8 character. If the decoded codepoint is invalid then the "replacement character"
  *           0xFFFD will be recorded instead.
- * @related  sappend_UTF8 cf_decode_UTF8 cf_decode_UTF16
+ * @related  cf_decode_UTF16 sappend_UTF8
  */
 CF_API const char* CF_CALL cf_decode_UTF8(const char* s, int* codepoint);
 
@@ -774,7 +774,7 @@ CF_API const char* CF_CALL cf_decode_UTF8(const char* s, int* codepoint);
  *           return s;
  *           }
  *           ```
- * @related  sappend_UTF8 cf_decode_UTF8 cf_decode_UTF16
+ * @related  cf_decode_UTF8 sappend_UTF8
  */
 CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint);
 
@@ -796,7 +796,7 @@ CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint
  *           - You can simply compare pointers for equality, as opposed to comparing the string contents, as long as both strings came from this function.
  *           - You may optionally call `sinuke` to free all resources used by the global string table.
  *           - This function is very fast if the string was already stored previously.
- * @related  sintern sintern_range sivalid silen sinuke
+ * @related  sintern_range sinuke sivalid
  */
 #define sintern(s) cf_sintern(s)
 
@@ -815,7 +815,7 @@ CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint
  *           - You can simply compare pointers for equality, as opposed to comparing the string contents, as long as both strings came from this function.
  *           - You may optionally call `sinuke` to free all resources used by the global string table.
  *           - This function is very fast if the string was already stored previously.
- * @related  sintern sintern_range sivalid silen sinuke
+ * @related  sintern sinuke sivalid
  */
 #define sintern_range(start, end) cf_sintern_range(start, end)
 
@@ -825,7 +825,7 @@ CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint
  * @brief    Returns true if the string is a static, stable, unique pointer from `sintern`.
  * @param    s            The string.
  * @remarks  This is *not* a secure method -- do not use it on any potentially dangerous strings. It's designed to be very simple and fast, nothing more.
- * @related  sintern sintern_range sivalid silen sinuke
+ * @related  sintern sintern_range silen
  */
 #define sivalid(s) (((cf_intern_t*)s - 1)->cookie == CF_INTERN_COOKIE)
 
@@ -836,7 +836,7 @@ CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint
  * @param    s            The string.
  * @remarks  This is *not* a secure method -- do not use it on any potentially dangerous strings. It's designed to be very simple and fast, nothing more.
  *           The return value is calculated in constant time, as opposed to calling `CF_STRLEN` (`strlen`).
- * @related  sintern sintern_range sivalid silen sinuke
+ * @related  sintern sintern_range sivalid
  */
 #define silen(s) (((cf_intern_t*)s - 1)->len)
 
@@ -845,7 +845,7 @@ CF_API const uint16_t* CF_CALL cf_decode_UTF16(const uint16_t* s, int* codepoint
  * @category string
  * @brief    Frees up all resources used by the global string table built by `sintern`.
  * @remarks  All strings previously returned by `sintern` are now invalid.
- * @related  sintern sintern_range sivalid silen sinuke
+ * @related  sintern sintern_range sivalid
  */
 #define sinuke() cf_sinuke()
 

--- a/include/cute_symbol.h
+++ b/include/cute_symbol.h
@@ -24,7 +24,7 @@ typedef void CF_SharedLibrary;
  * @return   Returns `NULL` in the case of errors, and can be unloaded by calling `unload_shared_library`.
  * @remarks  Does not use the virtual file system. Once loaded, individual functions can be loaded from the shared
  *           library be called `cf_load_function`. See [Virtual File System](https://randygaul.github.io/cute_framework/topics/virtual_file_system).
- * @related  cf_load_shared_library cf_unload_shared_library cf_load_function
+ * @related  cf_load_function cf_unload_shared_library
  */
 CF_API CF_SharedLibrary* CF_CALL cf_load_shared_library(const char* path);
 
@@ -33,7 +33,7 @@ CF_API CF_SharedLibrary* CF_CALL cf_load_shared_library(const char* path);
  * @category utility
  * @brief    Unloads a shared library previously loaded with `load_shared_library`.
  * @param    library      A library of functions from `load_shared_library`.
- * @related  cf_load_shared_library cf_unload_shared_library cf_load_function
+ * @related  cf_load_shared_library cf_load_function
  */
 CF_API void cf_unload_shared_library(CF_SharedLibrary* library);
 
@@ -45,7 +45,7 @@ CF_API void cf_unload_shared_library(CF_SharedLibrary* library);
  * @param    function_name  The name of the function.
  * @remarks  The function pointer is not valid after calling `unload_shared_library`. After obtaining the function pointer with `load_function`
  *           you must typecast it yourself. Returns `NULL` in the case of errors.
- * @related  cf_load_shared_library cf_unload_shared_library cf_load_function
+ * @related  cf_load_shared_library cf_unload_shared_library
  */
 CF_API void* cf_load_function(CF_SharedLibrary* library, const char* function_name);
 

--- a/include/cute_time.h
+++ b/include/cute_time.h
@@ -21,7 +21,7 @@ extern "C" {
  * @struct   CF_DELTA_TIME
  * @category time
  * @brief    The `dt` or elapsed time from the previous two frames. Use this as an estimate to advance your current frame.
- * @related  CF_DELTA_TIME cf_update_time CF_OnUpdateFn
+ * @related  cf_update_time CF_OnUpdateFn
  */
 CF_API extern float CF_DELTA_TIME;
 // @end
@@ -33,7 +33,7 @@ CF_API extern float CF_DELTA_TIME;
  * @remarks  To turn on fixed-timestep use `cf_set_fixed_timestep`. Fixed timestep is useful when games need determinism. Determinism
  *           means given the same inputs, the exact same outputs are produced. This is especially important for networked games, or
  *           games that require extreme precision and fine-tuning (such as certain fighting games or platformers).
- * @related  CF_DELTA_TIME cf_update_time CF_OnUpdateFn CF_DELTA_TIME_INTERPOLANT cf_set_fixed_timestep cf_set_fixed_timestep_max_updates
+ * @related  cf_update_time cf_set_fixed_timestep cf_set_fixed_timestep_max_updates
  */
 CF_API extern float CF_DELTA_TIME_FIXED;
 // @end
@@ -46,7 +46,7 @@ CF_API extern float CF_DELTA_TIME_FIXED;
  *           than the fixed updates. To produce smooth visuals, the current time is mod'd producing an interpolant value from [0,1].
  *           Typically games will store two transforms, the previous and current transform, each representing a position at a fixed timestep
  *           interval. This interpolant value is to interpolate between these two states to produce a smooth rendering transition.
- * @related  CF_DELTA_TIME cf_update_time CF_OnUpdateFn CF_DELTA_TIME_INTERPOLANT cf_set_fixed_timestep cf_set_fixed_timestep_max_updates
+ * @related  cf_update_time cf_set_fixed_timestep cf_set_fixed_timestep_max_updates
  */
 CF_API extern float CF_DELTA_TIME_INTERPOLANT;
 // @end
@@ -57,7 +57,7 @@ CF_API extern float CF_DELTA_TIME_INTERPOLANT;
  * @brief    The number of machine ticks since program start.
  * @remarks  The frequency of these ticks is platform dependent. If you want to convert these ticks to relative to one second of actual time
  *           call `cf_get_tick_frequency` and use it as a divisor.
- * @related  CF_TICKS CF_PREV_TICKS cf_get_ticks cf_get_tick_frequency cf_make_stopwatch CF_SECONDS
+ * @related  cf_get_ticks cf_get_tick_frequency cf_make_stopwatch
  */
 CF_API extern uint64_t CF_TICKS;
 // @end
@@ -68,7 +68,7 @@ CF_API extern uint64_t CF_TICKS;
  * @brief    The number of machine ticks since program start for the last frame.
  * @remarks  The frequency of these ticks is platform dependent. If you want to convert these ticks to relative to one second of actual time
  *           call `cf_get_tick_frequency` and use it as a divisor.
- * @related  CF_TICKS CF_PREV_TICKS cf_get_ticks cf_get_tick_frequency cf_make_stopwatch CF_SECONDS
+ * @related  cf_get_ticks cf_get_tick_frequency cf_make_stopwatch
  */
 CF_API extern uint64_t CF_PREV_TICKS;
 // @end
@@ -77,7 +77,7 @@ CF_API extern uint64_t CF_PREV_TICKS;
  * @struct   CF_SECONDS
  * @category time
  * @brief    The number of seconds elapsed since program start.
- * @related  CF_TICKS CF_PREV_TICKS cf_get_ticks cf_get_tick_frequency cf_make_stopwatch CF_SECONDS CF_PREV_SECONDS
+ * @related  cf_get_ticks cf_get_tick_frequency cf_make_stopwatch
  */
 CF_API extern double CF_SECONDS;
 // @end
@@ -86,7 +86,7 @@ CF_API extern double CF_SECONDS;
  * @struct   CF_PREV_SECONDS
  * @category time
  * @brief    The number of seconds elapsed since program start for the last frame.
- * @related  CF_TICKS CF_PREV_TICKS cf_get_ticks cf_get_tick_frequency cf_make_stopwatch CF_SECONDS CF_PREV_SECONDS
+ * @related  cf_get_ticks cf_get_tick_frequency cf_make_stopwatch
  */
 CF_API extern double CF_PREV_SECONDS;
 // @end
@@ -97,7 +97,7 @@ CF_API extern double CF_PREV_SECONDS;
  * @brief    The number of seconds left for the global pause control.
  * @remarks  The entire application can be paused with `cf_pause_for` or `cf_pause_for_ticks`, which pause updates that will
  *           happen when `cf_update_time` is called.
- * @related  CF_PAUSE_TIME_LEFT cf_update_time cf_pause_for cf_pause_for_ticks cf_is_paused
+ * @related  cf_pause_for cf_pause_for_ticks cf_update_time
  */
 CF_API extern float CF_PAUSE_TIME_LEFT;
 // @end
@@ -109,7 +109,7 @@ CF_API extern float CF_PAUSE_TIME_LEFT;
  * @remarks  This callback can be used to implement your main-loop, and is generally used to update your gameplay/logic/physics.
  *           Usually rendering will occur outside of this callback one time per frame. This callback is only really useful when
  *           using a fixed timestep (see `cf_set_fixed_timestep`), as multiple calls can occur given a single frame's update.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT cf_set_target_framerate
+ * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time
  */
 typedef void (CF_OnUpdateFn)(void* udata);
 
@@ -121,7 +121,7 @@ typedef void (CF_OnUpdateFn)(void* udata);
  * @remarks  Often times a fixed-timestep can occur multiple times in one frame. In this case, `CF_OnUpdateFn` will be called once
  *           per update to simulate a fixed-timestep (see `CF_OnUpdateFn` and `cf_update_time`). The max number of updates possible 
  *           is clamped below `cf_set_fixed_timestep_max_updates`.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT cf_set_target_framerate
+ * @related  cf_set_fixed_timestep_max_updates cf_set_target_framerate cf_update_time
  */
 CF_API void CF_CALL cf_set_fixed_timestep(int frames_per_second);
 
@@ -133,7 +133,7 @@ CF_API void CF_CALL cf_set_fixed_timestep(int frames_per_second);
  * @remarks  Often times a fixed-timestep can occur multiple times in one frame. In this case, `CF_OnUpdateFn` will be called once
  *           per update to simulate a fixed-timestep (see `CF_OnUpdateFn` and `cf_update_time`). The max number of updates possible 
  *           is clamped below `max_updates`.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT cf_set_target_framerate
+ * @related  cf_set_fixed_timestep cf_set_target_framerate cf_update_time
  */
 CF_API void CF_CALL cf_set_fixed_timestep_max_updates(int max_updates);
 
@@ -144,7 +144,7 @@ CF_API void CF_CALL cf_set_fixed_timestep_max_updates(int max_updates);
  * @param    frames_per_second  Target frequency to run the app.
  * @remarks  This effect will try to render the game at a target framerate, similar to vsync. Set to -1 to disable this effect (disabled by default).
  *           This only affects rendering (not gameplay/update), see `cf_set_fixed_timestep` to control your gameplay/update framerate.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT cf_set_target_framerate
+ * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time
  */
 CF_API void CF_CALL cf_set_target_framerate(int frames_per_second);
 
@@ -152,7 +152,7 @@ CF_API void CF_CALL cf_set_target_framerate(int frames_per_second);
  * @function cf_set_update_udata
  * @category time
  * @brief    Sets the `udata` passed into `CF_OnUpdateFn`.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time cf_set_update_udata CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT
+ * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time
  */
 CF_API void CF_CALL cf_set_update_udata(void* udata);
 
@@ -163,7 +163,7 @@ CF_API void CF_CALL cf_set_update_udata(void* udata);
  * @param    on_update  Can be `NULL`. Called once per update. Mostly just useful for the fixed-timestep case (see `cf_set_fixed_timestep`).
  * @remarks  Typically you will want to call this function just after `cf_app_update`, or, alternatively pass
              in `on_update` to `cf_app_update` instead of calling this function at all.
- * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_update_time cf_set_update_udata CF_DELTA_TIME_FIXED CF_DELTA_TIME_INTERPOLANT
+ * @related  cf_set_fixed_timestep cf_set_fixed_timestep_max_updates cf_set_update_udata
  */
 CF_API void CF_CALL cf_update_time(CF_OnUpdateFn* on_update);
 
@@ -174,7 +174,7 @@ CF_API void CF_CALL cf_update_time(CF_OnUpdateFn* on_update);
  * @param    seconds    A number of seconds to pause the application for.
  * @remarks  The entire application can be paused with `cf_pause_for` or `cf_pause_for_ticks`, which pause updates that will
  *           happen when `cf_update_time` is called.
- * @related  CF_PAUSE_TIME_LEFT cf_update_time cf_pause_for cf_pause_for_ticks cf_is_paused
+ * @related  cf_pause_for_ticks cf_update_time cf_is_paused
  */
 CF_API void CF_CALL cf_pause_for(float seconds);
 
@@ -185,7 +185,7 @@ CF_API void CF_CALL cf_pause_for(float seconds);
  * @param    ticks      A number of ticks to pause the application for. See `cf_get_tick_frequency`.
  * @remarks  The entire application can be paused with `cf_pause_for` or `cf_pause_for_ticks`, which pause updates that will
  *           happen when `cf_update_time` is called.
- * @related  CF_PAUSE_TIME_LEFT cf_update_time cf_pause_for cf_pause_for_ticks cf_is_paused
+ * @related  cf_pause_for cf_update_time cf_is_paused
  */
 CF_API void CF_CALL cf_pause_for_ticks(uint64_t pause_ticks);
 
@@ -196,7 +196,7 @@ CF_API void CF_CALL cf_pause_for_ticks(uint64_t pause_ticks);
  * @param    interval   Number of seconds between each interval.
  * @param    offset     A starting offset in seconds for the interval. This gets mathematically modulo'd. Used to sync times for rythms or repeats.
  *           Simply place this within an if-statement!
- * @related  cf_on_interval cf_between_interval cf_on_timestamp
+ * @related  cf_on_timestamp cf_between_interval
  */
 CF_API bool CF_CALL cf_on_interval(float interval, float offset);
 
@@ -208,7 +208,7 @@ CF_API bool CF_CALL cf_on_interval(float interval, float offset);
  * @param    offset     A starting offset in seconds for the interval. This gets mathematically modulo'd. Used to sync times for rythms or repeats.
  * @remarks  This function is super useful for general purpose gameplay implementation where you want an event to fire for N seconds,
  *           and then _not_ fire for N seconds, flipping back and forth periodically. Simply place this within an if-statement.
- * @related  cf_on_interval cf_between_interval cf_on_timestamp
+ * @related  cf_on_interval cf_on_timestamp
  */
 CF_API bool CF_CALL cf_between_interval(float interval, float offset);
 
@@ -219,7 +219,7 @@ CF_API bool CF_CALL cf_between_interval(float interval, float offset);
  * @param    timestamp  The timestamp.
  * @remarks  This function is super useful for general purpose gameplay implementation where you want an event to fire at N seconds
  *           (since program start). Simply place this within an if-statement!
- * @related  cf_on_interval cf_between_interval cf_on_timestamp
+ * @related  cf_on_interval cf_between_interval
  */
 CF_API bool CF_CALL cf_on_timestamp(double timestamp);
 
@@ -228,7 +228,7 @@ CF_API bool CF_CALL cf_on_timestamp(double timestamp);
  * @category time
  * @brief    Returns true if the application is currently paused.
  * @remarks  Pause means from `cf_pause_for` or `cf_pause_for_ticks`.
- * @related  CF_PAUSE_TIME_LEFT cf_is_paused cf_pause_for cf_pause_for_ticks
+ * @related  cf_pause_for cf_pause_for_ticks CF_PAUSE_TIME_LEFT
  */
 CF_API bool CF_CALL cf_is_paused(void);
 
@@ -238,7 +238,7 @@ CF_API bool CF_CALL cf_is_paused(void);
  * @brief    Returns the number of ticks elapsed _right now_ since program start.
  * @remarks  `CF_TICK` and `CF_SECONDS` are only recorded once at the beginning of an update (see `cf_update_time`). This function instead
  *           queries the application for the number of ticks _right now_. Mostly useful for performance measuring.
- * @related  cf_get_ticks cf_get_tick_frequency
+ * @related  cf_get_tick_frequency
  */
 CF_API uint64_t CF_CALL cf_get_ticks(void);
 
@@ -246,7 +246,7 @@ CF_API uint64_t CF_CALL cf_get_ticks(void);
  * @function cf_get_tick_frequency
  * @category time
  * @brief    Returns the machine-dependent number of ticks that occur in one second.
- * @related  cf_get_ticks cf_get_tick_frequency
+ * @related  cf_get_ticks
  */
 CF_API uint64_t CF_CALL cf_get_tick_frequency(void);
 
@@ -266,7 +266,7 @@ CF_API void CF_CALL cf_sleep(int milliseconds);
  * @brief    A stopwatch for general purpose precise timings.
  * @remarks  Once created with `cf_make_stopwatch` the time elapsed can be fetched. To reset the stopwatch, simply call
  *           `cf_make_stopwatch` again and overwrite your old stopwatch.
- * @related  CF_Stopwatch cf_make_stopwatch cf_seconds cf_milliseconds cf_microseconds
+ * @related  cf_seconds cf_make_stopwatch cf_milliseconds
  */
 typedef struct CF_Stopwatch
 {
@@ -283,7 +283,7 @@ typedef struct CF_Stopwatch
  * @remarks  Once created with `cf_make_stopwatch` the time elapsed can be fetched. To reset the stopwatch, simply call
  *           `cf_make_stopwatch` again and overwrite your old stopwatch. To fetch the time elapsed, call `cf_stopwatch_seconds`,
  *           `cf_stopwatch_milliseconds`, or `cf_microseconds`.
- * @related  CF_Stopwatch cf_make_stopwatch cf_stopwatch_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
+ * @related  cf_stopwatch_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
  */
 CF_API CF_Stopwatch CF_CALL cf_make_stopwatch(void);
 
@@ -291,7 +291,7 @@ CF_API CF_Stopwatch CF_CALL cf_make_stopwatch(void);
  * @function cf_stopwatch_seconds
  * @category time
  * @brief    Returns the number of seconds elapsed since the last call to `cf_make_stopwatch` was made.
- * @related  CF_Stopwatch cf_make_stopwatch cf_stopwatch_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
+ * @related  cf_stopwatch_milliseconds cf_stopwatch_microseconds cf_make_stopwatch
  */
 CF_API double CF_CALL cf_stopwatch_seconds(CF_Stopwatch stopwatch);
 
@@ -299,7 +299,7 @@ CF_API double CF_CALL cf_stopwatch_seconds(CF_Stopwatch stopwatch);
  * @function cf_stopwatch_milliseconds
  * @category time
  * @brief    Returns the number of milliseconds elapsed since the last call to `cf_make_stopwatch` was made.
- * @related  CF_Stopwatch cf_make_stopwatch cf_stopwatch_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
+ * @related  cf_stopwatch_microseconds cf_stopwatch_seconds cf_make_stopwatch
  */
 CF_API double CF_CALL cf_stopwatch_milliseconds(CF_Stopwatch stopwatch);
 
@@ -307,7 +307,7 @@ CF_API double CF_CALL cf_stopwatch_milliseconds(CF_Stopwatch stopwatch);
  * @function cf_stopwatch_microseconds
  * @category time
  * @brief    Returns the number of microseconds elapsed since the last call to `cf_make_stopwatch` was made.
- * @related  CF_Stopwatch cf_make_stopwatch cf_seconds cf_stopwatch_milliseconds cf_stopwatch_microseconds
+ * @related  cf_stopwatch_milliseconds cf_seconds cf_make_stopwatch
  */
 CF_API double CF_CALL cf_stopwatch_microseconds(CF_Stopwatch stopwatch);
 

--- a/tools/update_related.py
+++ b/tools/update_related.py
@@ -1,0 +1,147 @@
+import pathlib
+import re
+
+ROOT = pathlib.Path('include')
+
+overrides = {
+	'sdyna': ['sset', 'sfree', 'smake'],
+	'slen': ['scount', 'sempty', 'sset'],
+	'sempty': ['slen', 'scount', 'sset'],
+	'spush': ['spop', 'sset', 'sfit'],
+	'sfree': ['sset', 'smake', 'sdyna'],
+	'scount': ['slen', 'scap', 'sempty'],
+	'scap': ['sfit', 'slen', 'sset'],
+	'sfirst': ['slast', 'spush', 'spop'],
+	'slast': ['sfirst', 'spush', 'spop'],
+	'sclear': ['sset', 'sfree', 'spush'],
+	'sfit': ['scap', 'spush', 'slen'],
+	'sfmt': ['sfmt_append', 'svfmt', 'sset'],
+	'sfmt_append': ['sfmt', 'svfmt_append', 'sappend'],
+	'svfmt': ['sfmt', 'svfmt_append', 'sset'],
+	'svfmt_append': ['sfmt_append', 'sfmt', 'svfmt'],
+	'sset': ['sdup', 'smake', 'sfree'],
+	'sdup': ['sset', 'smake', 'sfree'],
+	'smake': ['sdup', 'sset', 'sfree'],
+	'scmp': ['sequ', 'sicmp', 'siequ'],
+	'sicmp': ['siequ', 'scmp', 'sequ'],
+	'sequ': ['scmp', 'siequ', 'sicmp'],
+	'siequ': ['sicmp', 'sequ', 'scmp'],
+	'sprefix': ['ssuffix', 'scontains', 'sfind'],
+	'ssuffix': ['sprefix', 'scontains', 'sfind'],
+	'scontains': ['sfind', 'sprefix', 'ssuffix'],
+	'stoupper': ['stolower', 'sicmp', 'siequ'],
+	'stolower': ['stoupper', 'sicmp', 'siequ'],
+	'sappend': ['scat', 'sappend_range', 'sfmt_append'],
+	'scat': ['sappend', 'scat_range', 'sfmt_append'],
+	'sappend_range': ['sappend', 'scat_range', 'sfmt_append'],
+	'scat_range': ['scat', 'sappend_range', 'sfmt_append'],
+	'sreplace': ['serase', 'sfind', 'sinsert'],
+	'serase': ['sreplace', 'spop', 'spopn'],
+	'sinsert': ['sreplace', 'sfind', 'sappend'],
+	'ssplit_once': ['ssplit', 'sfind', 'scontains'],
+	'ssplit': ['ssplit_once', 'sfind', 'scontains'],
+	'sfind': ['scontains', 'sfirst_index_of', 'slast_index_of'],
+	'sfirst_index_of': ['sfind', 'slast_index_of', 'scontains'],
+	'slast_index_of': ['sfind', 'sfirst_index_of', 'scontains'],
+	'sdecode_UTF8': ['sappend_UTF8', 'cf_decode_UTF8', 'cf_decode_UTF16'],
+	'sdecode_UTF16': ['sappend_UTF8', 'cf_decode_UTF8', 'cf_decode_UTF16'],
+	'sappend_UTF8': ['cf_decode_UTF8', 'cf_decode_UTF16', 'sdecode_UTF8'],
+	'cf_core_count': ['cf_cacheline_size'],
+}
+
+def common_prefix_length(a: str, b: str) -> int:
+	count = 0
+	for ca, cb in zip(a.lower(), b.lower()):
+		if ca != cb:
+			break
+		count += 1
+	return count
+
+def shared_segments(a: str, b: str) -> int:
+	a_parts = a.split('_')
+	b_parts = b.split('_')
+	count = 0
+	for ap, bp in zip(a_parts, b_parts):
+		if ap != bp:
+			break
+		count += 1
+	return count
+
+def base_name(name: str) -> str:
+	parts = name.split('_')
+	if name.startswith('cf_') or name.startswith('CF_'):
+		if len(parts) >= 2:
+			return '_'.join(parts[:2])
+	match = re.match(r'^[a-zA-Z]+', name)
+	return match.group(0) if match else name
+
+def curate_related(name: str, tokens: list[str]) -> list[str]:
+	tokens = list(dict.fromkeys(tokens))
+	override = overrides.get(name)
+	if override:
+		return override[:3]
+	base = base_name(name)
+	func_candidates = []
+	type_candidates = []
+	for idx, token in enumerate(tokens):
+		if token == name:
+			continue
+		score = 0
+		score += shared_segments(name, token) * 140
+		score += common_prefix_length(name, token) * 6
+		if token.lower().startswith(base.lower()):
+			score += 80
+		if token.startswith('CF_'):
+			type_candidates.append((score + 200, idx, token))
+		else:
+			func_candidates.append((score, idx, token))
+	func_candidates.sort(key=lambda item: (-item[0], item[1]))
+	type_candidates.sort(key=lambda item: (-item[0], item[1]))
+	curated: list[str] = []
+	for score, idx, token in func_candidates:
+		if token not in curated:
+			curated.append(token)
+		if len(curated) == 3:
+			return curated
+	for score, idx, token in type_candidates:
+		if token not in curated:
+			curated.append(token)
+		if len(curated) == 3:
+			return curated
+	allow_self = not curated
+	for token in tokens:
+		if token in curated:
+			continue
+		if token == name and not allow_self:
+			continue
+		curated.append(token)
+		allow_self = False
+		if len(curated) == 3:
+			break
+	return curated
+
+def process_file(path: pathlib.Path) -> None:
+	lines = path.read_text().splitlines()
+	changed = False
+	current_name = None
+	for i, line in enumerate(lines):
+		match = re.search(r'\* @(function|struct|enum|typedef|macro)\s+(\w+)', line)
+		if match:
+			current_name = match.group(2)
+		match = re.search(r'\* @related\s+(.*)', line)
+		if match and current_name:
+			tokens = match.group(1).split()
+			curated = curate_related(current_name, tokens)
+			new_line = f" * @related  {' '.join(curated)}"
+			if new_line != line:
+				lines[i] = new_line
+				changed = True
+	if changed:
+		path.write_text('\n'.join(lines) + '\n')
+
+def main() -> None:
+	for path in ROOT.rglob('*.h'):
+		process_file(path)
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
## Summary
- add a script to curate @related links in public header documentation
- regenerate all header comments so @related entries focus on the top three references per API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6d9c87de8832386f716379146592d