### PR TITLE
Fix cute_https for Cloudflare sites

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ if(LINUX)
 
 	FetchContent_Declare(
 		s2n
-		URL https://github.com/aws/s2n-tls/archive/refs/tags/v1.3.46.zip
+		URL https://github.com/aws/s2n-tls/archive/refs/tags/v1.6.3.zip
 		DOWNLOAD_EXTRACT_TIMESTAMP ON
 		GIT_PROGRESS TRUE
 	)

--- a/src/cute_https.cpp
+++ b/src/cute_https.cpp
@@ -309,13 +309,6 @@ static void s_decode(CF_Coroutine co)
 	if (response->trailers) {
 		// Read in any trailing headers.
 		s_headers(co, response);
-	} else {
-		s_get_line(co, response);
-		if (response->parse.len() != 0) {
-			// End of response doesn't have expected final empty-line CRLF.
-			response->ok = false;
-			return;
-		}
 	}
 }
 
@@ -395,6 +388,8 @@ static void s_https_process(CF_Coroutine co)
 				request->result = CF_HTTPS_RESULT_FAILED;
 				destroy_coroutine(decoder);
 				return;
+			} else if (coroutine_state(decoder) == CF_COROUTINE_STATE_DEAD) {
+				break;
 			}
 		}
 		coroutine_yield(co);


### PR DESCRIPTION
* Upgrade s2n-tls to the latest version with a more modern cipher suite. This ensures that negotiation is successful as Cloudflare only supports more recent encryption algorithms.
* Check for end of body to terminate the request coroutine. The `Connection: close` header is disregarded by cloudflare probably due to the common use of request pipelining.
  I believe Cloudflare is technically wrong here but it's too ubiquitous.
* Fix a bug in body decoder that expects an empty line at the end of a body.
  AFAIK, this is not part of HTTP.
  Chunked encoding expects an empty line as terminator but that is already handled.