### PR TITLE
HiDPI rendering tweaks

### DIFF
--- a/docs/topics/hidpi.md
+++ b/docs/topics/hidpi.md
@@ -1,0 +1,43 @@
+# High-DPI Rendering
+
+Modern displays (Apple Retina, many 4K laptops, phones) pack several physical pixels into a single logical "point". Cute Framework handles this for you: your game works in **logical points**, while CF renders internally at the display's **physical pixel** resolution. You get crisp output on high-density displays without changing any of your drawing code.
+
+## Points vs. Pixels
+
+CF's public API is expressed in logical points. Window size ([`cf_app_get_size`](../app/cf_app_get_size.md)), draw coordinates, and the [camera](../topics/camera.md) all work in points. A 640x480 window is 640x480 points no matter which display it lives on.
+
+Under the hood CF sizes its default canvas in *physical* pixels: `logical_size * pixel_scale`. On a 2x Retina display a 640x480 window renders into a 1280x960 canvas. The projection still spans 640x480 logical units, so nothing you draw moves — there are simply more physical texels to rasterize text glyphs and SDF shape edges into, which is what makes them look sharp.
+
+Because of this you generally don't need to think about DPI at all. Draw in points; CF renders at native resolution.
+
+## `pixel_scale` vs. `dpi_scale`
+
+Two functions report display density, and they're easy to confuse:
+
+- [`cf_app_get_pixel_scale`](../app/cf_app_get_pixel_scale.md) — the number of physical pixels per logical point, e.g. `2.0f` on a 2x Retina display. This is the ratio CF actually renders at, and the one to multiply a logical size by to get physical pixels.
+- [`cf_app_get_dpi_scale`](../app/cf_app_get_dpi_scale.md) — the OS's *suggested* UI content scale. It is informational only and does **not** describe the rendering ratio. Most games can ignore it.
+
+When you need to convert between points and physical pixels — for example, sizing an offscreen canvas to match the swapchain — use `cf_app_get_pixel_scale`.
+
+## Retro / pixel-art canvas
+
+Sometimes a low resolution is the whole point. For an intentional retro or pixel-art look, call [`cf_app_set_canvas_size`](../app/cf_app_set_canvas_size.md) to pin the app's default canvas to an exact device-pixel size:
+
+```cpp
+// Render at a fixed 320x180, then scale up to fill the window.
+cf_app_set_canvas_size(320, 180);
+```
+
+Pinning opts that canvas out of CF's automatic pixel-scale sizing, so it won't auto-resize when the window moves to a display with a different density. The upscale to fill the window becomes a deliberate stylistic choice rather than accidental blur.
+
+## Opting out entirely
+
+To render at 1:1 logical-to-physical (skipping the high-density backbuffer altogether — e.g. to save fill-rate on a low-end device), pass [`CF_APP_OPTIONS_NO_HIGH_DPI_BIT`](../app/cf_appoptionflagbits.md) when creating the app. [`cf_app_get_pixel_scale`](../app/cf_app_get_pixel_scale.md) then always returns `1.0f`.
+
+```cpp
+cf_make_app("My Game", 0, 0, 0, 640, 480, CF_APP_OPTIONS_NO_HIGH_DPI_BIT, argv[0]);
+```
+
+## Sample
+
+See [samples/hidpi.c](https://github.com/RandyGaul/cute_framework/blob/master/samples/hidpi.c) for a runnable demonstration: text at several sizes, a row of SDF shapes, and a live [`cf_app_get_pixel_scale`](../app/cf_app_get_pixel_scale.md) readout to eyeball crispness on your own display.

--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -200,6 +200,8 @@ CF_API CF_DisplayOrientation CF_CALL cf_display_orientation(CF_DisplayID display
 	CF_ENUM(APP_OPTIONS_GFX_OPENGL_BIT,                       1 << 11) \
 	/* @entry Starts the application with a debug mode graphics context. */ \
 	CF_ENUM(APP_OPTIONS_GFX_DEBUG_BIT,                          1 << 12) \
+	/* @entry Disables the OS's high-pixel-density (Retina/HiDPI) backbuffer, forcing 1:1 logical-to-physical rendering. `cf_app_get_pixel_scale` will always return 1.0f. */ \
+	CF_ENUM(APP_OPTIONS_NO_HIGH_DPI_BIT,                        1 << 13) \
 	/* @end */
 
 typedef int CF_AppOptionFlags;
@@ -364,9 +366,9 @@ CF_API int CF_CALL cf_app_draw_onto_screen(bool clear);
 /**
  * @function cf_app_get_size
  * @category app
- * @brief    Gets the size of the window in pixels.
- * @param    w          The width of the window in pixels.
- * @param    h          The height of the window in pixels.
+ * @brief    Gets the size of the window in logical points (called "points" on Retina/HiDPI displays; use `cf_app_get_pixel_scale` to convert to physical pixels).
+ * @param    w          The width of the window in logical points.
+ * @param    h          The height of the window in logical points.
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
 CF_API void CF_CALL cf_app_get_size(int* w, int* h);
@@ -374,7 +376,7 @@ CF_API void CF_CALL cf_app_get_size(int* w, int* h);
 /**
  * @function cf_app_get_width
  * @category app
- * @brief    Returns the size of the window width in pixels.
+ * @brief    Returns the size of the window width in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
 CF_API int CF_CALL cf_app_get_width(void);
@@ -382,7 +384,7 @@ CF_API int CF_CALL cf_app_get_width(void);
 /**
  * @function cf_app_get_height
  * @category app
- * @brief    Returns the size of the window height in pixels.
+ * @brief    Returns the size of the window height in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
  * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
  */
 CF_API int CF_CALL cf_app_get_height(void);
@@ -415,6 +417,18 @@ CF_API float CF_CALL cf_app_get_dpi_scale(void);
  * @related  cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
  */
 CF_API bool CF_CALL cf_app_dpi_scale_was_changed(void);
+
+/**
+ * @function cf_app_get_pixel_scale
+ * @category app
+ * @brief    Returns the number of physical pixels per logical point for the app's window.
+ * @remarks  This is the ratio CF actually renders at internally -- e.g. 2.0f on a 2x Retina display. Unlike
+ *           `cf_app_get_dpi_scale` (the OS's suggested UI content scale, which is informational only), this value
+ *           directly reflects the backbuffer/canvas pixel density and is what you'd multiply a logical size by to
+ *           get physical pixels. Returns 1.0f if `CF_APP_OPTIONS_NO_HIGH_DPI_BIT` was passed to `cf_make_app`.
+ * @related  cf_app_get_dpi_scale cf_app_get_size cf_app_get_canvas_width cf_app_get_canvas_height
+ */
+CF_API float CF_CALL cf_app_get_pixel_scale(void);
 
 /**
  * @function cf_app_set_size
@@ -676,6 +690,9 @@ CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
  * @param    w          The width in pixels to resize the canvas to.
  * @param    h          The height in pixels to resize the canvas to.
  * @remarks  Be careful about calling this function, as it will invalidate any old references from `cf_app_get_canvas`.
+ *           Calling this pins the canvas to an exact device-pixel size and opts out of CF's automatic pixel-density-based
+ *           canvas scaling -- the canvas will no longer auto-resize if the window moves to a display with a different
+ *           pixel density.
  * @related  cf_app_get_canvas cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
  */
 CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
@@ -695,6 +712,18 @@ CF_API int CF_CALL cf_app_get_canvas_width(void);
  * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync
  */
 CF_API int CF_CALL cf_app_get_canvas_height(void);
+
+/**
+ * @function cf_app_set_canvas_blit_filter
+ * @category app
+ * @brief    Sets the filter used when the app's canvas is blitted onto the screen, if their sizes differ.
+ * @param    filter     The filter to use: `CF_FILTER_NEAREST` (default; crisp/blocky, good for pixel art) or `CF_FILTER_LINEAR` (smooth).
+ * @remarks  This only matters when the app's canvas size (see `cf_app_set_canvas_size`) doesn't match the window's physical
+ *           pixel size -- for example a pinned low-resolution retro canvas. When the canvas already matches the physical size
+ *           (the default), this setting has no visible effect since no stretching occurs.
+ * @related  cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_canvas_height CF_Filter
+ */
+CF_API void CF_CALL cf_app_set_canvas_blit_filter(CF_Filter filter);
 
 /**
  * @function cf_app_set_vsync
@@ -902,6 +931,7 @@ CF_INLINE int app_get_width() { return cf_app_get_width(); }
 CF_INLINE int app_get_height() { return cf_app_get_height(); }
 CF_INLINE float app_get_dpi_scale() { return cf_app_get_dpi_scale(); }
 CF_INLINE bool app_dpi_scale_was_changed() { return cf_app_dpi_scale_was_changed(); }
+CF_INLINE float app_get_pixel_scale() { return cf_app_get_pixel_scale(); }
 CF_INLINE void app_center_window() { cf_app_center_window(); }
 CF_INLINE bool app_was_resized() { return cf_app_was_resized(); }
 CF_INLINE bool app_was_moved() { return cf_app_was_moved(); }
@@ -936,6 +966,7 @@ CF_INLINE void* app_init_imgui() { return cf_app_init_imgui(); }
 CF_INLINE void app_set_msaa(int msaa) { cf_app_set_msaa(msaa); }
 CF_INLINE CF_Canvas app_get_canvas() { return cf_app_get_canvas(); }
 CF_INLINE void app_set_canvas_size(int w, int h) { cf_app_set_canvas_size(w, h); }
+CF_INLINE void app_set_canvas_blit_filter(CF_Filter filter) { cf_app_set_canvas_blit_filter(filter); }
 CF_INLINE CF_PowerInfo app_power_info() { return cf_app_power_info(); }
 CF_INLINE struct SDL_Window* app_get_window() { return cf_app_get_window(); }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
       - Coroutines: topics/coroutines.md
       - Custom Sprites: topics/custom_sprites.md
       - Data Structures: topics/data_structures.md
+      - High-DPI Rendering: topics/hidpi.md
       - Web Builds with Emscripten: topics/emscripten.md
       - Input: topics/input.md
       - Input Bindings: topics/input_bindings.md

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -73,6 +73,7 @@ add_sample(sprite_slice sprite_slice.cpp)
 add_sample(sprite_shatter sprite_shatter.cpp)
 add_sample(screen_shatter screen_shatter.cpp)
 add_sample(font_debug font_debug.cpp)
+add_sample(hidpi hidpi.c)
 # Disabled on Windows -- MSVC crashes for internal reasons when compiling these.
 if(NOT WIN32)
 	add_sample(clay clay.c)

--- a/samples/clay.c
+++ b/samples/clay.c
@@ -745,11 +745,15 @@ static void handle_clay_core_commands(const Clay_RenderCommand* command)
 			cf_draw_sprite(&sprite);
 		} break;
 		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START: {
+			// Clay's boundingBox is in logical points, but cf_draw_push_scissor/
+			// cf_apply_scissor operate directly in the canvas's physical pixel
+			// space, so scale by pixel_scale to match (see docs/topics/hidpi.md).
+			float pixel_scale = cf_app_get_pixel_scale();
 			cf_draw_push_scissor((CF_Rect){
-				.x = command->boundingBox.x,
-				.y = command->boundingBox.y,
-				.w = command->boundingBox.width,
-				.h = command->boundingBox.height,
+				.x = (int)(command->boundingBox.x * pixel_scale),
+				.y = (int)(command->boundingBox.y * pixel_scale),
+				.w = (int)(command->boundingBox.width * pixel_scale),
+				.h = (int)(command->boundingBox.height * pixel_scale),
 			});
 		} break;
 		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END: {

--- a/samples/clay_ui_animations.c
+++ b/samples/clay_ui_animations.c
@@ -669,11 +669,15 @@ static void handle_clay_core_commands(const Clay_RenderCommand* command)
 			cf_draw_sprite(&sprite);
 		} break;
 		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START: {
+			// Clay's boundingBox is in logical points, but cf_draw_push_scissor/
+			// cf_apply_scissor operate directly in the canvas's physical pixel
+			// space, so scale by pixel_scale to match (see docs/topics/hidpi.md).
+			float pixel_scale = cf_app_get_pixel_scale();
 			cf_draw_push_scissor((CF_Rect){
-				.x = command->boundingBox.x,
-				.y = command->boundingBox.y,
-				.w = command->boundingBox.width,
-				.h = command->boundingBox.height,
+				.x = (int)(command->boundingBox.x * pixel_scale),
+				.y = (int)(command->boundingBox.y * pixel_scale),
+				.w = (int)(command->boundingBox.width * pixel_scale),
+				.h = (int)(command->boundingBox.height * pixel_scale),
 			});
 		} break;
 		case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END: {

--- a/samples/hidpi.c
+++ b/samples/hidpi.c
@@ -1,0 +1,183 @@
+/*
+	hidpi.c -- HiDPI / Retina rendering visual verification.
+
+	Cute Framework renders its default canvas at physical resolution (logical
+	size scaled by `cf_app_get_pixel_scale()`), so text and shapes stay crisp
+	on Retina/HiDPI displays without any extra work from the user. This sample
+	is a quick visual check of that: run it on a HiDPI display and glyph edges
+	and shape antialiasing should look sharp, not soft/blurry.
+
+	See docs/topics/hidpi.md for the full point/pixel model and the retro
+	pixel-art escape hatch (`cf_app_set_canvas_size`).
+
+	What it draws:
+	  - Text at three sizes (12px / 24px / 48px) to eyeball glyph
+	    crispness at different scales.
+	  - A row of basic SDF shapes (filled circle, outlined circle, lines
+	    of varying thickness including a thin ~1px line, a filled rounded
+	    box, and an outlined triangle) to eyeball shape edge antialiasing.
+	  - A live readout of `cf_app_get_pixel_scale()` alongside the physical
+	    canvas size, so the current display's HiDPI scale factor is visible
+	    at a glance.
+
+	No interactivity beyond closing the window; no external assets needed.
+*/
+
+#include <cute.h>
+#include <stdio.h>
+
+// Draws `text` such that it's horizontally centered underneath/at `top_center`,
+// with `top_center.y` acting as the top of the text (matches cf_draw_text's
+// top-left-origin convention).
+static void draw_text_centered(const char* text, CF_V2 top_center)
+{
+	CF_V2 size = cf_text_size(text, -1);
+	cf_draw_text(text, cf_v2(top_center.x - size.x * 0.5f, top_center.y), -1);
+}
+
+int main(int argc, char* argv[])
+{
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | CF_APP_OPTIONS_RESIZABLE_BIT;
+	CF_Result result = cf_make_app("HiDPI Rendering Test", 0, 0, 0, 1280, 800, options, argv[0]);
+	if (cf_is_error(result)) {
+		printf("Error: %s\n", result.details);
+		return -1;
+	}
+
+	// Solid, dark background so both white shape/text edges are easy to eyeball.
+	cf_clear_color(0.08f, 0.10f, 0.14f, 1.0f);
+
+	// CF's built-in pixel-art demo sprite, resized up -- contrasts a chunky,
+	// intentionally low-res sprite against the crisp vector text/shapes above.
+	CF_Sprite sprite = cf_make_demo_sprite();
+	cf_sprite_play(&sprite, "idle");
+	sprite.scale = cf_v2(3.0f, 3.0f);
+
+	while (cf_app_is_running()) {
+		cf_app_update(NULL);
+
+		if (cf_app_was_resized()) {
+			// Nothing special to handle here -- part of the point of this
+			// sample is to observe how resizing/HiDPI scaling affects
+			// rendering crispness.
+		}
+
+		cf_push_font("Calibri");
+		cf_draw_push_color(cf_color_white());
+
+		// -- Title --
+		cf_push_font_size(32);
+		draw_text_centered("HiDPI Rendering Test Harness", cf_v2(0, 380));
+		cf_pop_font_size();
+
+		cf_push_font_size(16);
+		draw_text_centered(
+			"Compare glyph and shape edge crispness before/after the physical-resolution rendering fix.",
+			cf_v2(0, 335)
+		);
+		cf_pop_font_size();
+
+		// -- Live pixel-scale readout --
+		char pixel_scale_buf[128];
+		float pixel_scale = cf_app_get_pixel_scale();
+		int physical_w = cf_app_get_canvas_width();
+		int physical_h = cf_app_get_canvas_height();
+		snprintf(
+			pixel_scale_buf, sizeof(pixel_scale_buf),
+			"pixel_scale: %.2fx (physical canvas: %dx%d)",
+			pixel_scale, physical_w, physical_h
+		);
+		cf_push_font_size(12);
+		draw_text_centered(pixel_scale_buf, cf_v2(0, 300));
+		cf_pop_font_size();
+
+		cf_draw_pop_color();
+
+		cf_draw_push_color(cf_make_color_rgb(120, 130, 150));
+		cf_draw_line(cf_v2(-620, 305), cf_v2(620, 305), 1.0f);
+		cf_draw_pop_color();
+
+		// -- Text at several font sizes --
+		const char* sample_small = "The quick brown fox jumps over the lazy dog -- AaBbCcGgQqRrSs 0123456789";
+		const char* sample_medium = "AaBbCcGgQq -- The quick brown fox -- 0123456789";
+		const char* sample_large = "AaBbCcGgQq 0123456789";
+
+		cf_draw_push_color(cf_color_white());
+
+		cf_push_font_size(14);
+		cf_draw_text("12px:", cf_v2(-600, 275), -1);
+		cf_pop_font_size();
+		cf_push_font_size(12);
+		cf_draw_text(sample_small, cf_v2(-600, 255), -1);
+		cf_pop_font_size();
+
+		cf_push_font_size(14);
+		cf_draw_text("24px:", cf_v2(-600, 220), -1);
+		cf_pop_font_size();
+		cf_push_font_size(24);
+		cf_draw_text(sample_medium, cf_v2(-600, 195), -1);
+		cf_pop_font_size();
+
+		cf_push_font_size(14);
+		cf_draw_text("48px:", cf_v2(-600, 145), -1);
+		cf_pop_font_size();
+		cf_push_font_size(48);
+		cf_draw_text(sample_large, cf_v2(-600, 115), -1);
+		cf_pop_font_size();
+
+		cf_draw_pop_color();
+
+		cf_draw_push_color(cf_make_color_rgb(120, 130, 150));
+		cf_draw_line(cf_v2(-620, -100), cf_v2(620, -100), 1.0f);
+		cf_draw_pop_color();
+
+		// -- Row of assorted SDF shapes (exercise aaf-based antialiasing) --
+		float shapes_y = -180.0f;
+		float label_y = -235.0f;
+
+		cf_draw_push_color(cf_color_white());
+
+		// Filled circle.
+		cf_draw_circle_fill2(cf_v2(-500, shapes_y), 40.0f);
+
+		// Hollow (outlined) circle.
+		cf_draw_circle2(cf_v2(-360, shapes_y), 40.0f, 3.0f);
+
+		// Lines of varying thickness, including a thin ~1px line.
+		cf_draw_line(cf_v2(-260, shapes_y + 20), cf_v2(-120, shapes_y + 20), 1.0f);
+		cf_draw_line(cf_v2(-260, shapes_y), cf_v2(-120, shapes_y), 3.0f);
+		cf_draw_line(cf_v2(-260, shapes_y - 25), cf_v2(-120, shapes_y - 25), 6.0f);
+
+		// Filled rounded box.
+		CF_Aabb box = cf_make_aabb_pos_w_h(cf_v2(40, shapes_y), 100.0f, 70.0f);
+		cf_draw_box_rounded_fill(box, 14.0f);
+
+		// Outlined triangle.
+		cf_draw_tri(cf_v2(220, shapes_y + 40), cf_v2(180, shapes_y - 40), cf_v2(260, shapes_y - 40), 2.0f, 0.0f);
+
+		cf_draw_pop_color();
+
+		// Resized pixel-art demo sprite -- deliberately chunky, unlike the crisp
+		// vector shapes to its left.
+		sprite.transform.p = cf_v2(400, shapes_y + 20);
+		cf_sprite_update(&sprite);
+		cf_draw_sprite(&sprite);
+
+		cf_push_font_size(12);
+		draw_text_centered("Filled circle", cf_v2(-500, label_y));
+		draw_text_centered("Hollow circle", cf_v2(-360, label_y));
+		draw_text_centered("Lines 1/3/6px", cf_v2(-190, label_y));
+		draw_text_centered("Rounded box", cf_v2(40, label_y));
+		draw_text_centered("Triangle", cf_v2(220, label_y));
+		draw_text_centered("Demo sprite (3x)", cf_v2(400, label_y));
+		cf_pop_font_size();
+
+		cf_pop_font();
+
+		cf_app_draw_onto_screen(true);
+	}
+
+	cf_destroy_app();
+
+	return 0;
+}

--- a/samples/window_resizing.cpp
+++ b/samples/window_resizing.cpp
@@ -112,7 +112,11 @@ int main(int argc, char* argv[])
 
 		// Calculate scaled size based on current mode.
 		app_get_size(&window_w, &window_h);
-		app_set_canvas_size(window_w, window_h);
+		// Pin the backdrop canvas to the physical swapchain size so the final
+		// blit is 1:1 and stays crisp on HiDPI displays. The projection below
+		// stays in logical units, so game content doesn't move.
+		float pixel_scale = app_get_pixel_scale();
+		app_set_canvas_size((int)(window_w * pixel_scale), (int)(window_h * pixel_scale));
 		CF_V2 dest = calculate_dest_size(game_w, game_h, window_w, window_h, scale_mode);
 
 		// Draw the canvas scaled and centered in the window.

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -166,6 +166,15 @@ static void s_canvas(int w, int h)
 	app->canvas_h = h;
 }
 
+void cf_app_recreate_default_canvas_if_needed()
+{
+	if (!app->canvas_pinned) {
+		int w = (int)CF_ROUNDF(app->w * app->pixel_scale);
+		int h = (int)CF_ROUNDF(app->h * app->pixel_scale);
+		s_canvas(w, h);
+	}
+}
+
 CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, int y, int w, int h, CF_AppOptionFlags options, const char* argv0)
 {
 	bool use_dx11 = options & CF_APP_OPTIONS_GFX_D3D11_BIT;
@@ -282,7 +291,9 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	SDL_Window* window = NULL;
 	if (use_gfx) {
 		Uint32 flags = 0;
-		flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY; // Turn on high DPI support for all platforms.
+		if (!(options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT)) {
+			flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY; // Turn on high DPI support for all platforms, unless explicitly disabled.
+		}
 		if (use_opengl) flags |= SDL_WINDOW_OPENGL;
 		if (use_metal) flags |= SDL_WINDOW_METAL;
 		if (options & CF_APP_OPTIONS_FULLSCREEN_BIT) flags |= SDL_WINDOW_FULLSCREEN;
@@ -319,6 +330,9 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		SDL_GetWindowPosition(app->window, &app->x, &app->y);
 		app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
 		app->dpi_scale_prev = app->dpi_scale;
+		app->pixel_scale = window ? SDL_GetWindowPixelDensity(app->window) : 1.0f;
+		if (app->pixel_scale <= 0.0f) app->pixel_scale = 1.0f;
+		if (options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) app->pixel_scale = 1.0f;
 	}
 	::app = app;
 	cf_make_aseprite_cache();
@@ -336,7 +350,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		cf_load_internal_shaders();
 		cf_make_draw();
 
-		s_canvas(app->w, app->h);
+		cf_app_recreate_default_canvas_if_needed();
 
 		// Load up a default image of 1x1 white pixel.
 		// Used in various places as a placeholder or default.
@@ -618,6 +632,11 @@ bool cf_app_dpi_scale_was_changed()
 	return app->dpi_scale_was_changed;
 }
 
+float cf_app_get_pixel_scale()
+{
+	return app->pixel_scale;
+}
+
 void cf_app_set_size(int w, int h)
 {
 	SDL_SetWindowSize(app->window, w, h);
@@ -737,7 +756,7 @@ bool cf_app_set_msaa(int sample_count)
 
 	if (supported && app->sample_count != sample_count) {
 		app->sample_count = sample_count;
-		s_canvas(app->w, app->h);
+		cf_app_recreate_default_canvas_if_needed();
 	}
 
 	return supported;
@@ -750,6 +769,7 @@ CF_Canvas cf_app_get_canvas()
 
 void cf_app_set_canvas_size(int w, int h)
 {
+	app->canvas_pinned = true;
 	s_canvas(w, h);
 }
 
@@ -761,6 +781,11 @@ int cf_app_get_canvas_width()
 int cf_app_get_canvas_height()
 {
 	return app->canvas_h;
+}
+
+void cf_app_set_canvas_blit_filter(CF_Filter filter)
+{
+	app->canvas_blit_filter = filter;
 }
 
 void cf_app_set_vsync(bool true_turn_on_vsync)

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -451,7 +451,10 @@ void CF_Draw::set_aaf()
 {
 	float inv_cam_scale = 1.0f / len(s_draw->cam_stack.last().m.y);
 	float scale = s_draw->antialias.last();
-	aaf = scale * inv_cam_scale;
+	// The canvas is now rasterized at `pixel_scale` device pixels per logical unit,
+	// so divide by it here to keep the AA band one device pixel wide (instead of
+	// one logical unit wide, which would now span multiple device pixels).
+	aaf = scale * inv_cam_scale / app->pixel_scale;
 }
 
 void cf_make_draw()
@@ -1846,8 +1849,17 @@ CF_INLINE uint64_t cf_glyph_key(int cp, float font_size, int blur)
 {
 	int k0 = cp;
 	int k1 = (int)(font_size * 1000.0f);
-	int k2 = blur;
-	uint64_t key = ((uint64_t)k0 & 0xFFFFFFFFULL) << 32 | ((uint64_t)k1 & 0xFFFFULL) << 16 | ((uint64_t)k2 & 0xFFFFULL);
+	// Clamp here to match the clamp applied in s_render -- this keeps the cache key
+	// consistent with the blur actually rendered, and keeps k2 safely within its 8-bit
+	// field below regardless of what a caller passes to cf_push_font_blur().
+	int k2 = clamp(blur, 0, 20);
+	// Quantize pixel_scale (device pixels per logical unit) into 8 bits at 1/64 granularity
+	// (range 0..~4.0x) so glyphs rasterized at different pixel densities -- e.g. a window
+	// dragged between a 1x and 2x monitor -- don't alias onto the same cache entry. Clamp
+	// before casting so an unexpectedly large density saturates instead of wrapping back
+	// into a low, colliding bucket.
+	int k3 = (int)clamp(app->pixel_scale * 64.0f, 0.0f, 255.0f);
+	uint64_t key = ((uint64_t)k0 & 0xFFFFFFFFULL) << 32 | ((uint64_t)k1 & 0xFFFFULL) << 16 | ((uint64_t)k2 & 0xFFULL) << 8 | ((uint64_t)k3 & 0xFFULL);
 	return key;
 }
 
@@ -1935,10 +1947,15 @@ static void s_save(const char* path, uint8_t* pixels, int w, int h)
 
 static void s_render(CF_Font* font, CF_Glyph* glyph, float font_size, int blur)
 {
+	// Rasterize at physical resolution (bitmap dimensions are in device pixels) but keep the
+	// quad geometry and advance in logical units, so text stays pixel-scale-invariant in
+	// position/size and only gets sharper as `pixel_scale` increases.
+	float pixel_scale = app->pixel_scale;
+
 	// Create glyph quad.
 	blur = clamp(blur, 0, 20);
-	int pad = blur + 2;
-	float scale = stbtt_ScaleForPixelHeight(&font->info, font_size);
+	int pad = (int)CF_ROUNDF((blur + 2) * pixel_scale);
+	float scale = stbtt_ScaleForPixelHeight(&font->info, font_size * pixel_scale);
 	int xadvance, lsb, x0, y0, x1, y1;
 	stbtt_GetGlyphHMetrics(&font->info, glyph->index, &xadvance, &lsb);
 	stbtt_GetGlyphBitmapBox(&font->info, glyph->index, scale, scale, &x0, &y0, &x1, &y1);
@@ -1946,9 +1963,9 @@ static void s_render(CF_Font* font, CF_Glyph* glyph, float font_size, int blur)
 	int h = y1 - y0 + pad*2;
 	glyph->w = w;
 	glyph->h = h;
-	glyph->q0 = V2((float)x0, -(float)(y0 + h)); // Swapped y.
-	glyph->q1 = V2((float)(x0 + w), -(float)y0); // Swapped y.
-	glyph->xadvance = xadvance * scale;
+	glyph->q0 = V2((float)x0, -(float)(y0 + h)) / pixel_scale; // Swapped y. Logical units.
+	glyph->q1 = V2((float)(x0 + w), -(float)y0) / pixel_scale; // Swapped y. Logical units.
+	glyph->xadvance = xadvance * scale / pixel_scale;
 	glyph->visible |= w > 0 && h > 0;
 
 	// Render glyph.

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1974,8 +1974,12 @@ static void s_render(CF_Font* font, CF_Glyph* glyph, float font_size, int blur)
 	stbtt_MakeGlyphBitmap(&font->info, pixels_1bpp + pad * w + pad, w - pad*2, h - pad*2, w, scale, scale, glyph->index);
 	//s_save("glyph.png", pixels_1bpp, w, h);
 
-	// Apply blur.
-	if (blur) s_blur(pixels_1bpp, w, h, w, blur);
+	// Apply blur. `blur` is a logical-space radius; scale it to device pixels to
+	// match the bitmap's rasterization resolution, so the blur looks the same
+	// logical size regardless of pixel_scale (pad above already reserved room
+	// for this device-space radius).
+	int device_blur = (int)CF_ROUNDF(blur * pixel_scale);
+	if (device_blur) s_blur(pixels_1bpp, w, h, w, device_blur);
 	//s_save("glyph_blur.png", pixels_1bpp, w, h);
 
 	// Convert to premultiplied RGBA8 pixel format.

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2674,9 +2674,12 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 	bool vertical = s_draw->vertical.last();
 
 	auto advance_to_next_glyph = [&](CF_Glyph* last_glyph) {
-		// Max bound covers the entire glyph without kerning so we use w instead
-		// of xadvance
-		max_x = max(max_x, x + last_glyph->w);
+		// Max bound covers the entire glyph without kerning so we use the glyph's
+		// logical ink width (q1.x - q0.x) instead of xadvance. Note glyph->w is the
+		// *physical* rasterized bitmap width (scaled by pixel_scale, used for the
+		// sprite's source-texture size) -- not the same unit as the logical `x`
+		// cursor here, so it can't be used directly for this bound.
+		max_x = max(max_x, x + (last_glyph->q1.x - last_glyph->q0.x));
 		if (vertical) {
 			min_y = min(min_y, y + font->descent * scale);
 

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -733,7 +733,7 @@ void cf_gles_blit_canvas(CF_Canvas canvas_handle)
 		0, canvas->h, canvas->w, 0,
 		0, 0, window_width, window_height,
 		GL_COLOR_BUFFER_BIT,
-		GL_LINEAR
+		s_wrap(app->canvas_blit_filter)
 	);
 	CF_POLL_OPENGL_ERROR();
 	g_ctx.fbo = 0;

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -871,7 +871,7 @@ void cf_sdlgpu_blit_canvas(CF_Canvas canvas)
 			.destination = dst,
 			.load_op = SDL_GPU_LOADOP_CLEAR,
 			.flip_mode = SDL_FLIP_NONE,
-			.filter = SDL_GPU_FILTER_NEAREST,
+			.filter = s_wrap(app->canvas_blit_filter),
 			.cycle = true,
 		};
 		SDL_BlitGPUTexture(g_ctx.cmd, &blit_info);

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -499,6 +499,23 @@ void cf_begin_frame_input()
 	}
 }
 
+// Re-queries the window's physical pixel density and, if it changed, updates
+// app->pixel_scale and recreates the default canvas to match (unless pinned).
+// Called from both SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED and
+// SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED -- the former is the OS's content-scale
+// signal and the latter is the authoritative physical-pixel-size signal;
+// either can fire without the other depending on platform/monitor setup, so
+// both are handled the same way and this is idempotent when both fire together.
+static void s_refresh_pixel_scale()
+{
+	float pixel_scale = SDL_GetWindowPixelDensity(app->window);
+	if (pixel_scale <= 0.0f) pixel_scale = 1.0f;
+	if (pixel_scale != app->pixel_scale) {
+		app->pixel_scale = pixel_scale;
+		cf_app_recreate_default_canvas_if_needed();
+	}
+}
+
 void cf_pump_input_msgs()
 {
 	// Handle SDL messages.
@@ -554,16 +571,15 @@ void cf_pump_input_msgs()
 			app->window_state.has_keyboard_focus = false;
 			break;
 
-		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED: {
+		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
 			app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
 			app->dpi_scale_was_changed = true;
-			float pixel_scale = SDL_GetWindowPixelDensity(app->window);
-			if (pixel_scale <= 0.0f) pixel_scale = 1.0f;
-			if (pixel_scale != app->pixel_scale) {
-				app->pixel_scale = pixel_scale;
-				cf_app_recreate_default_canvas_if_needed();
-			}
-		} break;
+			s_refresh_pixel_scale();
+			break;
+
+		case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
+			s_refresh_pixel_scale();
+			break;
 
 		case SDL_EVENT_KEY_DOWN:
 		{

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -554,10 +554,16 @@ void cf_pump_input_msgs()
 			app->window_state.has_keyboard_focus = false;
 			break;
 
-		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
+		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED: {
 			app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
 			app->dpi_scale_was_changed = true;
-			break;
+			float pixel_scale = SDL_GetWindowPixelDensity(app->window);
+			if (pixel_scale <= 0.0f) pixel_scale = 1.0f;
+			if (pixel_scale != app->pixel_scale) {
+				app->pixel_scale = pixel_scale;
+				cf_app_recreate_default_canvas_if_needed();
+			}
+		} break;
 
 		case SDL_EVENT_KEY_DOWN:
 		{
@@ -671,8 +677,8 @@ void cf_pump_input_msgs()
 			CF_Touch& touch = app->touches.add();
 			touch.id = id;
 			touch.pressure = event.tfinger.pressure;
-			touch.x = event.tfinger.x * app->w; // NOTE: Probably wrong for high-DPI.
-			touch.y = event.tfinger.y * app->h; // NOTE: Probably wrong for high-DPI.
+			touch.x = event.tfinger.x * app->w;
+			touch.y = event.tfinger.y * app->h;
 		}	break;
 
 		case SDL_EVENT_FINGER_MOTION:
@@ -681,14 +687,14 @@ void cf_pump_input_msgs()
 			CF_Touch touch;
 			if (cf_touch_get(id, &touch)) {
 				touch.pressure = event.tfinger.pressure;
-				touch.x = event.tfinger.x * app->w; // NOTE: Probably wrong for high-DPI.
-				touch.y = event.tfinger.y * app->h; // NOTE: Probably wrong for high-DPI.
+				touch.x = event.tfinger.x * app->w;
+				touch.y = event.tfinger.y * app->h;
 			} else {
 				CF_Touch& touch = app->touches.add();
 				touch.id = id;
 				touch.pressure = event.tfinger.pressure;
-				touch.x = event.tfinger.x * app->w; // NOTE: Probably wrong for high-DPI.
-				touch.y = event.tfinger.y * app->h; // NOTE: Probably wrong for high-DPI.
+				touch.x = event.tfinger.x * app->w;
+				touch.y = event.tfinger.y * app->h;
 			}
 		}	break;
 

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -535,6 +535,7 @@ void cf_pump_input_msgs()
 			app->window_state.resized = true;
 			app->w = event.window.data1;
 			app->h = event.window.data2;
+			cf_app_recreate_default_canvas_if_needed();
 			break;
 
 		case SDL_EVENT_WINDOW_MOVED:

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -31,6 +31,10 @@ struct cs_context_t;
 
 CF_API extern struct CF_App* app;
 
+// Recreates the default offscreen canvas at logical_size * pixel_scale, unless the user has pinned
+// an explicit size via cf_app_set_canvas_size(). Called on init and whenever pixel_scale changes.
+void cf_app_recreate_default_canvas_if_needed();
+
 struct CF_MouseState
 {
 	int left_button = 0;
@@ -83,6 +87,9 @@ struct CF_App
 	float dpi_scale = 1.0f;
 	float dpi_scale_prev = 1.0f;
 	bool dpi_scale_was_changed = false;
+	float pixel_scale = 1.0f;   // Physical pixels per logical point (from SDL_GetWindowPixelDensity). Drives default-canvas sizing, AA, and glyph rasterization.
+	bool canvas_pinned = false; // True once cf_app_set_canvas_size() is called explicitly -- opts out of automatic pixel_scale-based canvas resizing.
+	CF_Filter canvas_blit_filter = CF_FILTER_NEAREST; // Filter used when blitting the app canvas onto the screen, if their sizes differ (e.g. a pinned retro canvas). Defaults to nearest for a crisp/blocky pixel-art look.
 	bool sync_window = false;
 	int draw_call_count = 0;
 	int w;


### PR DESCRIPTION
## The problem

CF force-enables a high-density backbuffer (`SDL_WINDOW_HIGH_PIXEL_DENSITY`), but then renders everything into a **logical-sized** offscreen canvas and stretch-blits that up to the physical backbuffer. On a 2x Retina display this throws away ~75% of the panel's resolution:

- **Text is blurry.** Glyphs are rasterized at the logical font size, then magnified.
- **Shape edges are soft.** SDF anti-aliasing is computed as "one logical pixel" wide, which becomes a 2-physical-pixel-wide blur after the upscale.

None of this is broken, exactly — apps run and are fully interactive — but on any HiDPI display they look noticeably soft compared to a native app. Screenshots below show the same window, same content, before and after.

## The fix

Render at the display's actual physical resolution, but keep the public API and coordinate system entirely in **logical points** — existing games don't move a single pixel, they just get sharper.

One new internal quantity drives everything: `pixel_scale` (physical pixels per logical point, from `SDL_GetWindowPixelDensity()`). This is deliberately a *different* value from the existing `cf_app_get_dpi_scale()` (the OS's suggested UI content scale), which was already being tracked but never actually fed into rendering anywhere — that getter is untouched.

- **Canvas**: the default offscreen canvas is now sized `logical_size × pixel_scale` instead of `logical_size`. The projection doesn't change — it still maps the same logical range to NDC, so a bigger canvas just means more physical texels for the same content. The final canvas→screen blit becomes 1:1, so the upscale-blur disappears entirely.
- **Anti-aliasing**: the shape AA factor is divided by `pixel_scale`, so the SDF edge is one *physical* pixel wide again instead of `pixel_scale` physical pixels.
- **Text**: glyphs are rasterized and cache-keyed at `font_size × pixel_scale`, but the on-screen quad and advance width stay in logical units (divided back down), so layout is byte-for-byte identical — only the rendered bitmap is higher-res.
- **Blur/glow/shadow text effects**: the blur kernel radius is also scaled by `pixel_scale` to match the higher-res raster (otherwise glow/shadow effects visibly shrink, in logical terms, as `pixel_scale` increases).

## New/changed public API

- **`cf_app_get_pixel_scale()`** — physical pixels per logical point (e.g. `2.0f` on a 2x Retina display). Use this to convert your own logical values into physical-pixel space (see the Clay fix below for a concrete example).
- **`CF_APP_OPTIONS_NO_HIGH_DPI_BIT`** — opts out entirely, forcing 1:1 logical-to-physical rendering (`pixel_scale` always `1.0f`) for apps that don't want the high-density backbuffer at all.
- **`cf_app_set_canvas_blit_filter()`** — the canvas→screen blit filter was hardcoded to `nearest` on the SDLGPU backend and `linear` on GLES. Unified behind one setting (defaults to `nearest`).
- **`cf_app_set_canvas_size()`** doc clarified — pinning the canvas to an exact size now explicitly opts *that* canvas out of automatic `pixel_scale` resizing. The "pin a low-res canvas for a retro/pixel-art look" pattern still works exactly as before; the point-sampled upscale is now a documented, deliberate choice instead of an unrelated side effect of this change.
- **`cf_app_get_size/width/height`** doc fix — these were documented as returning values "in pixels," but they're actually logical points on any HiDPI display. Docs now say so and point at `cf_app_get_pixel_scale()`.

## Samples & docs

- **New `samples/hidpi.c`** — text at several sizes, a row of SDF shapes, and a live `pixel_scale`/canvas-size readout. A quick way to eyeball crispness on any display.
- **`samples/window_resizing.cpp` fix** — it pins its backdrop canvas to the window size every frame; that pin now multiplies by `pixel_scale` so it stays crisp instead of silently reintroducing the exact blur this PR fixes.
- **New `docs/topics/hidpi.md`** — the point/pixel model, `pixel_scale` vs `dpi_scale`, and the retro-canvas escape hatch.

## Two real bugs found by actually testing on a Retina display

Both of these are general-purpose bugs, not specific to the new sample — they'd bite any existing game moved to this branch.

1. **Text measurement was off-center on HiDPI.** `cf_text_size`/`cf_text_width`'s line-extent tracking added `glyph->w` (the glyph bitmap's width, which is now in *physical* pixels) directly to a *logical*-space cursor — a unit mismatch invisible at `pixel_scale == 1.0` (which is exactly why it didn't show up until testing on a real Retina display) but overestimating the measured width by roughly one glyph's worth at `pixel_scale == 2.0`. Anything centering text off `cf_text_size` was affected. Fixed by using the glyph's already-logical ink width (`q1.x - q0.x`) instead.

2. **Clay's debug inspector (or any clipped/scrollable Clay region) rendered empty on HiDPI.** Clay's `boundingBox` is in logical points, but `cf_draw_push_scissor`/`cf_apply_scissor` set the GPU scissor rect directly in the canvas's *physical* pixel space — they bypass CF's logical→NDC projection entirely, unlike every other draw call. Fixed `samples/clay.c` and `samples/clay_ui_animations.c` to multiply by `cf_app_get_pixel_scale()` before building the scissor rect. **Worth checking your own Clay integration for the same pattern** if you use scissor/clipping.

Also wired up `SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED` (the authoritative "physical pixel size changed" signal) alongside the existing `SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED` hook, since the two can fire independently depending on platform/monitor setup.

## Testing

- Visually verified before/after on a 2x Retina MacBook display (SDLGPU/Metal) and a standard-DPI external display, including dragging the window between the two live.
- Verified Emscripten/web builds (GLES3 backend) of all touched samples load and run correctly in-browser.

## Screenshots

<img width="1392" height="944" alt="Screenshot 2026-07-06 at 01 00 45" src="https://github.com/user-attachments/assets/c7ac9bad-e0a5-4f1c-b18e-0dc60747302d" />
<img width="1392" height="944" alt="Screenshot 2026-07-06 at 01 00 40" src="https://github.com/user-attachments/assets/c6044395-6a98-43da-9e71-f43bfc596873" />
<img width="1392" height="1044" alt="Screenshot 2026-07-06 at 01 21 20" src="https://github.com/user-attachments/assets/93d9e428-3a46-4683-a345-6a5a186c7c60" />
<img width="1392" height="1044" alt="Screenshot 2026-07-06 at 01 21 15" src="https://github.com/user-attachments/assets/47bd5d79-7dad-4392-aa64-c5017e5bd32f" />
<img width="1312" height="1150" alt="Screenshot 2026-07-06 at 01 31 39" src="https://github.com/user-attachments/assets/2e422878-deae-4ac4-a973-646a25671476" />

PS. Obviously coded by Claude Code Sonnet 5 xhigh.