### PR TITLE
Use VS 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Build
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  CMAKE_BUILD_PARALLEL_LEVEL: 3
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
 
 jobs:
   build:


### PR DESCRIPTION
This PR configures the runner image to be `windows-2025-vs2026` which comes with Visual Studio 18 2026.