### PR TITLE
Add footer navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
   features:
     - navigation.path
     - navigation.indexes
+    - navigation.footer
     - content.code.copy
   palette:
     - media: "(prefers-color-scheme)"


### PR DESCRIPTION
Allows for quickly going to the previous or next help document

<img width="1565" height="873" alt="image" src="https://github.com/user-attachments/assets/141a9297-54b3-4c93-a0ec-7153ab6c7f47" />
