### PR TITLE
Correctly handle GL_TEXTURE_MIN_FILTER on GLES when there is no mipmap

### DIFF
--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -31,10 +31,9 @@ static inline GLenum s_wrap(CF_Filter f)
 
 static inline GLenum s_wrap(CF_MipFilter m, bool has_mips)
 {
-	if (!has_mips) return GL_NEAREST; // min filter without mips
 	switch (m) { default:
-	case CF_MIP_FILTER_NEAREST: return GL_NEAREST_MIPMAP_NEAREST;
-	case CF_MIP_FILTER_LINEAR:  return GL_LINEAR_MIPMAP_LINEAR;
+	case CF_MIP_FILTER_NEAREST: return has_mips ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
+	case CF_MIP_FILTER_LINEAR:  return has_mips ? GL_LINEAR_MIPMAP_LINEAR   : GL_LINEAR;
 	}
 }
 


### PR DESCRIPTION
It was driving me crazy why GLES and web version looks ugly.

It's best seen when a rotated sprite is in motion.
Without this patch (should be watched in full screen):

https://github.com/user-attachments/assets/4de03763-a03d-424c-8fc0-945c97675264

With this patch:

https://github.com/user-attachments/assets/15021190-8dfa-49a5-b50b-09d0a0ba7246

Basically, fallback to the equivalent no mipmap filtering mode instead of directly go linear.
This should still honor the defaults and mirror the behavior of the SDL GPU backend.