### PR TITLE
Add per-sound pan control

### DIFF
--- a/docs/topics/audio.md
+++ b/docs/topics/audio.md
@@ -64,6 +64,8 @@ void PlaySound(SoundFX fx, bool loop = false)
 
 See the page [`CF_SoundParams`](../audio/cf_soundparams.md) to view all the different settings available. There's more than just looping, including pan, volume, pause state, pitch, etc.
 
+While a sound is playing you can update its parameters live. Volume, pitch, pause, loop, and pan all have getters/setters on the [`CF_Sound`](../audio/cf_sound.md) handle — for example [`cf_sound_set_pan`](../audio/cf_sound_set_pan.md) moves a playing effect across the stereo field (useful when an object moves from left to right on screen).
+
 You can play many sound FX all simultaneously, up to many thousands without hitting any kind of performance difference on many platforms.
 
 > [!NOTE]

--- a/include/cute_audio.h
+++ b/include/cute_audio.h
@@ -23,7 +23,7 @@ extern "C" {
  * @struct   CF_Sound
  * @category audio
  * @brief    An opaque pointer representing a sound created by `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 typedef struct CF_Sound { uint64_t id; } CF_Sound;
 // @end
@@ -120,7 +120,8 @@ CF_API int CF_CALL cf_audio_channel_count(CF_Audio audio);
  * @category audio
  * @brief    Sets the global stereo pan for all audio.
  * @param    pan          0.5f means perfect balance for left/right speakers. 0.0f means only left speaker, 1.0f means only right speaker.
- * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause
+ * @remarks  This multiplies against each sound's own pan. Prefer `cf_sound_set_pan` to move individual sounds in the stereo field.
+ * @related  cf_audio_set_pan cf_audio_set_global_volume cf_audio_set_sound_volume cf_audio_set_pause cf_sound_set_pan cf_sound_get_pan
  */
 CF_API void CF_CALL cf_audio_set_pan(float pan);
 
@@ -277,7 +278,7 @@ CF_API void CF_CALL cf_music_set_on_finish_callback(void (*on_finished)(void* ud
  * @category audio
  * @brief    Parameters for the function `cf_play_sound`.
  * @remarks  You can use default settings from the `cf_sound_params_defaults` function.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 typedef struct CF_SoundParams
 {
@@ -290,7 +291,7 @@ typedef struct CF_SoundParams
 	/* @member Default: 0.5f. A volume control from 0.0f to 1.0f. 0.0f meaning silent, 1.0f meaning max volume. */
 	float volume;
 
-	/* @member Default: 0.5f. A stereo pan control from 0.0f to 1.0f. 0.0f means left-speaker, 1.0f means right speaker, 0.5f means equal both. */
+	/* @member Default: 0.5f. A stereo pan control from 0.0f to 1.0f. 0.0f means left-speaker, 1.0f means right speaker, 0.5f means equal both. Can be updated while playing with `cf_sound_set_pan`. */
 	float pan;
 
 	/* @member Default: 1.0f. Lower numbers lower the pitch and increase playback speed. Higher numbers increase the pitch and reduce playback speed. */
@@ -305,7 +306,7 @@ typedef struct CF_SoundParams
  * @function cf_sound_params_defaults
  * @category audio
  * @brief    Returns a `CF_SoundParams` filled with default state, to use with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults(void)
 {
@@ -326,7 +327,7 @@ CF_INLINE CF_SoundParams CF_CALL cf_sound_params_defaults(void)
  * @param    audio_source   The `CF_Audio` samples for the sound to play.
  * @param    params         `CF_SoundParams` on how to play the sound. You can use default values by calling `cf_sound_params_defaults`.
  * @return   Returns a playing sound `CF_Sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API CF_Sound CF_CALL cf_play_sound(CF_Audio audio_source, CF_SoundParams params);
 
@@ -347,7 +348,7 @@ CF_API void CF_CALL cf_sound_set_on_finish_callback(void (*on_finished)(CF_Sound
  * @brief    Returns whether or not a sound is active.
  * @param    sound          The sound.
  * @return   Returns true if the sound is active, or false if it finished playing (and was not looped).
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API bool CF_CALL cf_sound_is_active(CF_Sound sound);
 
@@ -357,7 +358,7 @@ CF_API bool CF_CALL cf_sound_is_active(CF_Sound sound);
  * @brief    Returns whether or not a sound is paused.
  * @param    sound          The sound.
  * @remarks  You can set a sound to paused with `cf_sound_set_is_paused`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API bool CF_CALL cf_sound_get_is_paused(CF_Sound sound);
 
@@ -367,7 +368,7 @@ CF_API bool CF_CALL cf_sound_get_is_paused(CF_Sound sound);
  * @brief    Returns whether or not a sound is looped.
  * @param    sound          The sound.
  * @remarks  You can set a sound to looped with `cf_sound_set_is_looped`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API bool CF_CALL cf_sound_get_is_looped(CF_Sound sound);
 
@@ -377,9 +378,20 @@ CF_API bool CF_CALL cf_sound_get_is_looped(CF_Sound sound);
  * @brief    Returns the volume of the sound.
  * @param    sound          The sound.
  * @remarks  You can set a sound volume with `cf_sound_set_volume`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API float CF_CALL cf_sound_get_volume(CF_Sound sound);
+
+/**
+ * @function cf_sound_get_pan
+ * @category audio
+ * @brief    Returns the stereo pan of the sound.
+ * @param    sound          The sound.
+ * @return   A value from 0.0f to 1.0f. 0.0f means left speaker, 1.0f means right speaker, 0.5f means equal both.
+ * @remarks  You can set a sound pan with `cf_sound_set_pan`, or upon creation with `cf_play_sound`.
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ */
+CF_API float CF_CALL cf_sound_get_pan(CF_Sound sound);
 
 /**
  * @function cf_sound_get_pitch
@@ -387,7 +399,7 @@ CF_API float CF_CALL cf_sound_get_volume(CF_Sound sound);
  * @brief    Returns the pitch of the sound.
  * @param    sound          The sound.
  * @remarks  You can set a sound pitch with `cf_sound_set_pitch`, or upon creation with `cf_play_sound`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch cf_sound_get_pitch
  */
 CF_API float CF_CALL cf_sound_get_pitch(CF_Sound sound);
 
@@ -398,7 +410,7 @@ CF_API float CF_CALL cf_sound_get_pitch(CF_Sound sound);
  * @param    sound          The sound.
  * @remarks  You can set a sound's playback time with `cf_sound_set_time`. This can be useful to sync a dynamic audio system that
  *           can turn on/off different instruments or sounds.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API double CF_CALL cf_sound_get_time(CF_Sound sound);
 
@@ -409,7 +421,7 @@ CF_API double CF_CALL cf_sound_get_time(CF_Sound sound);
  * @param    sound            The sound.
  * @param    true_for_paused  The pause state to set.
  * @remarks  You can get a sound's paused state with `cf_sound_get_is_paused`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API void CF_CALL cf_sound_set_is_paused(CF_Sound sound, bool true_for_paused);
 
@@ -420,7 +432,7 @@ CF_API void CF_CALL cf_sound_set_is_paused(CF_Sound sound, bool true_for_paused)
  * @param    sound            The sound.
  * @param    true_for_looped  The loop state to set.
  * @remarks  You can get a sound's looped state with `cf_sound_get_is_looped`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API void CF_CALL cf_sound_set_is_looped(CF_Sound sound, bool true_for_looped);
 
@@ -431,16 +443,28 @@ CF_API void CF_CALL cf_sound_set_is_looped(CF_Sound sound, bool true_for_looped)
  * @param    sound      The sound.
  * @param    volume     A value from 0.0f to 1.0f. 0.0f meaning silent, 1.0f meaning max volume.
  * @remarks  You can get a sound's volume with `cf_sound_get_volume`.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API void CF_CALL cf_sound_set_volume(CF_Sound sound, float volume);
+
+/**
+ * @function cf_sound_set_pan
+ * @category audio
+ * @brief    Sets the stereo pan for the sound.
+ * @param    sound  The sound.
+ * @param    pan    A value from 0.0f to 1.0f. 0.0f means left speaker, 1.0f means right speaker, 0.5f means equal both.
+ * @remarks  You can get a sound's pan with `cf_sound_get_pan`. Use this to move a playing sound across the stereo field,
+ *           for example when an object moves from left to right on screen.
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
+ */
+CF_API void CF_CALL cf_sound_set_pan(CF_Sound sound, float pan);
 
 /**
  * @function cf_sound_set_pitch
  * @category audio
  * @brief    Sets pitch for the sound.
  * @remarks  Defaults to 1.0f.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API void CF_CALL cf_sound_set_pitch(CF_Sound sound, float pitch);
 
@@ -452,7 +476,7 @@ CF_API void CF_CALL cf_sound_set_pitch(CF_Sound sound, float pitch);
  * @param    time_in_seconds  The playback position to seek to, in seconds.
  * @remarks  You can get a sound's playback time with `cf_sound_get_time`. This can be useful to sync a dynamic audio system that
  *           can turn on/off different instruments or sounds.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API CF_Result CF_CALL cf_sound_set_time(CF_Sound sound, double time_in_seconds);
 
@@ -460,7 +484,7 @@ CF_API CF_Result CF_CALL cf_sound_set_time(CF_Sound sound, double time_in_second
  * @function cf_sound_stop
  * @category audio
  * @brief    Stops the sound instance so it no longer plays.
- * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_stop cf_sound_set_pitch
+ * @related  CF_SoundParams CF_Sound cf_sound_params_defaults cf_play_sound cf_sound_is_active cf_sound_get_is_paused cf_sound_get_is_looped cf_sound_get_volume cf_sound_get_pan cf_sound_get_time cf_sound_set_time cf_sound_set_is_paused cf_sound_set_is_looped cf_sound_set_volume cf_sound_set_pan cf_sound_stop cf_sound_set_pitch
  */
 CF_API void CF_CALL cf_sound_stop(CF_Sound sound);
 
@@ -517,11 +541,13 @@ CF_INLINE bool sound_is_active(CF_Sound sound) { return cf_sound_is_active(sound
 CF_INLINE bool sound_get_is_paused(CF_Sound sound) { return cf_sound_get_is_paused(sound); }
 CF_INLINE bool sound_get_is_looped(CF_Sound sound) { return cf_sound_get_is_looped(sound); }
 CF_INLINE float sound_get_volume(CF_Sound sound) { return cf_sound_get_volume(sound); }
+CF_INLINE float sound_get_pan(CF_Sound sound) { return cf_sound_get_pan(sound); }
 CF_INLINE float sound_get_pitch(CF_Sound sound) { return cf_sound_get_pitch(sound); }
 CF_INLINE double sound_get_time(CF_Sound sound) { return cf_sound_get_time(sound); }
 CF_INLINE void sound_set_is_paused(CF_Sound sound, bool true_for_paused) { cf_sound_set_is_paused(sound, true_for_paused); }
 CF_INLINE void sound_set_is_looped(CF_Sound sound, bool true_for_looped) { cf_sound_set_is_looped(sound, true_for_looped); }
 CF_INLINE void sound_set_volume(CF_Sound sound, float volume) { cf_sound_set_volume(sound, volume); }
+CF_INLINE void sound_set_pan(CF_Sound sound, float pan) { cf_sound_set_pan(sound, pan); }
 CF_INLINE void sound_set_pitch(CF_Sound sound, float pitch = 1.0f) { cf_sound_set_pitch(sound, pitch); }
 CF_INLINE CF_Result sound_set_time(CF_Sound sound, double time_in_seconds) { return cf_sound_set_time(sound, time_in_seconds); }
 CF_INLINE void sound_stop(CF_Sound sound) { cf_sound_stop(sound); }

--- a/libraries/cute/cute_sound.h
+++ b/libraries/cute/cute_sound.h
@@ -85,6 +85,7 @@
 		                * Removed cs_cull_duplicates (better handled user-side).
 		                * Fixed music fade to incorporate user volume.
 		                * WAV loader now supports 8/16/24/32-bit PCM and 32/64-bit float.
+		3.01 (07/17/2026) Ramp per-sound gain across mix buffers when pan/volume change to avoid zipper clicks.
 
 
 	CONTRIBUTORS
@@ -880,6 +881,10 @@ typedef struct cs_sound_inst_t
 	float volume;
 	float pan0;
 	float pan1;
+	// Last gains applied by the mixer. Used to ramp toward the next target
+	// so abrupt pan/volume changes don't click (zipper noise).
+	float mixed_vA;
+	float mixed_vB;
 	float pitch;
 	double sample_index;
 	cs_audio_source_t* audio;
@@ -1236,8 +1241,31 @@ static inline cs__m128i cs_mm_floor_epi32(cs__m128 v)
 	return cs_mm_sub_epi32(trunc, adjust);
 }
 
+// Build a 4-wide gain vector ramping from g0 to g1 across samples j..j+3 of a
+// samples_to_write-long stretch. Lanes are in low-to-high memory order.
+static inline cs__m128 cs_ramp_gains(float g0, float g1, int j, int samples_to_write)
+{
+	if (g0 == g1 || samples_to_write <= 1) {
+		return cs_mm_set1_ps(g0);
+	}
+	float denom = (float)samples_to_write;
+	float d = g1 - g0;
+	// t = (sample + 0.5) / N so each lane sits at the center of its sample.
+	float t0 = ((float)j + 0.5f) / denom;
+	float t1 = ((float)j + 1.5f) / denom;
+	float t2 = ((float)j + 2.5f) / denom;
+	float t3 = ((float)j + 3.5f) / denom;
+	if (t0 > 1.0f) t0 = 1.0f;
+	if (t1 > 1.0f) t1 = 1.0f;
+	if (t2 > 1.0f) t2 = 1.0f;
+	if (t3 > 1.0f) t3 = 1.0f;
+	// set_ps(e3,e2,e1,e0) -> memory [e0,e1,e2,e3]
+	return cs_mm_set_ps(g0 + d * t3, g0 + d * t2, g0 + d * t1, g0 + d * t0);
+}
+
 // Mix with pitch shifting (resampling with linear interpolation).
-static void cs_mix_pitched(cs_audio_source_t* audio, cs__m128 vA, cs__m128 vB, int write_offset_wide, int write_wide, float pitch, double sample_index, bool looped)
+// vA0/vB0 ramp to vA1/vB1 across samples_to_write output samples.
+static void cs_mix_pitched(cs_audio_source_t* audio, float vA0, float vB0, float vA1, float vB1, int samples_to_write, int write_offset_wide, int write_wide, float pitch, double sample_index, bool looped)
 {
 	cs__m128* floatA = s_ctx->floatA;
 	cs__m128* floatB = s_ctx->floatB;
@@ -1286,6 +1314,8 @@ static void cs_mix_pitched(cs_audio_source_t* audio, cs__m128 vA, cs__m128 vB, i
 			);
 		}
 		cs__m128 A = cs_mm_add_ps(loA, cs_mm_mul_ps(index_frac, cs_mm_sub_ps(hiA, loA)));
+		cs__m128 vA = cs_ramp_gains(vA0, vA1, j, samples_to_write);
+		cs__m128 vB = cs_ramp_gains(vB0, vB1, j, samples_to_write);
 
 		if (audio->channel_count == 2) {
 			cs__m128 loB, hiB;
@@ -1334,22 +1364,47 @@ static void cs_mix_pitched(cs_audio_source_t* audio, cs__m128 vA, cs__m128 vB, i
 #undef CS_WRAP_SAMPLE
 
 // Mix without pitch shifting (direct copy with volume).
-static void cs_mix_simple(cs_audio_source_t* audio, cs__m128 vA, cs__m128 vB, int write_offset_wide, int write_wide, int sample_index_wide)
+// vA0/vB0 ramp to vA1/vB1 across samples_to_write output samples.
+static void cs_mix_simple(cs_audio_source_t* audio, float vA0, float vB0, float vA1, float vB1, int samples_to_write, int write_offset_wide, int write_wide, int sample_index_wide)
 {
 	cs__m128* floatA = s_ctx->floatA;
 	cs__m128* floatB = s_ctx->floatB;
 	cs__m128* cA = (cs__m128*)audio->channels[0];
 	cs__m128* cB = (cs__m128*)audio->channels[1];
+	bool constant = (vA0 == vA1 && vB0 == vB1);
 
-	if (audio->channel_count == 2) {
-		for (int i = 0; i < write_wide; ++i) {
+	if (constant) {
+		cs__m128 vA = cs_mm_set1_ps(vA0);
+		cs__m128 vB = cs_mm_set1_ps(vB0);
+		if (audio->channel_count == 2) {
+			for (int i = 0; i < write_wide; ++i) {
+				cs__m128 A = cs_mm_mul_ps(cA[i + sample_index_wide], vA);
+				cs__m128 B = cs_mm_mul_ps(cB[i + sample_index_wide], vB);
+				floatA[i + write_offset_wide] = cs_mm_add_ps(floatA[i + write_offset_wide], A);
+				floatB[i + write_offset_wide] = cs_mm_add_ps(floatB[i + write_offset_wide], B);
+			}
+		} else {
+			for (int i = 0; i < write_wide; ++i) {
+				cs__m128 A = cA[i + sample_index_wide];
+				cs__m128 B = cs_mm_mul_ps(A, vB);
+				A = cs_mm_mul_ps(A, vA);
+				floatA[i + write_offset_wide] = cs_mm_add_ps(floatA[i + write_offset_wide], A);
+				floatB[i + write_offset_wide] = cs_mm_add_ps(floatB[i + write_offset_wide], B);
+			}
+		}
+	} else if (audio->channel_count == 2) {
+		for (int i = 0, j = 0; i < write_wide; ++i, j += 4) {
+			cs__m128 vA = cs_ramp_gains(vA0, vA1, j, samples_to_write);
+			cs__m128 vB = cs_ramp_gains(vB0, vB1, j, samples_to_write);
 			cs__m128 A = cs_mm_mul_ps(cA[i + sample_index_wide], vA);
 			cs__m128 B = cs_mm_mul_ps(cB[i + sample_index_wide], vB);
 			floatA[i + write_offset_wide] = cs_mm_add_ps(floatA[i + write_offset_wide], A);
 			floatB[i + write_offset_wide] = cs_mm_add_ps(floatB[i + write_offset_wide], B);
 		}
 	} else {
-		for (int i = 0; i < write_wide; ++i) {
+		for (int i = 0, j = 0; i < write_wide; ++i, j += 4) {
+			cs__m128 vA = cs_ramp_gains(vA0, vA1, j, samples_to_write);
+			cs__m128 vB = cs_ramp_gains(vB0, vB1, j, samples_to_write);
 			cs__m128 A = cA[i + sample_index_wide];
 			cs__m128 B = cs_mm_mul_ps(A, vB);
 			A = cs_mm_mul_ps(A, vA);
@@ -1411,16 +1466,18 @@ static void cs_mix(int bytes_to_write)
 
 			CUTE_SOUND_ASSERT(audio->channels[0]);
 
-			// Calculate volume.
-			float vA0, vB0;
-			cs_calc_volume(playing, &vA0, &vB0);
-			cs__m128 vA = cs_mm_set1_ps(vA0);
-			cs__m128 vB = cs_mm_set1_ps(vB0);
+			// Target gains from current pan/volume. Ramp from last applied gains so
+			// abrupt parameter changes (e.g. fast mouse pan) don't click.
+			float vA_end, vB_end;
+			cs_calc_volume(playing, &vA_end, &vB_end);
+			float vA_start = playing->mixed_vA;
+			float vB_start = playing->mixed_vB;
 
 			// Mix samples, handling looping.
 			int samples_remaining = samples_needed;
 			int write_offset = 0;
 			bool pitched = playing->pitch != 1.0f;
+			bool did_mix = false;
 
 			while (samples_remaining > 0) {
 				// Check for end of sound before mixing.
@@ -1469,21 +1526,36 @@ static void cs_mix(int bytes_to_write)
 
 				if (samples_to_write <= 0) break;
 
+				// Gains at the start/end of this write, progressing over the full mix buffer.
+				float t0 = (float)write_offset / (float)samples_needed;
+				float t1 = (float)(write_offset + samples_to_write) / (float)samples_needed;
+				float chunk_vA0 = vA_start + (vA_end - vA_start) * t0;
+				float chunk_vB0 = vB_start + (vB_end - vB_start) * t0;
+				float chunk_vA1 = vA_start + (vA_end - vA_start) * t1;
+				float chunk_vB1 = vB_start + (vB_end - vB_start) * t1;
+
 				int write_wide = CUTE_SOUND_ALIGN(samples_to_write, 4) / 4;
 				int write_offset_wide = (int)CUTE_SOUND_ALIGN(write_offset, 4) / 4;
 				int sample_index_wide = (int)CUTE_SOUND_TRUNC((int)playing->sample_index, 4) / 4;
 
 				// Mix the samples.
 				if (pitched) {
-					cs_mix_pitched(audio, vA, vB, write_offset_wide, write_wide, playing->pitch, playing->sample_index, playing->looped);
+					cs_mix_pitched(audio, chunk_vA0, chunk_vB0, chunk_vA1, chunk_vB1, samples_to_write, write_offset_wide, write_wide, playing->pitch, playing->sample_index, playing->looped);
 				} else {
-					cs_mix_simple(audio, vA, vB, write_offset_wide, write_wide, sample_index_wide);
+					cs_mix_simple(audio, chunk_vA0, chunk_vB0, chunk_vA1, chunk_vB1, samples_to_write, write_offset_wide, write_wide, sample_index_wide);
 				}
+				did_mix = true;
 
 				// Advance by exact fractional amount.
 				playing->sample_index += (double)samples_to_write * (double)playing->pitch;
 				write_offset += samples_to_write;
 				samples_remaining -= samples_to_write;
+			}
+
+			// Commit ramped gains only if this instance is still active and mixed.
+			if (did_mix && playing->active) {
+				playing->mixed_vA = vA_end;
+				playing->mixed_vB = vB_end;
 			}
 
 			playing = next;
@@ -1936,6 +2008,7 @@ static cs_sound_inst_t* s_inst_music(cs_audio_source_t* src, float volume)
 	inst->pitch = 1.0f;
 	inst->audio = src;
 	inst->sample_index = 0;
+	cs_calc_volume(inst, &inst->mixed_vA, &inst->mixed_vB);
 	s_insert(inst);
 	return inst;
 }
@@ -1958,6 +2031,7 @@ static cs_sound_inst_t* s_inst(cs_audio_source_t* src, cs_sound_params_t params)
 	inst->audio = src;
 	inst->sample_index = params.start_time * (double)src->sample_rate;
 	CUTE_SOUND_ASSERT(inst->sample_index < (double)src->sample_count);
+	cs_calc_volume(inst, &inst->mixed_vA, &inst->mixed_vB);
 	s_insert(inst);
 	return inst;
 }

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -89,6 +89,7 @@ add_sample(hrc hrc.c)
 add_sample(canvas_readback canvas_readback.c)
 add_sample(glitch glitch.cpp)
 add_sample(customsprite custom_sprite.c)
+add_sample(sound_pan sound_pan.c)
 
 # Pre-compile shaders for certain samples.
 if (CF_CUTE_SHADERC)

--- a/samples/sound_pan.c
+++ b/samples/sound_pan.c
@@ -1,0 +1,183 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include <cute.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+// Generates a short mono sine tone as a 16-bit PCM WAV in memory.
+// Looping this gives a continuous drone so stereo pan is easy to hear.
+static CF_Audio s_make_tone_audio(float frequency_hz, float duration_seconds)
+{
+	const int sample_rate = 44100;
+	const int channels = 1;
+	const int bits_per_sample = 16;
+	int sample_count = (int)(sample_rate * duration_seconds);
+	if (sample_count < 1) sample_count = 1;
+
+	int data_bytes = sample_count * channels * (bits_per_sample / 8);
+	int total_bytes = 44 + data_bytes;
+	uint8_t* wav = (uint8_t*)cf_alloc(total_bytes);
+	memset(wav, 0, total_bytes);
+
+	// RIFF header
+	memcpy(wav + 0, "RIFF", 4);
+	*(uint32_t*)(wav + 4) = (uint32_t)(36 + data_bytes);
+	memcpy(wav + 8, "WAVE", 4);
+
+	// fmt chunk
+	memcpy(wav + 12, "fmt ", 4);
+	*(uint32_t*)(wav + 16) = 16; // PCM chunk size
+	*(uint16_t*)(wav + 20) = 1;  // PCM format
+	*(uint16_t*)(wav + 22) = (uint16_t)channels;
+	*(uint32_t*)(wav + 24) = (uint32_t)sample_rate;
+	*(uint32_t*)(wav + 28) = (uint32_t)(sample_rate * channels * bits_per_sample / 8);
+	*(uint16_t*)(wav + 32) = (uint16_t)(channels * bits_per_sample / 8);
+	*(uint16_t*)(wav + 34) = (uint16_t)bits_per_sample;
+
+	// data chunk
+	memcpy(wav + 36, "data", 4);
+	*(uint32_t*)(wav + 40) = (uint32_t)data_bytes;
+
+	int16_t* samples = (int16_t*)(wav + 44);
+	const float two_pi = 6.28318530718f;
+	const float amplitude = 0.35f; // keep headroom
+	for (int i = 0; i < sample_count; ++i) {
+		float t = (float)i / (float)sample_rate;
+		float s = sinf(two_pi * frequency_hz * t) * amplitude;
+		samples[i] = (int16_t)(s * 32767.0f);
+	}
+
+	CF_Audio audio = cf_audio_load_wav_from_memory(wav, total_bytes);
+	cf_free(wav);
+	return audio;
+}
+
+static float s_clampf(float v, float lo, float hi)
+{
+	if (v < lo) return lo;
+	if (v > hi) return hi;
+	return v;
+}
+
+static float s_pan_from_x(float x, float half_width)
+{
+	// Map world X into [0, 1]: left edge = 0, right edge = 1, center = 0.5.
+	return s_clampf((x / half_width) * 0.5f + 0.5f, 0.0f, 1.0f);
+}
+
+int main(int argc, char* argv[])
+{
+	const int W = 640;
+	const int H = 480;
+	const float half_w = 280.0f;
+
+	CF_Result result = cf_make_app("Sound Pan", 0, 0, 0, W, H, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
+	if (cf_is_error(result)) return -1;
+
+	// ~1s of 220Hz — loops cleanly for continuous panning demos.
+	CF_Audio tone = s_make_tone_audio(220.0f, 1.0f);
+	if (!tone.id) {
+		printf("Failed to create tone audio.\n");
+		cf_destroy_app();
+		return -1;
+	}
+
+	CF_SoundParams params = cf_sound_params_defaults();
+	params.looped = true;
+	params.volume = 0.8f;
+	params.pan = 0.5f;
+	CF_Sound sound = cf_play_sound(tone, params);
+
+	float ship_x = 0.0f;
+	float ship_y = 0.0f;
+	bool auto_move = true;
+	float auto_t = 0.0f;
+
+	while (cf_app_is_running()) {
+		cf_app_update(NULL);
+
+		if (cf_key_just_pressed(CF_KEY_SPACE)) {
+			auto_move = !auto_move;
+		}
+
+		if (auto_move) {
+			auto_t += CF_DELTA_TIME;
+			// Slow sweep left <-> right.
+			ship_x = sinf(auto_t * 0.8f) * half_w;
+		} else {
+			CF_V2 mouse = cf_screen_to_world(cf_v2(cf_mouse_x(), cf_mouse_y()));
+			ship_x = s_clampf(mouse.x, -half_w, half_w);
+			ship_y = s_clampf(mouse.y, -120.0f, 120.0f);
+		}
+
+		float pan = s_pan_from_x(ship_x, half_w);
+		cf_sound_set_pan(sound, pan);
+
+		// --- Visuals -------------------------------------------------------
+
+		// Track line.
+		cf_draw_push_color(cf_make_color_rgb(60, 60, 80));
+		cf_draw_line(cf_v2(-half_w, 0), cf_v2(half_w, 0), 2.0f);
+		cf_draw_pop_color();
+
+		// Left / right speaker markers (filled more when that side is louder).
+		float left_gain = 1.0f - pan;
+		float right_gain = pan;
+
+		cf_draw_push_color(cf_make_color_rgba(80, 180, 255, (uint8_t)(80 + left_gain * 175)));
+		cf_draw_circle_fill2(cf_v2(-half_w - 30.0f, 0), 18.0f + left_gain * 12.0f);
+		cf_draw_pop_color();
+
+		cf_draw_push_color(cf_make_color_rgba(255, 140, 80, (uint8_t)(80 + right_gain * 175)));
+		cf_draw_circle_fill2(cf_v2(half_w + 30.0f, 0), 18.0f + right_gain * 12.0f);
+		cf_draw_pop_color();
+
+		// "Ship" body.
+		cf_draw_push_color(cf_color_white());
+		cf_draw_circle_fill2(cf_v2(ship_x, ship_y), 14.0f);
+		cf_draw_pop_color();
+		cf_draw_push_color(cf_make_color_rgb(40, 200, 120));
+		cf_draw_circle2(cf_v2(ship_x, ship_y), 14.0f, 3.0f);
+		// Nose pointing direction of travel in auto mode.
+		float nose = auto_move ? cosf(auto_t * 0.8f) : 0.0f;
+		cf_draw_line(cf_v2(ship_x, ship_y), cf_v2(ship_x + nose * 28.0f, ship_y), 3.0f);
+		cf_draw_pop_color();
+
+		// Drop a vertical guide at the ship.
+		cf_draw_push_color(cf_make_color_rgba(255, 255, 255, 40));
+		cf_draw_line(cf_v2(ship_x, -140.0f), cf_v2(ship_x, 140.0f), 1.0f);
+		cf_draw_pop_color();
+
+		// HUD text.
+		char line[128];
+		cf_push_font_size(18.0f);
+
+		snprintf(line, sizeof(line), "pan  %.2f   (0 = left, 0.5 = center, 1 = right)", pan);
+		float tw = cf_text_width(line, -1);
+		cf_draw_text(line, cf_v2(-tw * 0.5f, 180.0f), -1);
+
+		snprintf(line, sizeof(line), "get_pan  %.2f", cf_sound_get_pan(sound));
+		tw = cf_text_width(line, -1);
+		cf_draw_text(line, cf_v2(-tw * 0.5f, 155.0f), -1);
+
+		const char* mode = auto_move ? "AUTO  (Space: mouse control)" : "MOUSE  (Space: auto sweep)";
+		tw = cf_text_width(mode, -1);
+		cf_draw_text(mode, cf_v2(-tw * 0.5f, -180.0f), -1);
+
+		cf_draw_text("L", cf_v2(-half_w - 36.0f, -40.0f), -1);
+		cf_draw_text("R", cf_v2(half_w + 24.0f, -40.0f), -1);
+
+		cf_app_draw_onto_screen(true);
+	}
+
+	cf_sound_stop(sound);
+	cf_audio_destroy(tone);
+	cf_destroy_app();
+	return 0;
+}

--- a/src/cute_audio.cpp
+++ b/src/cute_audio.cpp
@@ -234,6 +234,12 @@ float cf_sound_get_volume(CF_Sound sound)
 	return cs_sound_get_volume(cssound);
 }
 
+float cf_sound_get_pan(CF_Sound sound)
+{
+	cs_playing_sound_t cssound = { sound.id };
+	return cs_sound_get_pan(cssound);
+}
+
 float cf_sound_get_pitch(CF_Sound sound)
 {
 	cs_playing_sound_t cssound = { sound.id };
@@ -262,6 +268,12 @@ void cf_sound_set_volume(CF_Sound sound, float volume)
 {
 	cs_playing_sound_t cssound = { sound.id };
 	cs_sound_set_volume(cssound, volume);
+}
+
+void cf_sound_set_pan(CF_Sound sound, float pan)
+{
+	cs_playing_sound_t cssound = { sound.id };
+	cs_sound_set_pan(cssound, pan);
 }
 
 CF_Result cf_sound_set_time(CF_Sound sound, double time_in_seconds)


### PR DESCRIPTION
## Summary

- Add `cf_sound_get_pan` / `cf_sound_set_pan` (and C++ wrappers) so a playing sound can be moved in the stereo field after `cf_play_sound` (e.g. a ship flying left-to-right).
- Add a `sound_pan` sample that pans a looped tone with auto-sweep or mouse control.
- Fix zipper clicks on fast pan/volume changes by ramping L/R mixer gains across each mix buffer in cute_sound.

## Test plan

- [ ] Build and run `./build/sound_pan`
- [ ] Confirm auto-sweep pans L↔R smoothly
- [ ] Toggle Space and move the mouse quickly; audio should track without cracks
- [ ] Smoke-check unrelated audio (volume, pitch, music) still works

> [!IMPORTANT]
> Written with assistance from Grok (xAI). I only verified the correctness of the result via the sample for the commit d94107b4b543078e5695075946c7d039d734e6b4.