### PR TITLE
Ensure that ckit always use CF's allocator

### DIFF
--- a/include/cute_alloc.h
+++ b/include/cute_alloc.h
@@ -10,6 +10,10 @@
 
 #include "cute_defines.h"
 
+#define CK_ALLOC(sz) cf_alloc(sz)
+#define CK_REALLOC(p, sz) cf_realloc(p, sz)
+#define CK_FREE(p) cf_free(p)
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/src/cute_ckit.cpp
+++ b/src/cute_ckit.cpp
@@ -7,8 +7,5 @@
 
 #include <cute_alloc.h>
 
-#define CK_ALLOC(sz) cf_alloc(sz)
-#define CK_REALLOC(p, sz) cf_realloc(p, sz)
-#define CK_FREE(p) cf_free(p)
 #define CKIT_IMPLEMENTATION
 #include <cute/ckit.h>


### PR DESCRIPTION
Fixes https://github.com/RandyGaul/cute_framework/issues/470

This is kinda ugly.
The other way is to create a `cf_kit.h` file and include that instead everywhere so it is guaranteed to always be defined

Or since ckit.h is already vendored, just change it directly and add the defines there