### PR TITLE
removed incorrect 9 slice scaling

### DIFF
--- a/src/cute_aseprite_cache.cpp
+++ b/src/cute_aseprite_cache.cpp
@@ -213,8 +213,8 @@ static CF_Result s_aseprite_cache_load_from_memory(const char* unique_name, cons
 		});
 
 		if (slice->has_center_as_9_slice) {
-			CF_V2 min = cf_v2(slice->center_x, slice->center_y);
-			CF_V2 max = cf_v2(slice->center_x + slice->center_w, slice->center_y + slice->center_h);
+			CF_V2 min = cf_v2((float)slice->center_x, (float)slice->center_y);
+			CF_V2 max = cf_v2((float)slice->center_x + slice->center_w, (float)slice->center_y + slice->center_h);
 			CF_Aabb center_patch = cf_make_aabb(min, max);
 			for (int frame_number = slice->frame_number; frame_number < ase->frame_count; ++frame_number) {
 				entry.center_patches[frame_number] = center_patch;

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -715,10 +715,10 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
 	float full_width   = CF_FABSF(sprite->w * sprite->scale.x);
 	float full_height  = CF_FABSF(sprite->h * sprite->scale.y);
-	float inner_left   = left / full_width * 0.5f;
-	float inner_right  = right / full_width * 0.5f;
-	float inner_top    = top / full_height * 0.5f;
-	float inner_bottom = bottom / full_height * 0.5f;
+	float inner_left   = left / full_width;
+	float inner_right  = right / full_width;
+	float inner_top    = top / full_height;
+	float inner_bottom = bottom / full_height;
 
 	CF_V2 quads[9][4] = {
 		// top row
@@ -905,14 +905,14 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
 	float full_width   = CF_FABSF(sprite->w * sprite->scale.x);
 	float full_height  = CF_FABSF(sprite->h * sprite->scale.y);
-	float inner_left   = left / full_width * 0.5f;
-	float inner_right  = right / full_width * 0.5f;
-	float inner_top    = top / full_height * 0.5f;
-	float inner_bottom = bottom / full_height * 0.5f;
+	float inner_left   = left / full_width;
+	float inner_right  = right / full_width;
+	float inner_top    = top / full_height;
+	float inner_bottom = bottom / full_height;
 	
 	// tiled sizes in local space
-	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width * 0.5f, 
-								(center_patch.max.y - center_patch.min.y) / full_height * 0.5f);
+	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width, 
+								(center_patch.max.y - center_patch.min.y) / full_height);
 
 	CF_V2 quads[9][4] = {
 		// top row


### PR DESCRIPTION
forgot to remove 0.5f scaling, tested in my other project and was confused why the sprite was so tiny.
also got rid of some warnings from warnings from `cute_aseprite_cache.cpp` 9 slice loading.

it should look correct now, at scale of 1:1 there should be no tiling and it shouldn't look stretched anymore.

https://github.com/user-attachments/assets/8df110d0-8c62-4a36-befa-ed49945911c2

