### PR TITLE
Undo the flipping of GLES viewport and scissor coordinates

### DIFF
--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -490,9 +490,7 @@ static inline void s_apply_state()
 		target->viewport.w != current->viewport.w ||
 		target->viewport.h != current->viewport.h
 	) {
-		// Flip viewport vertically since OpenGL puts (0, 0) at the bottom left.
-		CF_GL_Canvas* canvas = g_ctx.canvas;
-		glViewport(target->viewport.x, canvas->h - target->viewport.y - target->viewport.h, target->viewport.w, target->viewport.h);
+		glViewport(target->viewport.x, target->viewport.y, target->viewport.w, target->viewport.h);
 	}
 
 	if (target->scissor_enabled != current->scissor_enabled) {
@@ -509,9 +507,7 @@ static inline void s_apply_state()
 		target->scissor.w != current->scissor.w ||
 		target->scissor.h != current->scissor.h)
 	) {
-		// Flip the scissor rect vertically since OpenGL puts (0, 0) at the bottom left.
-		CF_GL_Canvas* canvas = g_ctx.canvas;
-		glScissor(target->scissor.x, canvas->h - target->scissor.y - target->scissor.h, target->scissor.w, target->scissor.h);
+		glScissor(target->scissor.x, target->scissor.y, target->scissor.w, target->scissor.h);
 	}
 
 	if (target->stencil_reference != current->stencil_reference) {


### PR DESCRIPTION
When I wrote that comment about flipping ("Flip the scissor rect vertically since OpenGL..."), I was either confused or was experimenting with different render flipping methods to deal with the coordinate differences with Vulkan/SDL_GPU.

In the end it was never needed when flipping is handled by SPIRV-Tools at shader level but I forgot to remove the comment and the rect can just be passed verbatim.

This can be confirmed by running the scissor sample with both the SDL_GPU and GLES renderer.