### PR TITLE
Fix uninitialized vertex attributes on canvas blits

### DIFF
--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -3440,6 +3440,7 @@ void static s_blit(CF_Command* cmd, CF_Canvas src, CF_Canvas dst, bool clear_dst
 	for (int i = 0; i < 6; ++i) {
 		verts[i].pos = verts_world[i];
 		verts[i].posH = verts_posH[i];
+		verts[i].params = cmd->canvas_attributes;
 	}
 	verts[0].uv = V2(0,1);
 	verts[1].uv = V2(1,1);

--- a/src/internal/cute_draw_internal.h
+++ b/src/internal/cute_draw_internal.h
@@ -173,7 +173,7 @@ struct CF_Draw
 	CF_M3x2 mvp;
 	void reset_cam();
 	void set_aaf();
-	Cute::Array<CF_Color> user_params = { cf_make_color_hex(0) };
+	Cute::Array<CF_Color> user_params = { cf_color_clear() };
 	Cute::Array<CF_Color> tri_colors0 = { cf_color_white() };
 	Cute::Array<CF_Color> tri_colors1 = { cf_color_white() };
 	Cute::Array<CF_Color> tri_colors2 = { cf_color_white() };


### PR DESCRIPTION
`cf_draw_canvas` captures the pushed vertex attributes into `cmd.canvas_attributes`, but `s_blit` never copies them into the blit vertex buffer, so a custom shader's `params.attributes` reads uninitialized stack memory on the canvas-blit path. Fixed by filling `verts[i].params` in the blit vertex loop.

Also changed the `user_params` default from `cf_make_color_hex(0)` to `cf_color_clear()` to match the same default as `CF_Command::canvas_attributes`. This means that a shader doing something like `mix(color.rgb, attributes.rgb, attributes.a)` is a no-op instead of tinting everything black. 

backcompat note: 
shaders that read attributes without ever pushing them now see (0,0,0,0) instead of opaque black / garbage.