### PR TITLE
Add 9-slice support for easy sprites

### DIFF
--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -34,20 +34,20 @@ CF_API void CF_CALL cf_draw_sprite(const CF_Sprite* sprite);
 /**
  * @function cf_draw_sprite_9_slice
  * @category draw
- * @brief    Draws a sprite using 9 slice, the top, left, right and bottom sides will be stretched.
- *           if no center patch uvs are defined then this defaults back to cf_draw_sprite
- * @param    sprite     The sprite.
- * @related  cf_draw_sprite cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled cf_draw_quad cf_draw_to cf_app_draw_onto_screen
+ * @brief    Draws a sprite using 9-slice; the top, left, right and bottom sides are stretched.
+ * @param    sprite  The sprite. Works with aseprite sprites (center from .ase slices), easy sprites, and premade sprites.
+ * @remarks  If no center patch is defined this falls back to `cf_draw_sprite`. For easy sprites set the center patch with `cf_sprite_set_center_patch`.
+ * @related  cf_draw_sprite cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled cf_sprite_set_center_patch cf_draw_quad cf_draw_to cf_app_draw_onto_screen
  */
 CF_API void CF_CALL cf_draw_sprite_9_slice(const CF_Sprite* sprite);
 
 /**
  * @function cf_draw_sprite_9_slice_tiled
  * @category draw
- * @brief    Draws a sprite using 9 slice, the top, left, right and bottom will be tiled.
- *           if no center patch uvs are defined then this defaults back to cf_draw_sprite
- * @param    sprite     The sprite.
- * @related  cf_draw_sprite cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled cf_draw_quad cf_draw_to cf_app_draw_onto_screen
+ * @brief    Draws a sprite using 9-slice; the top, left, right and bottom sides are tiled.
+ * @param    sprite  The sprite. Works with aseprite sprites (center from .ase slices), easy sprites, and premade sprites.
+ * @remarks  If no center patch is defined this falls back to `cf_draw_sprite`. For easy sprites set the center patch with `cf_sprite_set_center_patch`.
+ * @related  cf_draw_sprite cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled cf_sprite_set_center_patch cf_draw_quad cf_draw_to cf_app_draw_onto_screen
  */
 CF_API void CF_CALL cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite);
 

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -110,7 +110,7 @@ typedef struct CF_Sprite
 	/* @member For internal use -- Cached pivot of the current frame (set by cf_sprite_update / cf_sprite_play). */
 	CF_V2 _pivot;
 
-	/* @member For internal use -- Cached center patch of the current frame for 9-slice (set by cf_sprite_update / cf_sprite_play). */
+	/* @member Cached center patch of the current frame for 9-slice. Set from .ase slice data by `cf_sprite_update` / `cf_sprite_play`, or manually via `cf_sprite_set_center_patch` (required for easy sprites). */
 	CF_Aabb _center_patch;
 
 	/* @member Scale factor for the sprite when drawing. Default of `(1, 1)`. See `cf_draw_sprite`. */
@@ -369,6 +369,27 @@ CF_INLINE float cf_sprite_get_scale_y(CF_Sprite* sprite) { CF_ASSERT(sprite); re
  * @related  CF_Sprite cf_sprite_get_scale_x cf_sprite_get_scale_y cf_sprite_set_scale_x cf_sprite_set_scale_y cf_sprite_set_scale
  */
 CF_INLINE void cf_sprite_set_scale(CF_Sprite* sprite, CF_V2 scale) { CF_ASSERT(sprite); sprite->scale = scale; }
+
+/**
+ * @function cf_sprite_set_center_patch
+ * @category sprite
+ * @brief    Sets the 9-slice center patch in pixel coordinates.
+ * @param    sprite        The sprite.
+ * @param    center_patch  AABB of the stretchable/tileable center region in pixels (min = top-left of the center, max = bottom-right), matching Aseprite 9-slice center rects.
+ * @remarks  Easy sprites have no .ase slice data, so you must call this before `cf_draw_sprite_9_slice` or `cf_draw_sprite_9_slice_tiled`. A zero AABB falls back to `cf_draw_sprite`. For aseprite sprites, `cf_sprite_update` / `cf_sprite_play` overwrite this from the asset's slice data.
+ * @related  CF_Sprite cf_sprite_get_center_patch cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled
+ */
+CF_INLINE void cf_sprite_set_center_patch(CF_Sprite* sprite, CF_Aabb center_patch) { CF_ASSERT(sprite); sprite->_center_patch = center_patch; }
+
+/**
+ * @function cf_sprite_get_center_patch
+ * @category sprite
+ * @brief    Returns the sprite's 9-slice center patch in pixel coordinates.
+ * @param    sprite  The sprite.
+ * @return   The center patch AABB. A zero AABB means 9-slice falls back to `cf_draw_sprite`.
+ * @related  CF_Sprite cf_sprite_set_center_patch cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled
+ */
+CF_INLINE CF_Aabb cf_sprite_get_center_patch(const CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->_center_patch; }
 
 /**
  * @function cf_sprite_set_scale_x
@@ -725,6 +746,8 @@ CF_INLINE float sprite_get_scale_y(CF_Sprite* sprite) { return cf_sprite_get_sca
 CF_INLINE void sprite_set_scale(CF_Sprite* sprite, CF_V2 scale) { cf_sprite_set_scale(sprite, scale); }
 CF_INLINE void sprite_set_scale_x(CF_Sprite* sprite, float x) { cf_sprite_set_scale_x(sprite, x); }
 CF_INLINE void sprite_set_scale_y(CF_Sprite* sprite, float y) { cf_sprite_set_scale_y(sprite, y); }
+CF_INLINE void sprite_set_center_patch(CF_Sprite* sprite, CF_Aabb center_patch) { cf_sprite_set_center_patch(sprite, center_patch); }
+CF_INLINE CF_Aabb sprite_get_center_patch(const CF_Sprite* sprite) { return cf_sprite_get_center_patch(sprite); }
 CF_INLINE float sprite_get_offset_x(CF_Sprite* sprite) { return cf_sprite_get_offset_x(sprite); }
 CF_INLINE float sprite_get_offset_y(CF_Sprite* sprite) { return cf_sprite_get_offset_y(sprite); }
 CF_INLINE void sprite_set_offset_x(CF_Sprite* sprite, float offset) { cf_sprite_set_offset_x(sprite, offset); }
@@ -765,6 +788,8 @@ CF_INLINE float sprite_get_scale_y(CF_Sprite& sprite) { return cf_sprite_get_sca
 CF_INLINE void sprite_set_scale(CF_Sprite& sprite, CF_V2 scale) { cf_sprite_set_scale(&sprite, scale); }
 CF_INLINE void sprite_set_scale_x(CF_Sprite& sprite, float x) { cf_sprite_set_scale_x(&sprite, x); }
 CF_INLINE void sprite_set_scale_y(CF_Sprite& sprite, float y) { cf_sprite_set_scale_y(&sprite, y); }
+CF_INLINE void sprite_set_center_patch(CF_Sprite& sprite, CF_Aabb center_patch) { cf_sprite_set_center_patch(&sprite, center_patch); }
+CF_INLINE CF_Aabb sprite_get_center_patch(const CF_Sprite& sprite) { return cf_sprite_get_center_patch(&sprite); }
 CF_INLINE float sprite_get_offset_x(CF_Sprite& sprite) { return cf_sprite_get_offset_x(&sprite); }
 CF_INLINE float sprite_get_offset_y(CF_Sprite& sprite) { return cf_sprite_get_offset_y(&sprite); }
 CF_INLINE void sprite_set_offset_x(CF_Sprite& sprite, float offset) { cf_sprite_set_offset_x(&sprite, offset); }

--- a/include/cute_sprite.h
+++ b/include/cute_sprite.h
@@ -375,7 +375,7 @@ CF_INLINE void cf_sprite_set_scale(CF_Sprite* sprite, CF_V2 scale) { CF_ASSERT(s
  * @category sprite
  * @brief    Sets the 9-slice center patch in pixel coordinates.
  * @param    sprite        The sprite.
- * @param    center_patch  AABB of the stretchable/tileable center region in pixels (min = top-left of the center, max = bottom-right), matching Aseprite 9-slice center rects.
+ * @param    center_patch  AABB of the stretchable/tileable center region in sprite pixels. Uses the same layout as Aseprite 9-slice center rects and as returned by `cf_sprite_get_center_patch` for `.ase` sprites: `min` is the top-left of the center, `max` is the bottom-right, with the origin at the top-left of the sprite (Y increases downward).
  * @remarks  Easy sprites have no .ase slice data, so you must call this before `cf_draw_sprite_9_slice` or `cf_draw_sprite_9_slice_tiled`. A zero AABB falls back to `cf_draw_sprite`. For aseprite sprites, `cf_sprite_update` / `cf_sprite_play` overwrite this from the asset's slice data.
  * @related  CF_Sprite cf_sprite_get_center_patch cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled
  */
@@ -386,7 +386,7 @@ CF_INLINE void cf_sprite_set_center_patch(CF_Sprite* sprite, CF_Aabb center_patc
  * @category sprite
  * @brief    Returns the sprite's 9-slice center patch in pixel coordinates.
  * @param    sprite  The sprite.
- * @return   The center patch AABB. A zero AABB means 9-slice falls back to `cf_draw_sprite`.
+ * @return   The center patch AABB (`min` = top-left of center, `max` = bottom-right, origin at sprite top-left, Y down). A zero AABB means 9-slice falls back to `cf_draw_sprite`.
  * @related  CF_Sprite cf_sprite_set_center_patch cf_draw_sprite_9_slice cf_draw_sprite_9_slice_tiled
  */
 CF_INLINE CF_Aabb cf_sprite_get_center_patch(const CF_Sprite* sprite) { CF_ASSERT(sprite); return sprite->_center_patch; }

--- a/libraries/cute/cute_spritebatch.h
+++ b/libraries/cute/cute_spritebatch.h
@@ -1050,6 +1050,11 @@ spritebatch_sprite_t spritebatch_fetch(spritebatch_t* sb, SPRITEBATCH_U64 image_
 			}
 		}
 		else {
+			// Lonely textures live in 0..1 UV space; fetch returns the full image.
+			s.minx = 0;
+			s.miny = 0;
+			s.maxx = 1.0f;
+			s.maxy = 1.0f;
 			spritebatch_internal_lonely_sprite(sb, image_id, w, h, &s, 0);
 		}
 	}
@@ -1185,8 +1190,9 @@ int spritebatch_internal_lonely_sprite(spritebatch_t* sb, SPRITEBATCH_U64 image_
 
 		if (sprite_out) {
 			sprite_out->texture_id = tex->texture_id;
-			sprite_out->minx = sprite_out->miny = 0;
-			sprite_out->maxx = sprite_out->maxy = 1.0f;
+			// Preserve local UVs already set by the caller (0..1 texture space for lonely
+			// textures). 9-slice and other partial-UV draws depend on this. Callers that
+			// want the full texture (e.g. spritebatch_fetch) should set 0..1 first.
 
 			if (SPRITEBATCH_LONELY_FLIP_Y_AXIS_FOR_UV)
 			{

--- a/samples/9_slice.c
+++ b/samples/9_slice.c
@@ -1,12 +1,30 @@
 #include <cute.h>
 #include <dcimgui.h>
 
+// Demonstrates 9-slice for both aseprite sprites (center patch from .ase slices)
+// and easy sprites (center patch via cf_sprite_set_center_patch).
+// ASE (left) and easy (right) share the same art and controls for comparison.
+// Easy frames are built from the ASE pixel data via cf_sprite_get_pixels — no separate PNGs.
+
 void mount_content_directory_as(const char* dir)
 {
 	char* path = cf_path_normalize(cf_fs_get_base_directory());
-	path = cf_string_append(path, "/9_slice_data");
-	cf_fs_mount(path, dir, false);
-	cf_string_free(path);
+	char* mounted = cf_string_append(path, "/9_slice_data");
+	cf_fs_mount(mounted, dir, false);
+	cf_string_free(mounted);
+}
+
+// Build an easy sprite from one frame of an ASE animation (same pixels as the .ase).
+static CF_Sprite make_easy_from_ase_frame(CF_Sprite* ase, const char* animation)
+{
+	CF_Image img = cf_sprite_get_pixels(ase, 0, animation, 0);
+	CF_Sprite easy = cf_make_easy_sprite_from_pixels(img.pix, img.w, img.h);
+	cf_image_free(&img);
+
+	// Copy the 9-slice center patch the ASE loader read from the slice data.
+	cf_sprite_play(ase, animation);
+	cf_sprite_set_center_patch(&easy, cf_sprite_get_center_patch(ase));
+	return easy;
 }
 
 int main(int argc, char* argv[])
@@ -16,19 +34,33 @@ int main(int argc, char* argv[])
 
 	cf_app_init_imgui();
 
-	CF_Sprite sprite = cf_make_sprite("/9_slice.ase");
-	
+	CF_Sprite ase = cf_make_sprite("/9_slice.ase");
+
+	int animation_count = cf_sprite_animation_count(&ase);
+	const char** animation_names = NULL;
+	for (int i = 0; i < animation_count; i++) {
+		apush(animation_names, cf_sprite_animation_name_at(&ase, i));
+	}
+	int animation_index = 0;
+
+	// One easy sprite per ASE animation frame (pixels pulled from the .ase).
+	CF_Sprite* easy = NULL;
+	afit(easy, animation_count);
+	for (int i = 0; i < animation_count; i++) {
+		apush(easy, make_easy_from_ase_frame(&ase, animation_names[i]));
+	}
+	if (animation_count > 0) {
+		cf_sprite_play(&ase, animation_names[0]);
+	}
+
 	CF_Sprite demo = cf_make_demo_sprite();
 	cf_sprite_play(&demo, "spin");
 	float rotation = 0.0f;
 	bool is_tiled = false;
 
-	int animation_count = cf_sprite_animation_count(&sprite);
-	const char** animation_names = NULL;
-	for (int i = 0; i < animation_count; i++) {
-		apush(animation_names, cf_sprite_animation_name_at(&sprite, i));
-	}
-	int animation_index = 0;
+	// Shared draw state for ASE and easy.
+	CF_V2 position = cf_v2(0, 0);
+	CF_V2 scale = cf_v2(1, 1);
 
 	while (cf_app_is_running()) {
 		cf_app_update(NULL);
@@ -37,23 +69,40 @@ int main(int argc, char* argv[])
 
 		cf_sprite_update(&demo);
 
+		ase.transform.p = position;
+		ase.scale = scale;
+		ase.transform.r = cf_sincos(rotation * CF_PI / 180.0f);
+
+		CF_Sprite* easy_cur = &easy[animation_index];
+		easy_cur->transform.p = position;
+		easy_cur->scale = scale;
+		easy_cur->transform.r = ase.transform.r;
+
+		// ASE left, easy right — same scale/rotation for comparison.
+		const float side_offset = 40.0f;
+		ase.transform.p.x = position.x - side_offset;
+		easy_cur->transform.p.x = position.x + side_offset;
+
 		if (is_tiled) {
-			cf_draw_sprite_9_slice_tiled(&sprite);
+			cf_draw_sprite_9_slice_tiled(&ase);
+			cf_draw_sprite_9_slice_tiled(easy_cur);
+		} else {
+			cf_draw_sprite_9_slice(&ase);
+			cf_draw_sprite_9_slice(easy_cur);
 		}
-		else {
-			cf_draw_sprite_9_slice(&sprite);
-		}
+
+		cf_draw_text("ASE", cf_v2(position.x - side_offset - 6.0f, position.y - 30.0f), -1);
+		cf_draw_text("Easy", cf_v2(position.x + side_offset - 6.0f, position.y - 30.0f), -1);
 
 		ImGui_Begin("9 Slice", NULL, ImGuiWindowFlags_None);
+		ImGui_TextWrapped("ASE (left) vs easy (right). Easy frames come from cf_sprite_get_pixels; center patch via cf_sprite_set_center_patch.");
 		if (ImGui_ComboChar("Animation", &animation_index, animation_names, animation_count)) {
-			cf_sprite_play(&sprite, animation_names[animation_index]);
+			cf_sprite_play(&ase, animation_names[animation_index]);
 		}
-
 		ImGui_Checkbox("Tiled?", &is_tiled);
-		ImGui_SliderFloat2("Position", (float*)&sprite.transform.p, -20, 20);
-		ImGui_SliderFloat2("Scale", (float*)&sprite.scale, -2, 2);
+		ImGui_SliderFloat2("Position", (float*)&position, -20, 20);
+		ImGui_SliderFloat2("Scale", (float*)&scale, -2, 2);
 		ImGui_SliderFloat("Rotation", &rotation, 0, 360);
-		sprite.transform.r = cf_sincos(rotation * CF_PI / 180.0f);
 		ImGui_End();
 
 		cf_sprite_draw(&demo);
@@ -61,6 +110,10 @@ int main(int argc, char* argv[])
 		cf_app_draw_onto_screen(true);
 	}
 
+	for (int i = 0; i < asize(easy); i++) {
+		cf_easy_sprite_unload(&easy[i]);
+	}
+	afree(easy);
 	afree(animation_names);
 	cf_destroy_app();
 

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -611,34 +611,53 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	DRAW_PUSH_ITEM(s);
 }
 
-void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
+static SPRITEBATCH_U64 s_sprite_image_id(const CF_Sprite* sprite)
 {
-	CF_ASSERT(sprite);
-	int frame_index = sprite->frame_index;
-	SPRITEBATCH_U64 image_id = 0;
-
 	if (sprite->id != CF_SPRITE_ID_INVALID) {
 		if (sprite->blend_index > 0) {
 			CF_SpriteAsset* asset = cf_sprite_get_asset(sprite->id);
 			const char* anim_name = sprite->animation_name;
 			const CF_Animation* anim = anim_name ? map_get(asset->animations, anim_name) : NULL;
 			int global_frame = sprite->frame_index + (anim ? anim->frame_offset : 0);
-			image_id = asset->blend_frame_ids[sprite->blend_index][global_frame];
-		} else {
-			image_id = sprite->_image_id;
+			return asset->blend_frame_ids[sprite->blend_index][global_frame];
 		}
-	} else if (sprite->easy_sprite_id >= CF_PREMADE_ID_RANGE_LO && sprite->easy_sprite_id <= CF_PREMADE_ID_RANGE_HI) {
-		CF_ASSERT(!"Not implemented yet.");
-	} else {
-		CF_ASSERT(!"Not implemented yet.");
+		return sprite->_image_id;
 	}
+	return sprite->easy_sprite_id;
+}
 
-	// revert back to default cf_draw since center patch is 0
+// Remap local 0..1 UVs into a premade atlas sub-image's absolute UVs.
+static void s_remap_premade_uvs(CF_AtlasSubImage sub, CF_V2* uv0, CF_V2* uv1, int count)
+{
+	float dx = sub.maxx - sub.minx;
+	float dy = sub.maxy - sub.miny;
+	for (int i = 0; i < count; ++i) {
+		uv0[i].x = dx * uv0[i].x + sub.minx;
+		uv0[i].y = dy * uv0[i].y + sub.miny;
+		uv1[i].x = dx * uv1[i].x + sub.minx;
+		uv1[i].y = dy * uv1[i].y + sub.miny;
+	}
+}
+
+void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
+{
+	CF_ASSERT(sprite);
+
+	// No center patch — fall back to a normal sprite draw (ase, easy, and premade).
 	CF_Aabb center_patch = sprite->_center_patch;
 	if (center_patch.min.x == 0.0f && center_patch.min.y == 0.0f &&
 		center_patch.max.x == 0.0f && center_patch.max.y == 0.0f) {
 		cf_draw_sprite(sprite);
 		return;
+	}
+
+	SPRITEBATCH_U64 image_id = s_sprite_image_id(sprite);
+	bool is_premade = sprite->id == CF_SPRITE_ID_INVALID
+		&& sprite->easy_sprite_id >= CF_PREMADE_ID_RANGE_LO
+		&& sprite->easy_sprite_id <= CF_PREMADE_ID_RANGE_HI;
+	CF_AtlasSubImage premade_sub = { 0 };
+	if (is_premade) {
+		premade_sub = s_draw->premade_sub_image_id_to_sub_image.find(sprite->easy_sprite_id);
 	}
 
 	float left = center_patch.min.x;
@@ -648,8 +667,7 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 
 	CF_V2 center_uv0 = cf_v2(left / sprite->w, bottom / sprite->h);
 	CF_V2 center_uv1 = cf_v2(right / sprite->w, top / sprite->h);
-	CF_V2 center_uv_size = center_uv1 - center_uv0;
-	
+
 	right = sprite->w - right;
 	top = sprite->h - top;
 
@@ -684,6 +702,10 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 		cf_v2(center_uv1.x, center_uv0.y),
 		cf_v2(1.0f        , center_uv0.y),
 	};
+
+	if (is_premade) {
+		s_remap_premade_uvs(premade_sub, uvs0, uvs1, 9);
+	}
 
 	// inner pieces needs to be scaled down by the sprite scale since we're operating in local quad space
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
@@ -811,31 +833,22 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 {
 	CF_ASSERT(sprite);
-	int frame_index = sprite->frame_index;
-	SPRITEBATCH_U64 image_id = 0;
 
-	if (sprite->id != CF_SPRITE_ID_INVALID) {
-		if (sprite->blend_index > 0) {
-			CF_SpriteAsset* asset = cf_sprite_get_asset(sprite->id);
-			const char* anim_name = sprite->animation_name;
-			const CF_Animation* anim = anim_name ? map_get(asset->animations, anim_name) : NULL;
-			int global_frame = sprite->frame_index + (anim ? anim->frame_offset : 0);
-			image_id = asset->blend_frame_ids[sprite->blend_index][global_frame];
-		} else {
-			image_id = sprite->_image_id;
-		}
-	} else if (sprite->easy_sprite_id >= CF_PREMADE_ID_RANGE_LO && sprite->easy_sprite_id <= CF_PREMADE_ID_RANGE_HI) {
-		CF_ASSERT(!"Not implemented yet.");
-	} else {
-		CF_ASSERT(!"Not implemented yet.");
-	}
-
-	// revert back to default cf_draw since center patch is 0
+	// No center patch — fall back to a normal sprite draw (ase, easy, and premade).
 	CF_Aabb center_patch = sprite->_center_patch;
 	if (center_patch.min.x == 0.0f && center_patch.min.y == 0.0f &&
 		center_patch.max.x == 0.0f && center_patch.max.y == 0.0f) {
 		cf_draw_sprite(sprite);
 		return;
+	}
+
+	SPRITEBATCH_U64 image_id = s_sprite_image_id(sprite);
+	bool is_premade = sprite->id == CF_SPRITE_ID_INVALID
+		&& sprite->easy_sprite_id >= CF_PREMADE_ID_RANGE_LO
+		&& sprite->easy_sprite_id <= CF_PREMADE_ID_RANGE_HI;
+	CF_AtlasSubImage premade_sub = { 0 };
+	if (is_premade) {
+		premade_sub = s_draw->premade_sub_image_id_to_sub_image.find(sprite->easy_sprite_id);
 	}
 
 	float left = center_patch.min.x;
@@ -845,7 +858,6 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 
 	CF_V2 center_uv0 = cf_v2(left / sprite->w, bottom / sprite->h);
 	CF_V2 center_uv1 = cf_v2(right / sprite->w, top / sprite->h);
-	CF_V2 center_uv_size = center_uv1 - center_uv0;
 
 	right = sprite->w - right;
 	top = sprite->h - top;
@@ -880,6 +892,10 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 		cf_v2(1.0f        , center_uv0.y),
 	};
 
+	if (is_premade) {
+		s_remap_premade_uvs(premade_sub, uvs0, uvs1, 9);
+	}
+
 	// inner pieces needs to be scaled down by the sprite scale since we're operating in local quad space
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
 	float full_width   = CF_FABSF(sprite->w * sprite->scale.x);
@@ -888,9 +904,9 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 	float inner_right  = right / full_width;
 	float inner_top    = top / full_height;
 	float inner_bottom = bottom / full_height;
-	
+
 	// tiled sizes in local space
-	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width, 
+	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width,
 								(center_patch.max.y - center_patch.min.y) / full_height);
 
 	CF_V2 quads[9][4] = {

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -660,16 +660,22 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 		premade_sub = s_draw->premade_sub_image_id_to_sub_image.find(sprite->easy_sprite_id);
 	}
 
+	// Center patch edges in Aseprite pixel space (origin top-left of sprite, Y down):
+	// min = top-left of center, max = bottom-right of center.
 	float left = center_patch.min.x;
 	float right = center_patch.max.x;
-	float bottom = center_patch.min.y;
-	float top = center_patch.max.y;
+	float min_y = center_patch.min.y;
+	float max_y = center_patch.max.y;
 
-	CF_V2 center_uv0 = cf_v2(left / sprite->w, bottom / sprite->h);
-	CF_V2 center_uv1 = cf_v2(right / sprite->w, top / sprite->h);
+	CF_V2 center_uv0 = cf_v2(left / sprite->w, min_y / sprite->h);
+	CF_V2 center_uv1 = cf_v2(right / sprite->w, max_y / sprite->h);
 
-	right = sprite->w - right;
-	top = sprite->h - top;
+	// Horizontal border thicknesses from each sprite edge to the center.
+	float left_border = left;
+	float right_border = sprite->w - right;
+	// Vertical strip sizes fed into geometry (same mapping as the previous top/bottom locals).
+	float strip_from_max_y = sprite->h - max_y;
+	float strip_from_min_y = min_y;
 
 	CF_V2 uvs0[] = {
 		// top row
@@ -711,10 +717,10 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
 	float full_width   = CF_FABSF(sprite->w * sprite->scale.x);
 	float full_height  = CF_FABSF(sprite->h * sprite->scale.y);
-	float inner_left   = left / full_width;
-	float inner_right  = right / full_width;
-	float inner_top    = top / full_height;
-	float inner_bottom = bottom / full_height;
+	float inner_left   = left_border / full_width;
+	float inner_right  = right_border / full_width;
+	float inner_top    = strip_from_max_y / full_height;
+	float inner_bottom = strip_from_min_y / full_height;
 
 	CF_V2 quads[9][4] = {
 		// top row
@@ -851,16 +857,22 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 		premade_sub = s_draw->premade_sub_image_id_to_sub_image.find(sprite->easy_sprite_id);
 	}
 
+	// Center patch edges in Aseprite pixel space (origin top-left of sprite, Y down):
+	// min = top-left of center, max = bottom-right of center.
 	float left = center_patch.min.x;
 	float right = center_patch.max.x;
-	float bottom = center_patch.min.y;
-	float top = center_patch.max.y;
+	float min_y = center_patch.min.y;
+	float max_y = center_patch.max.y;
 
-	CF_V2 center_uv0 = cf_v2(left / sprite->w, bottom / sprite->h);
-	CF_V2 center_uv1 = cf_v2(right / sprite->w, top / sprite->h);
+	CF_V2 center_uv0 = cf_v2(left / sprite->w, min_y / sprite->h);
+	CF_V2 center_uv1 = cf_v2(right / sprite->w, max_y / sprite->h);
 
-	right = sprite->w - right;
-	top = sprite->h - top;
+	// Horizontal border thicknesses from each sprite edge to the center.
+	float left_border = left;
+	float right_border = sprite->w - right;
+	// Vertical strip sizes fed into geometry (same mapping as the previous top/bottom locals).
+	float strip_from_max_y = sprite->h - max_y;
+	float strip_from_min_y = min_y;
 
 	CF_V2 uvs0[] = {
 		// top row
@@ -900,10 +912,10 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 	// otherwise we end up with just a normal scaled up sprite instead of a 9 slice one
 	float full_width   = CF_FABSF(sprite->w * sprite->scale.x);
 	float full_height  = CF_FABSF(sprite->h * sprite->scale.y);
-	float inner_left   = left / full_width;
-	float inner_right  = right / full_width;
-	float inner_top    = top / full_height;
-	float inner_bottom = bottom / full_height;
+	float inner_left   = left_border / full_width;
+	float inner_right  = right_border / full_width;
+	float inner_top    = strip_from_max_y / full_height;
+	float inner_bottom = strip_from_min_y / full_height;
 
 	// tiled sizes in local space
 	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width,

--- a/test/test_sprite.cpp
+++ b/test/test_sprite.cpp
@@ -45,8 +45,38 @@ TEST_CASE(test_easy_sprite_unload)
 	return true;
 }
 
+/* Easy sprites store a user-defined 9-slice center patch. */
+TEST_CASE(test_easy_sprite_center_patch)
+{
+	CHECK(cf_is_error(cf_make_app(NULL, 0, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT | CF_APP_OPTIONS_NO_GFX_BIT, NULL)));
+
+	CF_Pixel pixels[16 * 16] = { 0 };
+	CF_Sprite s = cf_make_easy_sprite_from_pixels(pixels, 16, 16);
+	REQUIRE(s.easy_sprite_id);
+
+	// Default is zero — 9-slice falls back to normal draw.
+	CF_Aabb zero = cf_sprite_get_center_patch(&s);
+	REQUIRE(zero.min.x == 0 && zero.min.y == 0 && zero.max.x == 0 && zero.max.y == 0);
+
+	CF_Aabb patch = cf_make_aabb(cf_v2(4, 4), cf_v2(12, 12));
+	cf_sprite_set_center_patch(&s, patch);
+	CF_Aabb got = cf_sprite_get_center_patch(&s);
+	REQUIRE(got.min.x == 4 && got.min.y == 4);
+	REQUIRE(got.max.x == 12 && got.max.y == 12);
+
+	// Easy sprites are single-frame; update must not clear the patch.
+	cf_sprite_update(&s);
+	got = cf_sprite_get_center_patch(&s);
+	REQUIRE(got.min.x == 4 && got.max.x == 12);
+
+	cf_easy_sprite_unload(&s);
+	cf_destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_sprite)
 {
 	RUN_TEST_CASE(test_make_sprite);
 	RUN_TEST_CASE(test_easy_sprite_unload);
+	RUN_TEST_CASE(test_easy_sprite_center_patch);
 }


### PR DESCRIPTION
## Summary

- Implement 9-slice drawing for easy sprites (and premade atlas sprites) instead of asserting "Not implemented yet"
- Add `cf_sprite_set_center_patch` / `cf_sprite_get_center_patch` so easy sprites can define a center patch (ASE sprites still load it from slice data)
- Preserve local UVs for lonely spritebatch textures so partial 9-slice UVs work before atlas packing
- Extend `samples/9_slice` to draw ASE vs easy side-by-side (easy frames from `cf_sprite_get_pixels` on the same `.ase`)
- Unit test for easy sprite center patch retention

Fixes https://github.com/RandyGaul/cute_framework/issues/394

<img width="1136" height="912" alt="image" src="https://github.com/user-attachments/assets/287bb3e9-806d-40d1-942f-f79dff394731" />


## Test plan

- [x] `./build/debug/tests` — all pass (including `test_easy_sprite_center_patch`)
- [x] Run `./build/debug/9_slice`
- [x] Confirm ASE (left) and Easy (right) match for `color_corners` / `arrows` / `boxes`
- [x] Toggle tiled, scale, rotation; both sides stay in sync
- [x] Zero center patch still falls back to normal `cf_draw_sprite`