### PR TITLE
Fix text kerning, HiDPI glyph padding, and invisible-glyph rasterization

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2792,7 +2792,7 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 		// Advance the cursor by the pair kern so it accumulates across the line and is
 		// reflected in measurement + bounds, not just the visible glyph. Horizontal only;
 		// hit_newline guards against kerning across line breaks.
-		if (!vertical && !hit_newline) {
+		if (!vertical && !hit_newline && cp_prev) {
 			x += cf_font_get_kern(font, font_size, cp_prev, cp);
 		}
 

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1790,7 +1790,9 @@ CF_Result cf_make_font_from_memory(void* data, int size, const char* font_name)
 	stbtt_GetFontBoundingBox(&font->info, &x0, &y0, &x1, &y1);
 	font->width = x1 - x0;
 
-	// Build kerning table.
+	// Build the legacy kerning table, keyed by glyph index (as stb provides it). Used
+	// as a fallback in cf_font_get_kern for fonts whose GPOS table isn't in a layout
+	// stb's minimal parser understands, even though real kern data still exists here.
 	Array<stbtt_kerningentry> table_array;
 	int table_length = stbtt_GetKerningTableLength(&font->info);
 	table_array.ensure_capacity(table_length);
@@ -2021,10 +2023,22 @@ CF_Glyph* cf_font_get_glyph(CF_Font* font, int code, float font_size, int blur)
 
 float cf_font_get_kern(CF_Font* font, float font_size, int code0, int code1)
 {
-	uint64_t key = CF_KERN_KEY(code0, code1);
-	int* val = font->kerning.try_get(key);
-	if (!val) return 0;
-	return *val * stbtt_ScaleForPixelHeight(&font->info, font_size);
+	// Prefer GPOS -- stb's codepoint API converts to glyph indices internally and
+	// reads GPOS pair-adjustment tables, which is where most modern fonts keep
+	// kerning. But stb's GPOS parser only understands a narrow set of lookup
+	// formats: some fonts (e.g. this project's bundled Calibri) have a GPOS table
+	// stb can't read, yet still carry real data in the legacy `kern` table. Since
+	// stb only consults `kern` when there's no GPOS table at all, fall back to our
+	// own glyph-index lookup into `kerning` (built in cf_make_font_from_data) when
+	// the GPOS path comes up empty.
+	int advance = stbtt_GetCodepointKernAdvance(&font->info, code0, code1);
+	if (!advance) {
+		int g0 = stbtt_FindGlyphIndex(&font->info, code0);
+		int g1 = stbtt_FindGlyphIndex(&font->info, code1);
+		int* val = font->kerning.try_get(CF_KERN_KEY(g0, g1));
+		if (val) advance = *val;
+	}
+	return advance * stbtt_ScaleForPixelHeight(&font->info, font_size);
 }
 
 void cf_push_font(const char* font)
@@ -2204,6 +2218,10 @@ static const char* s_find_end_of_line(CF_Font* font, const char* text, float wra
 	const char* start_of_word = 0;
 	float word_w = 0;
 	int cp;
+	int cp_prev = 0;
+	// Mirrors the main render loop's hit_newline gating, so wrap points land where
+	// the kerned text will actually break.
+	bool at_line_start = true;
 
 	while (*text) {
 		const char* text_prev = text;
@@ -2214,22 +2232,25 @@ static const char* s_find_end_of_line(CF_Font* font, const char* text, float wra
 			x = 0;
 			word_w = 0;
 			start_of_word = 0;
+			at_line_start = true;
 			continue;
 		} else if (cp == '\r') {
 			continue;
 		} else {
+			float kern = at_line_start ? 0 : cf_font_get_kern(font, font_size, cp_prev, cp);
+			float advance = glyph->xadvance + kern;
 			if (s_is_space(cp)) {
-				x += word_w + glyph->xadvance;
+				x += word_w + advance;
 				word_w = 0;
 				start_of_word = 0;
 			} else {
 				if (!start_of_word) {
 					start_of_word = text_prev;
 				}
-				if (x + word_w + glyph->xadvance < wrap_width) {
-					word_w += glyph->xadvance;
+				if (x + word_w + advance < wrap_width) {
+					word_w += advance;
 				} else {
-					if (word_w + glyph->xadvance < wrap_width) {
+					if (word_w + advance < wrap_width) {
 						// Put entire word on the next line.
 						return start_of_word;
 					} else {
@@ -2238,6 +2259,8 @@ static const char* s_find_end_of_line(CF_Font* font, const char* text, float wra
 					}
 				}
 			}
+			cp_prev = cp;
+			at_line_start = false;
 		}
 	}
 
@@ -2766,6 +2789,13 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			continue;
 		}
 
+		// Advance the cursor by the pair kern so it accumulates across the line and is
+		// reflected in measurement + bounds, not just the visible glyph. Horizontal only;
+		// hit_newline guards against kerning across line breaks.
+		if (!vertical && !hit_newline) {
+			x += cf_font_get_kern(font, font_size, cp_prev, cp);
+		}
+
 		// Prepare a sprite struct for rendering.
 		float xadvance = glyph->xadvance;
 		if (render || markups) {
@@ -2777,11 +2807,9 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			s.geom.alpha = 1.0f;
 			CF_Color color = s_draw->colors.last();
 
-			uint64_t kern_key = CF_KERN_KEY(cp_prev, cp);
-			v2 kern = V2(cf_font_get_kern(font, font_size, cp_prev, cp), 0);
 			v2 pad = V2(1,1); // Account for 1-pixel padding in spritebatch.
-			v2 q0 = glyph->q0 + V2(x,y) + kern - pad;
-			v2 q1 = glyph->q1 + V2(x,y) + kern + pad;
+			v2 q0 = glyph->q0 + V2(x,y) - pad;
+			v2 q1 = glyph->q1 + V2(x,y) + pad;
 
 			// Apply any active custom text effects.
 			bool use_corner_colors = false;

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1968,7 +1968,12 @@ static void s_render(CF_Font* font, CF_Glyph* glyph, float font_size, int blur)
 	glyph->q0 = V2((float)x0, -(float)(y0 + h)) / pixel_scale; // Swapped y. Logical units.
 	glyph->q1 = V2((float)(x0 + w), -(float)y0) / pixel_scale; // Swapped y. Logical units.
 	glyph->xadvance = xadvance * scale / pixel_scale;
-	glyph->visible |= w > 0 && h > 0;
+	glyph->rendered = true;
+
+	// Glyphs with no ink (spaces, etc.) have nothing to rasterize -- layout metrics
+	// above are still valid and needed, but skip allocating a bitmap/atlas slot for
+	// them entirely, and skip drawing them (see `visible` check in s_draw_text).
+	if (!glyph->visible) return;
 
 	// Render glyph.
 	uint8_t* pixels_1bpp = (uint8_t*)CF_CALLOC(w * h);
@@ -2014,7 +2019,7 @@ CF_Glyph* cf_font_get_glyph(CF_Font* font, int code, float font_size, int blur)
 		glyph->index = glyph_index;
 		glyph->visible = stbtt_IsGlyphEmpty(&font->info, glyph_index) == 0;
 	}
-	if (glyph->image_id) return glyph;
+	if (glyph->rendered) return glyph;
 
 	// Render the glyph if it exists in the font, but is not yet rendered.
 	s_render(font, glyph, font_size, blur);
@@ -2807,7 +2812,11 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			s.geom.alpha = 1.0f;
 			CF_Color color = s_draw->colors.last();
 
-			v2 pad = V2(1,1); // Account for 1-pixel padding in spritebatch.
+			// Account for spritebatch's 1-pixel atlas border. The border is 1 *device*
+			// pixel (glyph bitmaps are rasterized at pixel_scale resolution), but q0/q1
+			// are in logical units, so the pad must shrink by pixel_scale to match --
+			// otherwise on HiDPI the quad is stretched past the glyph's actual coverage.
+			v2 pad = V2(1,1) / app->pixel_scale;
 			v2 q0 = glyph->q0 + V2(x,y) - pad;
 			v2 q1 = glyph->q1 + V2(x,y) + pad;
 

--- a/src/internal/cute_font_internal.h
+++ b/src/internal/cute_font_internal.h
@@ -25,6 +25,7 @@ struct CF_Glyph
 	int w, h;
 	float xadvance;
 	bool visible;
+	bool rendered; // Metrics (and, if visible, the atlas image) have been computed.
 };
 
 struct CF_Font


### PR DESCRIPTION
## Summary

A review of `src/cute_draw.cpp`'s text rendering path turned up three independent bugs. All are fixed here.

### 1. Kerning was not applied to the text layout cursor

`advance_to_next_glyph` in `s_draw_text` only advanced `x` by `glyph->xadvance`. The only place kerning was used was a local offset added to a single glyph's quad in the render block, which:
- Didn't accumulate — every glyph past the first carried none of the preceding kern adjustments.
- Was gated behind `if (render || markups)`, so the measurement pass (`cf_text_size`, word-wrap) never saw it, making returned sizes and wrap points disagree with what was actually drawn.

`cf_font_get_kern` also looked up the wrong key, so it usually returned 0 outright: the kerning table is built from `stbtt_GetKerningTable`, keyed by **glyph index**, but the lookup queried it with raw **codepoints**.

Fixing the lookup with stb's `stbtt_GetCodepointKernAdvance` (which converts codepoint -> glyph index and also reads GPOS) still returned 0 for classic pairs like "AV"/"To" on this project's bundled Calibri. A standalone probe against the embedded font data showed why: Calibri has a **populated legacy `kern` table** (26,706 entries, real values e.g. "To" = -182 units) *and* a `GPOS` table, but stb's minimal GPOS parser doesn't support this font's GPOS lookup layout, and stb only consults the legacy `kern` table when there's *no* GPOS table at all. The fix now tries GPOS first and falls back to the (correctly glyph-index-keyed) legacy table when GPOS reports nothing.

`s_find_end_of_line` (word-wrap) also now folds kerning into its width accounting, and the cursor correctly skips kerning for the first glyph of the string (`cp_prev` starts at 0 -- thanks for catching that in the follow-up commit).

### 2. HiDPI glyph padding was off by `pixel_scale`

The glyph quad's border pad was a flat `V2(1,1)` logical unit, meant to cover spritebatch's 1-pixel atlas border. That border is 1 *device* pixel, while glyph bitmaps rasterize at `pixel_scale` resolution and `q0/q1` are logical units -- so on Retina displays the pad overshot the border, stretching every glyph quad slightly past its actual coverage (worse for smaller glyphs). Fixed by dividing the pad by `app->pixel_scale`, matching how `q0/q1`/`xadvance` are already scaled elsewhere in the same function.

### 3. Every space character was rasterized, given an atlas slot, and drawn as a blank quad

`glyph->visible |= w > 0 && h > 0` always evaluated true (`w`/`h` include border padding, which is never zero), silently overriding `stbtt_IsGlyphEmpty`'s correct verdict. Every invisible glyph (spaces, etc.) ended up rasterized, cached into the atlas, and pushed as a blank draw quad on every occurrence. Beyond fixing the flag, invisible glyphs now skip `s_render`'s rasterization and atlas registration entirely -- layout metrics (`xadvance`, `q0`/`q1`) are still computed since those are needed regardless of visibility. A new `rendered` flag on `CF_Glyph` replaces the old `image_id`-based cache-hit check in `cf_font_get_glyph`, since invisible glyphs never get an `image_id`.

## Changes (`src/cute_draw.cpp`, `src/internal/cute_font_internal.h`)

- `cf_font_get_kern`: try `stbtt_GetCodepointKernAdvance` first, fall back to a glyph-index lookup into the legacy `kern` table.
- `s_draw_text`: accumulate kern into the `x` cursor before positioning each glyph (horizontal layout only, skipped right after a line break or for the first glyph), unconditionally so measurement stays consistent with rendering. Removed the now-redundant per-glyph kern offset on the quad.
- `s_find_end_of_line`: word-wrap width accounting now includes kerning too.
- Glyph quad padding now divides by `app->pixel_scale` to match the device-pixel atlas border.
- `s_render`/`cf_font_get_glyph`: invisible glyphs skip rasterization and atlas registration; `CF_Glyph::rendered` tracks "already processed" instead of `image_id`.

## Test plan

- [x] `cmake --build build` -- clean, no new warnings
- [x] `./build/tests` -- 173/173 passing
- [x] Visual check via `samples/font_debug.cpp` against the bundled Calibri: kerning readout for "To" went from `0.00` to `-2.31` at font size 26; before/after screenshot crop confirms the `o` glyph is now pulled tight under the `T`
- [x] Debug print confirmed space-glyph behavior directly: `visible=0 rendered=1 image_id=0 xadvance=5.88` -- no rasterization or atlas slot allocated, but layout spacing is unaffected

<img width="1392" height="1044" alt="image" src="https://github.com/user-attachments/assets/9cadc15c-0f10-4065-9a81-1afaebc05464" />


https://claude.ai/code/session_011V2maY4DG1DHscsMEHy6Bf