### PR TITLE
Only set CMake output dir if CF is the top level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,11 @@ option(CF_CUTE_SHADERC "Build cute-shaderc, an offline shader compiler (requires
 option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
 
 # Make sure all libraries are placed into the same output folder.
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+	set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+endif ()
 
 # Platform detection.
 # Put Emscripten first so it doesn't fall into the generic UNIX/Linux path.


### PR DESCRIPTION
This allows projects that submodule+add_subdirectory CF to freely set their own output dir 