### PR TITLE
Skip over empty commands

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -3404,9 +3404,9 @@ void cf_render_layers_to(CF_Canvas canvas, int layer_lo, int layer_hi, bool clea
 	cf_arena_reset(&s_draw->uniform_arena);
 	s_draw->verts.clear();
 
-	// Remove commands that were processed.
+	// Remove commands that were processed or are empty.
 	for (int i = 0; i < s_draw->cmds.size();) {
-		if (s_draw->cmds[i].processed) {
+		if (s_draw->cmds[i].processed || s_draw->cmds[i].items.count() <= 0) {
 			s_draw->cmds.unordered_remove(i);
 		} else {
 			++i;


### PR DESCRIPTION
This fixes the merging of commands, so that we don't merge incorrectly.

Here's the modified recolor sample for testing:

```cpp
#include <cute.h>
using namespace Cute;

#include <imgui.h>

const char* s_recolor = R"(
	#include "blend.shd"

	vec4 shader(vec4 color, vec2 pos, vec2 screen_uv, vec4 params)
	{
		vec3 a = rgb_to_hsv(color.rgb);
		vec3 b = rgb_to_hsv(params.rgb);
		vec3 c = hsv_to_rgb(mix(a, b, params.a));
		return vec4(c, color.a);
	}
)";

int main(int argc, char* argv[])
{
	CF_Result result = make_app("Recolor", 0, 0, 0, 720, 480, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
	if (is_error(result)) return -1;
	CF_Shader recolor = make_draw_shader_from_source(s_recolor);
	app_init_imgui();

	CF_Sprite girl = cf_make_demo_sprite();
	sprite_play(girl, "spin");
	girl.scale = V2(4,4);

	while (app_is_running()) {
		app_update();

		static CF_Color color = color_red();
		static float strength = 0.5f;
		ImGui::Begin("Color Picker", NULL, ImGuiWindowFlags_AlwaysAutoResize);
		ImGui::ColorPicker3("Color", (float*)&color);
		ImGui::DragFloat("Strength", &strength, 0.01f, 0, 1);
		ImGui::End();

		sprite_update(girl);
		// Top-right girl
		draw_push();
		draw_translate(320, 240);
		sprite_draw(girl);
		draw_pop();
		for(int i = 0; i < 20; ++i) {
			draw_push();
			draw_push_layer(10);
			draw_push_shader(recolor);
			draw_translate((i * girl.w) + girl.w * 2 , 0);
			draw_push_vertex_attributes(color.r, color.g, color.b, strength);
			sprite_draw(girl);
			draw_pop_shader();
			draw_pop_layer();
			draw_pop();
		}

		// Center girl
		sprite_draw(girl);

		// Bottom-left girl
		draw_push();
		draw_translate(-320, -240);
		sprite_draw(girl);
		draw_pop();

		app_draw_onto_screen(true);
	}

	destroy_app();

	return 0;
}
```

# Before

<img width="832" height="624" alt="image" src="https://github.com/user-attachments/assets/992a4bc8-85d1-400f-913e-e5f606af7e32" />

# After

<img width="832" height="624" alt="image" src="https://github.com/user-attachments/assets/68eef936-832d-4446-b731-984ff01b662c" />

Claude Code was used to find the problem.