### PR TITLE
Split query by underscore

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,8 @@ nav:
 
 # Plugins
 plugins:
-  - search
+  - search:
+      separator: '[\s\-\_]+'
   - social
 
 # Extensions


### PR DESCRIPTION
This helps to get cf_make_sprite higher in the results when one types in make_sprite. Additionally, now searching for make_app actually shows cf_make_app, rather than the Getting started topic result.