### PR TITLE
Follow-up fixes from PR #508 review

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -369,7 +369,7 @@ CF_API int CF_CALL cf_app_draw_onto_screen(bool clear);
  * @brief    Gets the size of the window in logical points (called "points" on Retina/HiDPI displays; use `cf_app_get_pixel_scale` to convert to physical pixels).
  * @param    w          The width of the window in logical points.
  * @param    h          The height of the window in logical points.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
  */
 CF_API void CF_CALL cf_app_get_size(int* w, int* h);
 
@@ -377,7 +377,7 @@ CF_API void CF_CALL cf_app_get_size(int* w, int* h);
  * @function cf_app_get_width
  * @category app
  * @brief    Returns the size of the window width in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
  */
 CF_API int CF_CALL cf_app_get_width(void);
 
@@ -385,7 +385,7 @@ CF_API int CF_CALL cf_app_get_width(void);
  * @function cf_app_get_height
  * @category app
  * @brief    Returns the size of the window height in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
  */
 CF_API int CF_CALL cf_app_get_height(void);
 

--- a/samples/window_resizing.cpp
+++ b/samples/window_resizing.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
 		// blit is 1:1 and stays crisp on HiDPI displays. The projection below
 		// stays in logical units, so game content doesn't move.
 		float pixel_scale = app_get_pixel_scale();
-		app_set_canvas_size((int)(window_w * pixel_scale), (int)(window_h * pixel_scale));
+		app_set_canvas_size((int)CF_ROUNDF(window_w * pixel_scale), (int)CF_ROUNDF(window_h * pixel_scale));
 		CF_V2 dest = calculate_dest_size(game_w, game_h, window_w, window_h, scale_mode);
 
 		// Draw the canvas scaled and centered in the window.

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -756,7 +756,7 @@ bool cf_app_set_msaa(int sample_count)
 
 	if (supported && app->sample_count != sample_count) {
 		app->sample_count = sample_count;
-		cf_app_recreate_default_canvas_if_needed();
+		s_canvas(app->canvas_w, app->canvas_h);
 	}
 
 	return supported;

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -756,7 +756,11 @@ bool cf_app_set_msaa(int sample_count)
 
 	if (supported && app->sample_count != sample_count) {
 		app->sample_count = sample_count;
-		s_canvas(app->canvas_w, app->canvas_h);
+		if (app->canvas_pinned) {
+			s_canvas(app->canvas_w, app->canvas_h);
+		} else {
+			cf_app_recreate_default_canvas_if_needed();
+		}
 	}
 
 	return supported;

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -508,6 +508,7 @@ void cf_begin_frame_input()
 // both are handled the same way and this is idempotent when both fire together.
 static void s_refresh_pixel_scale()
 {
+	if (app->options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) return;
 	float pixel_scale = SDL_GetWindowPixelDensity(app->window);
 	if (pixel_scale <= 0.0f) pixel_scale = 1.0f;
 	if (pixel_scale != app->pixel_scale) {

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -501,6 +501,8 @@ void cf_begin_frame_input()
 
 // Re-queries the window's physical pixel density and, if it changed, updates
 // app->pixel_scale and recreates the default canvas to match (unless pinned).
+// No-ops entirely when CF_APP_OPTIONS_NO_HIGH_DPI_BIT is set, since pixel_scale
+// must stay pinned at 1.0f in that mode.
 // Called from both SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED and
 // SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED -- the former is the OS's content-scale
 // signal and the latter is the authoritative physical-pixel-size signal;


### PR DESCRIPTION
## Summary

Addresses review feedback left on #508 (HiDPI rendering) after it merged.

- **Apply MSAA changes to pinned canvases** — `cf_app_set_msaa()` now recreates the canvas at its current size instead of going through `cf_app_recreate_default_canvas_if_needed()`, which no-ops once `cf_app_set_canvas_size()` has pinned the canvas. Previously MSAA changes silently had no effect for pinned-canvas apps. (noted independently by @chatgpt-codex-connector and Copilot)
- **Respect `NO_HIGH_DPI_BIT` in pixel scale refresh** — `s_refresh_pixel_scale()` no longer overwrites `app->pixel_scale` when the app opted out of HiDPI, matching `cf_app_get_pixel_scale()`'s documented guarantee to always return `1.0f` in that case. (Copilot)
- **Cross-reference `cf_app_get_pixel_scale` from window-size docs** — added it to `@related` on `cf_app_get_size`, `cf_app_get_width`, and `cf_app_get_height` for consistency. (Copilot)
- **Round instead of truncate in the `window_resizing` sample** — `(int)(window_w * pixel_scale)` truncated for fractional pixel scales, undersizing the pinned canvas and reintroducing blur; now uses `CF_ROUNDF` like `cf_app_recreate_default_canvas_if_needed()` does internally. (Copilot)

One additional comment from #508 (claiming `WINDOW_RESIZED` doesn't recreate the canvas on pixel-size-only changes) wasn't addressed — the same PR already added a `cf_app_recreate_default_canvas_if_needed()` call to the `WINDOW_RESIZED` handler, so that case is already covered.

## Test plan
- [x] `cmake --build build --target cute` — builds clean (only pre-existing unrelated warnings)
- [x] `cmake --build build --target windowresizing` — builds and links