### PR TITLE
Fix sprite pivot calculation

### DIFF
--- a/src/cute_aseprite_cache.cpp
+++ b/src/cute_aseprite_cache.cpp
@@ -257,8 +257,8 @@ static CF_Result s_aseprite_cache_load_from_memory(const char* unique_name, cons
 		if (slice->has_pivot) {
 			v2 pivot = V2((float)slice->pivot_x, (float)slice->pivot_y);
 			// Transform from CF's (0, 0) at center to ase's (0, 0) at top-left.
-			pivot.x = pivot.x - sw * 0.5f + 0.5f;
-			pivot.y = pivot.y - sh * 0.5f + 0.5f;
+			pivot.x =  pivot.x - sw * 0.5f + 0.5f;
+			pivot.y = -pivot.y + sh * 0.5f + 0.5f;
 
 			for (int frame_number = slice->frame_number; frame_number < ase->frame_count; ++frame_number) {
 				pivots[frame_number] = pivot;
@@ -481,8 +481,8 @@ void cf_aseprite_cache_reload_asset(uint64_t asset_id, ase_t* new_ase)
 		}
 		if (slice->has_pivot) {
 			v2 pivot = V2((float)slice->pivot_x, (float)slice->pivot_y);
-			pivot.x = pivot.x - sw * 0.5f + 0.5f;
-			pivot.y = pivot.y - sh * 0.5f + 0.5f;
+			pivot.x =  pivot.x - sw * 0.5f + 0.5f;
+			pivot.y = -pivot.y + sh * 0.5f + 0.5f;
 			for (int frame_number = slice->frame_number; frame_number < new_count; ++frame_number) {
 				pivots[frame_number] = pivot;
 			}

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -559,7 +559,7 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	s.h = sprite->h;
 	s.geom.type = BATCH_GEOMETRY_TYPE_SPRITE;
 
-	v2 offset = sprite->offset + (sprite->id != CF_SPRITE_ID_INVALID ? sprite->_pivot : V2(0,0));
+	v2 offset = sprite->offset - (sprite->id != CF_SPRITE_ID_INVALID ? sprite->_pivot : V2(0,0));
 	v2 p = cf_add(sprite->transform.p, cf_mul(offset, sprite->scale));
 
 	v2 scale = V2(sprite->scale.x * s.w, sprite->scale.y * s.h);
@@ -751,7 +751,7 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 		},
 	};
 
-	v2 offset = sprite->offset + sprite->_pivot;
+	v2 offset = sprite->offset - sprite->_pivot;
 	v2 p = cf_add(sprite->transform.p, cf_mul_v2(offset, sprite->scale));
 	v2 scale = V2(sprite->scale.x * sprite->w, sprite->scale.y * sprite->h);
 
@@ -950,7 +950,7 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 		},
 	};
 
-	v2 offset = sprite->offset + sprite->_pivot;
+	v2 offset = sprite->offset - sprite->_pivot;
 	v2 p = cf_add(sprite->transform.p, cf_mul_v2(offset, sprite->scale));
 	v2 scale = V2(sprite->scale.x * sprite->w, sprite->scale.y * sprite->h);
 


### PR DESCRIPTION
* Y-axis is flipped since asesprite's goes down but CF's goes up
* Pivot should be subtracted, not added

I only found out about this once I start using x offset too.