### PR TITLE
Append dir when searching for shaders recursively

### DIFF
--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -28,7 +28,7 @@ static void s_shader_directory_recursive(CF_Path path)
 	for (int i = 0; i < dir.size(); ++i) {
 		CF_Path p = app->shader_directory + path + dir[i];
 		if (p.is_directory()) {
-			s_shader_directory_recursive(p);
+			s_shader_directory_recursive(path + dir[i]);
 		} else {
 			CF_Stat stat;
 			fs_stat(p, &stat);
@@ -69,7 +69,7 @@ static void s_shader_watch_recursive(CF_Path path)
 	for (int i = 0; i < dir.size(); ++i) {
 		CF_Path p = app->shader_directory + path + dir[i];
 		if (p.is_directory()) {
-			s_shader_directory_recursive(p);
+			s_shader_watch_recursive(path + dir[i]);
 		} else {
 			CF_Stat stat;
 			fs_stat(p, &stat);


### PR DESCRIPTION
Given an input like `/hrc/bounce.shd`:
When recursing into subdirectories, we're passing `p`, the full poath including shader directory prefix) instead of the relative path `path + dir[i]`. This causes the next recursion to enumerate `"/shaders/shaders/hrc"` instead of `"/shaders/hrc"`, so shader files in subdirectories are never registered in the lookup map.