### PR TITLE
Add mid-string font style swaps via text markup (#349)

### DIFF
--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -1069,7 +1069,10 @@ typedef bool (CF_TextEffectFn)(CF_TextEffect* fx);
  *                example : "<font name=\"MyBold\" size=48>Big bold text</font>"
  *                example : "<font size=32>Larger text, same face</font>"
  *                name    : (optional string) - Name of a font previously loaded with `cf_make_font` (or `font` as an alias key). Omit to keep the current face and only change size.
- *                size    : (optional number) - Pixel size to use for this span.
+ *                size    : (optional number) - Pixel size to use for this span. A line's height, baseline, and measured
+ *                          size (see `cf_text_size`) grow to fit the largest size on that line, so large spans stay inside
+ *                          the reported bounds and successive lines don't collide. Animated effects (wave/shake) are not
+ *                          counted in measurement. Note: vertical text (`cf_push_text_vertical_layout`) uses base-face columns.
  *           ```
  *           When registering a custom text effect, any parameters in the string will be stored for you
  *           automatically. You only need to fetch them with the appropriate cf_text_effect_get*** function.

--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -1067,7 +1067,8 @@ typedef bool (CF_TextEffectFn)(CF_TextEffect* fx);
  *                        : default (font_height / 20) - The thickness of the strike line.
  *           + font
  *                example : "<font name=\"MyBold\" size=48>Big bold text</font>"
- *                name    : (required string) - Name of a font previously loaded with `cf_make_font` (or `font` as an alias key).
+ *                example : "<font size=32>Larger text, same face</font>"
+ *                name    : (optional string) - Name of a font previously loaded with `cf_make_font` (or `font` as an alias key). Omit to keep the current face and only change size.
  *                size    : (optional number) - Pixel size to use for this span.
  *           ```
  *           When registering a custom text effect, any parameters in the string will be stored for you

--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -1065,14 +1065,50 @@ typedef bool (CF_TextEffectFn)(CF_TextEffect* fx);
  *                example : "<strike>Strikethrough</strike>"
  *                example : "<strike=10>Thick Strikethrough</strike>"
  *                        : default (font_height / 20) - The thickness of the strike line.
+ *           + font
+ *                example : "<font name=\"MyBold\" size=48>Big bold text</font>"
+ *                name    : (required string) - Name of a font previously loaded with `cf_make_font` (or `font` as an alias key).
+ *                size    : (optional number) - Pixel size to use for this span.
  *           ```
  *           When registering a custom text effect, any parameters in the string will be stored for you
  *           automatically. You only need to fetch them with the appropriate cf_text_effect_get*** function.
  *           Note: You can also setup parameters for markup as strings, not just numbers/colors. Example: `<color=#2c5ee8 metadata=\"Just some string.\">blue text</color>`,
  *           where the `color` markup contains a parameter called `metadata` and a string value of `"Just some string."`.
- * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
+ *
+ *           For bold/italic style tags, load the corresponding font faces and map them with `cf_text_effect_set_font`
+ *           (bold/italic are separate fonts, not runtime styles). Example:
+ *           ```c
+ *           cf_make_font("fonts/Calibri-Bold.ttf", "Calibri Bold");
+ *           cf_text_effect_set_font("b", "Calibri Bold");
+ *           cf_draw_text("Hello <b>bold</b> world", pos, -1);
+ *           ```
+ * @related  CF_TextEffect CF_TextEffectFn cf_text_effect_register cf_text_effect_set_font cf_text_effect_get_number cf_text_effect_get_color cf_text_effect_get_string
  */
 CF_API void CF_CALL cf_text_effect_register(const char* name, CF_TextEffectFn* fn);
+
+/**
+ * @function cf_text_effect_set_font
+ * @category text
+ * @brief    Maps a text-effect code name to a loaded font for mid-string font swaps (e.g. bold/italic).
+ * @param    effect_name  Text code name, e.g. `"b"` or `"i"`. Used as `<b>...</b>` in `cf_draw_text`.
+ * @param    font_name    Name of a font previously loaded with `cf_make_font` / `cf_make_font_from_memory`.
+ * @remarks  Bold, italic, and other styles are separate font files -- load each face, then map it here.
+ *           If `effect_name` is not yet registered, a no-op effect is registered automatically so the
+ *           markup parses and renders. Glyph metrics (advance, kerning) come from the mapped font for
+ *           that span. Nested overrides use the innermost active font. When both a mapped font and a
+ *           `<font name=...>` markup apply, later (typically inner) overrides win.
+ *
+ *           Example:
+ *           ```c
+ *           cf_make_font("fonts/MyFont-Bold.ttf", "MyFont Bold");
+ *           cf_make_font("fonts/MyFont-Italic.ttf", "MyFont Italic");
+ *           cf_text_effect_set_font("b", "MyFont Bold");
+ *           cf_text_effect_set_font("i", "MyFont Italic");
+ *           cf_draw_text("Normal, <b>bold</b>, <i>italic</i>.", position, -1);
+ *           ```
+ * @related  CF_TextEffect cf_text_effect_register cf_text_effect_set_font cf_make_font cf_draw_text
+ */
+CF_API void CF_CALL cf_text_effect_set_font(const char* effect_name, const char* font_name);
 
 /**
  * @function cf_text_effect_get_number
@@ -1936,6 +1972,7 @@ CF_INLINE v2 text_size(const char* text, int num_chars_to_render = -1) { return 
 CF_INLINE void draw_text(const char* text, v2 position, int num_chars_to_render = -1) { cf_draw_text(text, position, num_chars_to_render); }
 
 CF_INLINE void text_effect_register(const char* name, CF_TextEffectFn* fn) { cf_text_effect_register(name, fn); }
+CF_INLINE void text_effect_set_font(const char* effect_name, const char* font_name) { cf_text_effect_set_font(effect_name, font_name); }
 CF_INLINE double text_effect_get_number(const CF_TextEffect* fx, const char* key, double default_val = 0) { return cf_text_effect_get_number(fx, key, default_val); }
 CF_INLINE CF_Color text_effect_get_color(const CF_TextEffect* fx, const char* key, CF_Color default_val = cf_color_white()) { return cf_text_effect_get_color(fx, key, default_val); }
 CF_INLINE const char* text_effect_get_string(const CF_TextEffect* fx, const char* key, const char* default_val = NULL) { return cf_text_effect_get_string(fx, key, default_val); }

--- a/samples/text_drawing.cpp
+++ b/samples/text_drawing.cpp
@@ -26,6 +26,9 @@ int main(int argc, char* argv[])
 
 	draw_push_shape_aa(1.5f);
 	make_font_from_memory(proggy_data, proggy_sz, "ProggyClean");
+	// Map <b> to a second face so style tags are visible without a real bold TTF.
+	// In a game you would load "MyFont-Bold.ttf" / "MyFont-Italic.ttf" and map those.
+	text_effect_set_font("b", "ProggyClean");
 	set_fixed_timestep();
 	int draw_calls = 0;
 
@@ -78,25 +81,26 @@ int main(int argc, char* argv[])
 		draw_pop_color();
 
 		// Using font blurring for a glowing effect.
+		// Left column, above the style-tag demos and clear of the right-side gradients.
 		push_font_size(13 * 5);
 		push_font_blur(10);
-		draw_text_boxed("glowing~", V2(-200-10,-90+10));
+		draw_text_boxed("glowing~", V2(-500-10, -50+10));
 		pop_font_blur();
-		draw_text_boxed("<fade>glowing~</fade>", V2(-200,-90));
+		draw_text_boxed("<fade>glowing~</fade>", V2(-500, -50));
 
 		// Using font blurring for a shadow effect.
 		push_font_size(13 * 5);
 		push_font_blur(10);
 		draw_push_color(color_black());
-		draw_text_boxed("shadow", V2(-150-10-2.5f,-150+5));
+		draw_text_boxed("shadow", V2(-470-10-2.5f, -120+5));
 		draw_pop_color();
 		pop_font_blur();
-		draw_text_boxed("shadow", V2(-150,-150));
+		draw_text_boxed("shadow", V2(-470, -120));
 
 		// Drawing a formatted string.
 		String draws = String::fmt("Draw calls: %d", draw_calls);
 		push_font_size(13);
-		draw_text_boxed(draws.c_str(), V2(-960/2.0f + 10,-700/2.0f + 20));
+		draw_text_boxed(draws.c_str(), V2(-620.f, 400.f));
 
 		push_font_size(26);
 		draw_text_boxed("Half-rendered effect <wave>groovy</wave>", V2(-230.f, 180.f), 25);
@@ -173,6 +177,21 @@ int main(int argc, char* argv[])
 		push_font_size(30);
 		draw_text_boxed("<strike>Strikethrough on proportional font</strike>", V2(gx, gy - step*9));
 		draw_text_boxed("<wave><strike>wavy strike on proportional font</strike></wave>", V2(gx, gy - step*10));
+		pop_font_size();
+
+		// Font style tags via cf_text_effect_set_font / built-in <font> markup (#349).
+		// <b> is mapped to ProggyClean above; real bold/italic faces work the same way.
+		// Bottom-left column, below glow/shadow so the two demos never overlap.
+		push_font("Calibri");
+		push_font_size(26);
+		const float style_x = -600.f;
+		const float style_y = -230.f;
+		const float style_step = 32.f;
+		draw_text_boxed("Style tags: normal, <b>bold-mapped</b>, normal again.", V2(style_x, style_y));
+		draw_text_boxed("Inline <font name=\"ProggyClean\">monospace span</font> mid-sentence.", V2(style_x, style_y - style_step));
+		draw_text_boxed("<font name=\"ProggyClean\" size=36>Big mono</font> then <b>mapped bold</b>.", V2(style_x, style_y - style_step * 2.2f));
+		draw_text_boxed("<font name=\"ProggyClean\" size=22>nested <b>mapped</b> inside font</font>", V2(style_x, style_y - style_step * 3.5f));
+		draw_text_boxed("<wave><b>styled + wave</b></wave> and <b><color=#ffcc00>styled + color</color></b>", V2(style_x, style_y - style_step * 4.6f));
 		pop_font_size();
 
 		// Instructions

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2373,6 +2373,44 @@ static const char* s_find_end_of_line(CF_ParsedTextState* text_state, bool do_ef
 	return text + 1;
 }
 
+// Scan a single visual line [text, end_of_line) and report its vertical metrics: the
+// tallest ascent, deepest descent, and largest line-height across the per-glyph active
+// styles (base stack, or a <font size=...> / mapped-font override resolved the same way
+// as drawing). Used so a line's baseline, its line-to-line advance, and the measured
+// text box all follow the tallest style present on the line -- keeping large size spans
+// inside the reported bounds and stopping successive lines from colliding. Results are
+// in logical units (each face's metric is pre-scaled by its own pixel-height scale).
+static void s_measure_line_vmetrics(CF_ParsedTextState* text_state, bool do_effects, const char* base_font_name, CF_Font* base_font, float base_font_size, const char* text, int start_index, const char* end_of_line, float* out_ascent, float* out_descent, float* out_line_height)
+{
+	float base_scale = stbtt_ScaleForPixelHeight(&base_font->info, base_font_size);
+	float max_ascent = base_font->ascent * base_scale;
+	float min_descent = base_font->descent * base_scale; // Descent is negative; smaller == deeper.
+	float max_line_height = base_font->line_height * base_scale;
+
+	int index = start_index;
+	while (*text && text < end_of_line) {
+		int cp;
+		text = cf_string_decode_UTF8(text, &cp);
+		if (cp == '\n') break;
+
+		const char* font_name = base_font_name;
+		float font_size = base_font_size;
+		if (do_effects) s_resolve_text_style(text_state, index, &font_name, &font_size);
+		CF_Font* font = cf_font_get(font_name);
+		if (!font) font = base_font;
+
+		float s = stbtt_ScaleForPixelHeight(&font->info, font_size);
+		max_ascent = max(max_ascent, font->ascent * s);
+		min_descent = min(min_descent, font->descent * s);
+		max_line_height = max(max_line_height, font->line_height * s);
+		++index;
+	}
+
+	*out_ascent = max_ascent;
+	*out_descent = min_descent;
+	*out_line_height = max_line_height;
+}
+
 struct CF_CodeParseState
 {
 	CF_ParsedTextState* text_state;
@@ -2759,13 +2797,20 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 	}
 
 	// Gather up all state required for rendering.
-	// Base font/size drive baseline + line height so mixed-style lines stay stable.
+	// Base font/size seed each line's metrics; the active line then adopts the tallest
+	// per-glyph style on it (see s_measure_line_vmetrics) so large <font size=...> spans
+	// lower the baseline, grow the advance, and stay inside the measured box.
 	// Per-glyph font/size may differ via text-effect font overrides (see s_resolve_text_style).
 	float base_font_size = s_draw->font_sizes.last();
 	int blur = s_draw->blurs.last();
 	float wrap_w = s_draw->text_wrap_widths.last();
 	float scale = stbtt_ScaleForPixelHeight(&base_font->info, base_font_size);
 	float line_height = base_font->line_height * scale;
+	// Vertical metrics for the line currently being laid out. cur_line_height is the
+	// finishing line's advance; line_extra_ascent lowers the baseline by any ascent past
+	// the base face. Both default to the base face (used for empty lines with no glyphs).
+	float cur_line_height = line_height;
+	float line_extra_ascent = 0;
 	int cp_prev = 0;
 	int cp = 0;
 	const char* end_of_line = NULL;
@@ -2872,8 +2917,10 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			max_x = max(max_x, x);
 		} else {
 			x = position.x;
-			y -= line_height;
+			y -= cur_line_height;
 
+			// Base-descent floor for the new line; the line's own scan lowers min_y
+			// further if it turns out taller. Also covers a trailing empty line.
 			min_y = min(min_y, y + base_font->descent * scale);
 		}
 		hit_newline = true;
@@ -2898,6 +2945,8 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 		CF_DEFER(effect_cleanup());
 
 		if (cp == '\n') {
+			// Force the next line to recompute its boundary + vertical metrics.
+			end_of_line = NULL;
 			apply_newline();
 			continue;
 		}
@@ -2906,6 +2955,18 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 		// so bold/italic (or any font override) wraps at the correct visual width.
 		if (!end_of_line) {
 			end_of_line = s_find_end_of_line(text_state, do_effects, prev_text, index - 1, wrap_w);
+
+			// Establish this visual line's vertical metrics from the tallest active style
+			// on it, then lower the baseline by any extra ascent so large size spans fit
+			// under the previous line. min_y is extended for the line's deepest descent so
+			// measurement covers it. Horizontal only; vertical text keeps base-face columns.
+			if (!vertical) {
+				float line_ascent, line_descent, line_line_height;
+				s_measure_line_vmetrics(text_state, do_effects, base_font_name, base_font, base_font_size, prev_text, index - 1, end_of_line, &line_ascent, &line_descent, &line_line_height);
+				cur_line_height = line_line_height;
+				line_extra_ascent = line_ascent - base_font->ascent * scale;
+				min_y = min(min_y, (y - line_extra_ascent) + line_descent);
+			}
 		}
 
 		int finished_rendering_line = !(text < end_of_line);
@@ -2957,6 +3018,10 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 
 		// Prepare a sprite struct for rendering.
 		float xadvance = glyph->xadvance;
+		// This line's baseline, lowered by any ascent past the base face so a taller
+		// span sits under the previous line instead of overflowing above it. Equal to y
+		// for base-height lines, so ordinary text is unaffected.
+		float baseline_y = y - line_extra_ascent;
 		if (render || markups) {
 			bool visible = glyph->visible;
 			s.image_id = glyph->image_id;
@@ -2971,8 +3036,8 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			// are in logical units, so the pad must shrink by pixel_scale to match --
 			// otherwise on HiDPI the quad is stretched past the glyph's actual coverage.
 			v2 pad = V2(1,1) / app->pixel_scale;
-			v2 q0 = glyph->q0 + V2(x,y) - pad;
-			v2 q1 = glyph->q1 + V2(x,y) + pad;
+			v2 q0 = glyph->q0 + V2(x,baseline_y) - pad;
+			v2 q1 = glyph->q1 + V2(x,baseline_y) + pad;
 
 			// Apply any active custom text effects.
 			bool use_corner_colors = false;
@@ -2986,7 +3051,7 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 					effect->text_without_markups = text_state->sanitized.c_str();
 					effect->character = cp;
 					effect->index_into_effect = index - effect->index_into_string - 1;
-					effect->center = V2(x + xadvance*0.5f, y + h*0.25f);
+					effect->center = V2(x + xadvance*0.5f, baseline_y + h*0.25f);
 					effect->q0 = q0;
 					effect->q1 = q1;
 					effect->w = s.w;
@@ -3042,7 +3107,7 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			for (int i = 0; i < text_state->effects.count(); ++i) {
 				TextEffect* effect = text_state->effects + i;
 				if (effect->strike_thickness > 0) {
-					float y_mid = y + h * 0.25f + (q0.y - pre_fx_q0_y);
+					float y_mid = baseline_y + h * 0.25f + (q0.y - pre_fx_q0_y);
 					CF_Strike strike;
 					strike.p0 = V2(x, y_mid);
 					strike.p1 = V2(x + xadvance, y_mid);

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2578,7 +2578,10 @@ static void s_parse_code(CF_CodeParseState* s)
 	bool finish = s->try_next('/');
 	bool first = true;
 	while (!s->done()) {
-		const char* name = sintern(s_parse_code_name(s).c_str());
+		// A nameless tag (e.g. "<>") yields an empty String whose c_str() is NULL;
+		// sintern(NULL) would crash, so intern only a real name (matches s_parse_code_val).
+		String name_str = s_parse_code_name(s);
+		const char* name = !name_str.empty() ? sintern(name_str.c_str()) : NULL;
 		if (first) {
 			first = false;
 			code.effect_name = name;

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -2243,10 +2243,59 @@ static bool s_is_space(int cp)
 	}
 }
 
-static const char* s_find_end_of_line(CF_Font* font, const char* text, float wrap_width)
+// Resolve the active font name + size for a sanitized-string glyph index by walking
+// markup codes that cover that index. Later (typically nested/inner) overrides win.
+// Base font/size are the currently pushed stack values passed in by the caller.
+static void s_resolve_text_style(CF_ParsedTextState* text_state, int glyph_index, const char** font_name, float* font_size)
 {
-	float font_size = s_draw->font_sizes.last();
+	if (!text_state) return;
+
+	// Interned keys for the built-in <font> effect and its parameters.
+	static const char* s_font_effect = NULL;
+	static const char* s_name_key = NULL;
+	static const char* s_font_key = NULL;
+	static const char* s_size_key = NULL;
+	if (!s_font_effect) {
+		s_font_effect = sintern("font");
+		s_name_key = sintern("name");
+		s_font_key = sintern("font");
+		s_size_key = sintern("size");
+	}
+
+	// Codes are sorted by index_in_string at parse time, so we can stop once starts
+	// pass our glyph. Active codes are applied in start order so the last one wins.
+	for (int i = 0; i < text_state->codes.count(); ++i) {
+		CF_TextCode* code = text_state->codes + i;
+		if (glyph_index < code->index_in_string) break;
+		if (glyph_index >= code->index_in_string + code->glyph_count) continue;
+
+		CF_TextEffectDef* def = app->text_effect_defs.try_find(code->effect_name);
+		if (def && def->font_name && cf_font_get(def->font_name)) {
+			*font_name = def->font_name;
+		}
+
+		if (code->effect_name == s_font_effect) {
+			const CF_TextCodeVal* name_val = code->params.try_find(s_name_key);
+			if (!name_val) name_val = code->params.try_find(s_font_key);
+			if (name_val && name_val->type == CF_TEXT_CODE_VAL_TYPE_STRING && name_val->u.string) {
+				if (cf_font_get(name_val->u.string)) {
+					*font_name = name_val->u.string;
+				}
+			}
+			const CF_TextCodeVal* size_val = code->params.try_find(s_size_key);
+			if (size_val && size_val->type == CF_TEXT_CODE_VAL_TYPE_NUMBER) {
+				*font_size = (float)size_val->u.number;
+			}
+		}
+	}
+}
+
+static const char* s_find_end_of_line(CF_ParsedTextState* text_state, bool do_effects, const char* text, int start_index, float wrap_width)
+{
+	const char* base_font_name = s_draw->fonts.last();
+	float base_font_size = s_draw->font_sizes.last();
 	int blur = s_draw->blurs.last();
+	CF_Font* base_font = cf_font_get(base_font_name);
 	float x = 0;
 	const char* start_of_word = 0;
 	float word_w = 0;
@@ -2255,22 +2304,43 @@ static const char* s_find_end_of_line(CF_Font* font, const char* text, float wra
 	// Mirrors the main render loop's hit_newline gating, so wrap points land where
 	// the kerned text will actually break.
 	bool at_line_start = true;
+	int index = start_index;
+	const char* prev_font_name = NULL;
+	float prev_font_size = 0;
 
 	while (*text) {
 		const char* text_prev = text;
 		text = cf_string_decode_UTF8(text, &cp);
+
+		const char* font_name = base_font_name;
+		float font_size = base_font_size;
+		if (do_effects) {
+			s_resolve_text_style(text_state, index, &font_name, &font_size);
+		}
+		CF_Font* font = cf_font_get(font_name);
+		if (!font) font = base_font;
 		CF_Glyph* glyph = cf_font_get_glyph(font, cp, font_size, blur);
+		if (!glyph) {
+			++index;
+			continue;
+		}
 
 		if (cp == '\n') {
 			x = 0;
 			word_w = 0;
 			start_of_word = 0;
 			at_line_start = true;
+			prev_font_name = NULL;
+			++index;
 			continue;
 		} else if (cp == '\r') {
+			++index;
 			continue;
 		} else {
-			float kern = at_line_start ? 0 : cf_font_get_kern(font, font_size, cp_prev, cp);
+			float kern = 0;
+			if (!at_line_start && cp_prev && prev_font_name == font_name && prev_font_size == font_size) {
+				kern = cf_font_get_kern(font, font_size, cp_prev, cp);
+			}
 			float advance = glyph->xadvance + kern;
 			if (s_is_space(cp)) {
 				x += word_w + advance;
@@ -2293,7 +2363,10 @@ static const char* s_find_end_of_line(CF_Font* font, const char* text, float wra
 				}
 			}
 			cp_prev = cp;
+			prev_font_name = font_name;
+			prev_font_size = font_size;
 			at_line_start = false;
+			++index;
 		}
 	}
 
@@ -2471,7 +2544,9 @@ static void s_parse_code(CF_CodeParseState* s)
 		if (first) {
 			first = false;
 			code.effect_name = name;
-			code.fn = app->text_effect_fns.find(name);
+			code.fn = NULL;
+			CF_TextEffectDef* def = app->text_effect_defs.try_find(name);
+			if (def) code.fn = def->fn;
 		}
 		if (s->try_next('=')) {
 			CF_TextCodeVal val = s_parse_code_val(s);
@@ -2577,6 +2652,30 @@ static bool s_text_fx_gradient(CF_TextEffect* fx_ptr)
 	return true;
 }
 
+// Font/size for the built-in <font> effect are applied during layout (see
+// s_resolve_text_style); the callback itself is a no-op so the markup is valid.
+static bool s_text_fx_font(CF_TextEffect* fx_ptr)
+{
+	CF_UNUSED(fx_ptr);
+	return true;
+}
+
+static bool s_text_fx_stub(CF_TextEffect* fx_ptr)
+{
+	CF_UNUSED(fx_ptr);
+	return true;
+}
+
+static CF_TextEffectDef* s_get_or_create_text_effect_def(const char* name)
+{
+	name = sintern(name);
+	CF_TextEffectDef* def = app->text_effect_defs.try_find(name);
+	if (!def) {
+		def = app->text_effect_defs.insert(name);
+	}
+	return def;
+}
+
 static void s_parse_codes(CF_ParsedTextState* text_state, const char* text)
 {
 	// Register built-in text effects.
@@ -2589,6 +2688,7 @@ static void s_parse_codes(CF_ParsedTextState* text_state, const char* text)
 		text_effect_register("wave", s_text_fx_wave);
 		text_effect_register("strike", s_text_fx_strike);
 		text_effect_register("gradient", s_text_fx_gradient);
+		text_effect_register("font", s_text_fx_font);
 	}
 
 	CF_CodeParseState state = { };
@@ -2606,9 +2706,14 @@ static void s_parse_codes(CF_ParsedTextState* text_state, const char* text)
 			s->append(cp);
 		}
 	}
+	// Sort by start index, then by open order so nested spans that share a start
+	// index still apply outer→inner (last override wins in s_resolve_text_style).
 	std::stable_sort(text_state->codes.begin(), text_state->codes.end(),
-		[](const CF_TextCode& a, const CF_TextCode&b) {
-			return a.index_in_string < b.index_in_string;
+		[](const CF_TextCode& a, const CF_TextCode& b) {
+			if (a.index_in_string != b.index_in_string) {
+				return a.index_in_string < b.index_in_string;
+			}
+			return a.parse_order < b.parse_order;
 		}
 	);
 	text_state->sanitized = s->sanitized;
@@ -2616,9 +2721,10 @@ static void s_parse_codes(CF_ParsedTextState* text_state, const char* text)
 
 static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool render, cf_text_markup_info_fn* markups)
 {
-	CF_Font* font = cf_font_get(s_draw->fonts.last());
-	CF_ASSERT(font);
-	if (!font) return V2(0,0);
+	const char* base_font_name = s_draw->fonts.last();
+	CF_Font* base_font = cf_font_get(base_font_name);
+	CF_ASSERT(base_font);
+	if (!base_font) return V2(0,0);
 
 	// Text id can be custom or based on text's content
 	uint64_t text_id = s_draw->text_ids.last();
@@ -2653,16 +2759,20 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 	}
 
 	// Gather up all state required for rendering.
-	float font_size = s_draw->font_sizes.last();
+	// Base font/size drive baseline + line height so mixed-style lines stay stable.
+	// Per-glyph font/size may differ via text-effect font overrides (see s_resolve_text_style).
+	float base_font_size = s_draw->font_sizes.last();
 	int blur = s_draw->blurs.last();
 	float wrap_w = s_draw->text_wrap_widths.last();
-	float scale = stbtt_ScaleForPixelHeight(&font->info, font_size);
-	float line_height = font->line_height * scale;
+	float scale = stbtt_ScaleForPixelHeight(&base_font->info, base_font_size);
+	float line_height = base_font->line_height * scale;
 	int cp_prev = 0;
 	int cp = 0;
 	const char* end_of_line = NULL;
-	float h = (font->ascent + font->descent) * scale;
-	float w = font->width * scale;
+	float h = (base_font->ascent + base_font->descent) * scale;
+	float w = base_font->width * scale;
+	const char* prev_glyph_font_name = NULL;
+	float prev_glyph_font_size = 0;
 
 	// @NOTE -- Not 100% sure snapping to pixel is the best thing here, but it really does make
 	// text rendering feel a lot more robust, especially for nearest-neighbor rendering. Snap on
@@ -2670,12 +2780,12 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 	// to unsnapped shapes -- at pixel_scale 2 a logical-point snap only lands on even device pixels.
 	float pixel_scale = app->pixel_scale;
 	float x = CF_ROUNDF(position.x * pixel_scale) / pixel_scale;
-	float initial_y = CF_ROUNDF((position.y - font->ascent * scale) * pixel_scale) / pixel_scale;
+	float initial_y = CF_ROUNDF((position.y - base_font->ascent * scale) * pixel_scale) / pixel_scale;
 	float y = initial_y;
 	float max_x = x;
 	// Extend the height by descent to include spaces below the baseline.
 	// e.g: Characters such as "g", "y"...
-	float min_y = y + font->descent * scale;
+	float min_y = y + base_font->descent * scale;
 
 	int index = 0;
 	int code_index = 0;
@@ -2736,7 +2846,7 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 
 	bool vertical = s_draw->vertical.last();
 
-	auto advance_to_next_glyph = [&](CF_Glyph* last_glyph) {
+	auto advance_to_next_glyph = [&](CF_Glyph* last_glyph, float advance) {
 		// Max bound covers the entire glyph without kerning so we use the glyph's
 		// logical ink width (q1.x - q0.x) instead of xadvance. Note glyph->w is the
 		// *physical* rasterized bitmap width (scaled by pixel_scale, used for the
@@ -2744,11 +2854,12 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 		// cursor here, so it can't be used directly for this bound.
 		max_x = max(max_x, x + (last_glyph->q1.x - last_glyph->q0.x));
 		if (vertical) {
-			min_y = min(min_y, y + font->descent * scale);
+			min_y = min(min_y, y + base_font->descent * scale);
 
 			y -= line_height;
 		} else {
-			x += last_glyph->xadvance;
+			// Prefer the (possibly effect-modified) advance so layout matches rendering.
+			x += advance;
 		}
 	};
 
@@ -2763,9 +2874,10 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			x = position.x;
 			y -= line_height;
 
-			min_y = min(min_y, y + font->descent * scale);
+			min_y = min(min_y, y + base_font->descent * scale);
 		}
 		hit_newline = true;
+		prev_glyph_font_name = NULL;
 		++newline_count;
 	};
 	
@@ -2790,9 +2902,10 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			continue;
 		}
 
-		// Word wrapping logic.
+		// Word wrapping logic. Uses the same per-glyph font/size resolution as drawing
+		// so bold/italic (or any font override) wraps at the correct visual width.
 		if (!end_of_line) {
-			end_of_line = s_find_end_of_line(font, prev_text, wrap_w);
+			end_of_line = s_find_end_of_line(text_state, do_effects, prev_text, index - 1, wrap_w);
 		}
 
 		int finished_rendering_line = !(text < end_of_line);
@@ -2815,21 +2928,31 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			continue;
 		}
 
+		// Active face for this glyph (base stack, or a text-effect font override).
+		const char* active_font_name = base_font_name;
+		float active_font_size = base_font_size;
+		if (do_effects) {
+			s_resolve_text_style(text_state, index - 1, &active_font_name, &active_font_size);
+		}
+		CF_Font* active_font = cf_font_get(active_font_name);
+		if (!active_font) active_font = base_font;
+
 		spritebatch_sprite_t s = { };
 		s.minx = 0; // 9-slice implementation expects these to be defaulted to 0..1.
 		s.miny = 0;
 		s.maxx = 1;
 		s.maxy = 1;
-		CF_Glyph* glyph = cf_font_get_glyph(font, cp, font_size, blur);
+		CF_Glyph* glyph = cf_font_get_glyph(active_font, cp, active_font_size, blur);
 		if (!glyph) {
 			continue;
 		}
 
 		// Advance the cursor by the pair kern so it accumulates across the line and is
 		// reflected in measurement + bounds, not just the visible glyph. Horizontal only;
-		// hit_newline guards against kerning across line breaks.
-		if (!vertical && !hit_newline && cp_prev) {
-			x += cf_font_get_kern(font, font_size, cp_prev, cp);
+		// hit_newline guards against kerning across line breaks. Skip kerning across a
+		// font or size change -- pair kern tables are face-specific.
+		if (!vertical && !hit_newline && cp_prev && prev_glyph_font_name == active_font_name && prev_glyph_font_size == active_font_size) {
+			x += cf_font_get_kern(active_font, active_font_size, cp_prev, cp);
 		}
 
 		// Prepare a sprite struct for rendering.
@@ -2873,7 +2996,7 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 					effect->opacity = s.geom.alpha;
 					effect->xadvance = xadvance;
 					effect->visible = visible;
-					effect->font_size = font_size;
+					effect->font_size = active_font_size;
 					effect->on_begin = effect->on_start();
 					keep_going = fn(effect);
 					q0 = effect->q0;
@@ -2950,7 +3073,9 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			}
 		}
 
-		advance_to_next_glyph(glyph);
+		advance_to_next_glyph(glyph, xadvance);
+		prev_glyph_font_name = active_font_name;
+		prev_glyph_font_size = active_font_size;
 		hit_newline = false;
 	}
 
@@ -2987,7 +3112,18 @@ void cf_draw_text(const char* text, CF_V2 position, int text_length)
 
 void cf_text_effect_register(const char* name, CF_TextEffectFn* fn)
 {
-	app->text_effect_fns.insert(sintern(name), fn);
+	CF_TextEffectDef* def = s_get_or_create_text_effect_def(name);
+	def->fn = fn;
+}
+
+void cf_text_effect_set_font(const char* effect_name, const char* font_name)
+{
+	CF_TextEffectDef* def = s_get_or_create_text_effect_def(effect_name);
+	def->font_name = sintern(font_name);
+	// Auto-register a no-op callback so the markup is valid without a custom effect.
+	if (!def->fn) {
+		def->fn = s_text_fx_stub;
+	}
 }
 
 double cf_text_effect_get_number(const CF_TextEffect* fx, const char* key, double default_val)

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -142,7 +142,7 @@ struct CF_App
 	Cute::Map<CF_Pixel*> font_pixels;
 	Cute::Map<CF_TextEffectState> text_effect_states;
 	Cute::Map<CF_ParsedTextState> parsed_text_states;
-	Cute::Map<CF_TextEffectFn*> text_effect_fns;
+	Cute::Map<CF_TextEffectDef> text_effect_defs;
 
 	// Easy sprite stuff.
 	uint64_t easy_sprite_id_gen = CF_EASY_ID_RANGE_LO;

--- a/src/internal/cute_font_internal.h
+++ b/src/internal/cute_font_internal.h
@@ -50,11 +50,23 @@ CF_API float CF_CALL cf_font_scale_for_pixel_height(CF_Font* font, float pixel_h
 
 #define CF_KERN_KEY(cp0, cp1) (((uint64_t)cp0) << 32 | ((uint64_t)cp1))
 
+// Registered text-effect definition: optional callback + optional font override.
+// Font overrides are resolved at draw/measure time so `cf_text_effect_set_font`
+// takes effect even for already-parsed strings.
+struct CF_TextEffectDef
+{
+	CF_TextEffectFn* fn = NULL;
+	const char* font_name = NULL; // interned; NULL means no override
+};
+
 struct CF_TextCode
 {
 	const char* effect_name;
 	int index_in_string;
 	int glyph_count;
+	// Monotonic open order so nested codes that share the same start index still
+	// resolve outer→inner (later opens win when applying font overrides).
+	int parse_order;
 	CF_TextEffectFn* fn;
 	Cute::Map<CF_TextCodeVal> params;
 };
@@ -116,11 +128,16 @@ struct CF_ParsedTextState
 	Cute::String sanitized;
 	uint64_t hash = 0;
 	bool alive = false;
+	int next_parse_order = 0;
 	Cute::Array<TextEffect> effects;
 	Cute::Array<CF_TextCode> codes;
 	Cute::Array<CF_TextCode> parse_stack;
 
-	CF_INLINE void parse_add(CF_TextCode code) { parse_stack.add(code); }
+	CF_INLINE void parse_add(CF_TextCode code)
+	{
+		code.parse_order = next_parse_order++;
+		parse_stack.add(code);
+	}
 	CF_INLINE bool parse_finish(const char* effect_name, int final_index)
 	{
 		for (int i = parse_stack.count() - 1; i >= 0; --i) {

--- a/test/test_markups.cpp
+++ b/test/test_markups.cpp
@@ -102,6 +102,43 @@ TEST_CASE(test_markups_font_style)
 	return true;
 }
 
+TEST_CASE(test_markups_font_size_vertical_metrics)
+{
+	// A larger <font size=N> span must grow the measured vertical extent and the
+	// line-to-line advance, so measurement boxes and wrapped lines stay trustworthy.
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	push_font("Calibri");
+	push_font_size(32);
+
+	// Single line: a big size span is taller than the base-size line.
+	float base_h = text_height("Hello", -1);
+	float big_h = text_height("<font size=64>Hello</font>", -1);
+	REQUIRE(big_h > base_h);
+
+	// A big span embedded mid-line still lifts the whole line's height.
+	float mixed_h = text_height("a<font size=64>B</font>c", -1);
+	REQUIRE(mixed_h > base_h);
+
+	// text_size().y agrees with text_height().
+	CF_V2 big_sz = text_size("<font size=64>Hello</font>", -1);
+	REQUIRE(big_sz.y == big_h);
+
+	// Multi-line: a big second line makes the block taller than an all-base block,
+	// i.e. the line advance follows the tallest style on each line (no collision).
+	float two_base = text_height("small\nsmall", -1);
+	float two_big = text_height("small\n<font size=64>BIG</font>", -1);
+	REQUIRE(two_big > two_base);
+
+	// A pure-base string is unaffected by the feature.
+	REQUIRE(text_height("small\nsmall", -1) == two_base);
+
+	pop_font_size();
+	pop_font();
+	destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_markups)
 {
 	// Don't submit this to GitHub as the build machines can't init a graphics context.
@@ -109,5 +146,6 @@ TEST_SUITE(test_markups)
 	RUN_TEST_CASE(test_markups_basic);
 	RUN_TEST_CASE(test_markups_bad_inputs);
 	RUN_TEST_CASE(test_markups_font_style);
+	RUN_TEST_CASE(test_markups_font_size_vertical_metrics);
 #endif
 }

--- a/test/test_markups.cpp
+++ b/test/test_markups.cpp
@@ -139,6 +139,27 @@ TEST_CASE(test_markups_font_size_vertical_metrics)
 	return true;
 }
 
+TEST_CASE(test_markups_empty_tag_no_crash)
+{
+	// A degenerate tag with no name (e.g. "<>") makes the parser produce an empty tag
+	// name; interning its NULL c_str() used to crash. Measuring must be safe instead.
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	push_font("Calibri");
+	push_font_size(24);
+
+	// None of these should crash; each returns a finite, non-negative width.
+	REQUIRE(text_width("<>", -1) >= 0);
+	REQUIRE(text_width("a<>b", -1) >= 0);
+	REQUIRE(text_width("<=x>text</>", -1) >= 0);
+	REQUIRE(text_width("< >spaced", -1) >= 0);
+
+	pop_font_size();
+	pop_font();
+	destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_markups)
 {
 	// Don't submit this to GitHub as the build machines can't init a graphics context.
@@ -147,5 +168,6 @@ TEST_SUITE(test_markups)
 	RUN_TEST_CASE(test_markups_bad_inputs);
 	RUN_TEST_CASE(test_markups_font_style);
 	RUN_TEST_CASE(test_markups_font_size_vertical_metrics);
+	RUN_TEST_CASE(test_markups_empty_tag_no_crash);
 #endif
 }

--- a/test/test_markups.cpp
+++ b/test/test_markups.cpp
@@ -65,11 +65,49 @@ TEST_CASE(test_markups_bad_inputs)
 	return true;
 }
 
+// Embedded ProggyClean for style-tag measurement without depending on VFS mounts.
+#include "../samples/proggy.h"
+
+TEST_CASE(test_markups_font_style)
+{
+	// Bold/italic style tags swap to a different loaded face and use that face's metrics.
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	// Load a second face distinct from the default Calibri.
+	REQUIRE(!is_error(make_font_from_memory(proggy_data, proggy_sz, "ProggyClean")));
+
+	text_effect_set_font("b", "ProggyClean");
+
+	push_font("Calibri");
+	push_font_size(32);
+
+	float plain_w = text_width("Hello", -1);
+	float mapped_w = text_width("<b>Hello</b>", -1);
+	float font_tag_w = text_width("<font name=\"ProggyClean\">Hello</font>", -1);
+	float size_tag_w = text_width("<font name=\"ProggyClean\" size=64>Hello</font>", -1);
+
+	// Mapped <b> and explicit <font name> should match each other and differ from base face.
+	REQUIRE(mapped_w == font_tag_w);
+	REQUIRE(mapped_w != plain_w);
+	// Larger size override should measure wider than the default size span.
+	REQUIRE(size_tag_w > font_tag_w);
+
+	// Nested: inner set_font override wins over outer <font>.
+	float nested_w = text_width("<font name=\"Calibri\"><b>Hello</b></font>", -1);
+	REQUIRE(nested_w == mapped_w);
+
+	pop_font_size();
+	pop_font();
+	destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_markups)
 {
 	// Don't submit this to GitHub as the build machines can't init a graphics context.
 #if 0
 	RUN_TEST_CASE(test_markups_basic);
 	RUN_TEST_CASE(test_markups_bad_inputs);
+	RUN_TEST_CASE(test_markups_font_style);
 #endif
 }


### PR DESCRIPTION
## Summary

Implements https://github.com/RandyGaul/cute_framework/issues/349: text codes can switch to a different loaded font (and optional size) mid-string, so bold/italic and general face swaps work with correct glyph metrics.


https://github.com/user-attachments/assets/81beaa7e-1816-4f7c-93f5-26d6566cbc62



### Public API

```c
cf_text_effect_set_font("b", "MyFont Bold");
cf_draw_text("Hello <b>bold</b>", pos, -1);

// Built-in general swap:
cf_draw_text("<font name=\"MyFont Bold\" size=48>Big</font>", pos, -1);
```

C++: `text_effect_set_font(...)`.

- Bold/italic are **separate font files** you load yourself; this only maps markup names onto those faces.
- Unregistered effect names auto-register a no-op callback so `<b>` works without a custom effect function.

### Behavior

| Concern | Behavior |
|--------|----------|
| Per glyph | Resolve active font/size **before** glyph fetch |
| Metrics | Advance + kerning come from the active face |
| Kerning | Skipped across font/size changes |
| Nesting | Innermost / last override wins (parse open order for same-start spans) |
| Baseline / line height | Stay on the **base** (pushed) font for stable paragraphs |
| Wrap / `text_width` | Use the same resolution as drawing |
| `<font>` | Built-in: `name` (or `font`) string, optional `size` number |

### Mental model

```text
Load faces                 Map short tags              Markup switches mid-string
make_font(...)      →      set_font("b", "Bold")  →    "Hi <b>there</b>"
                           (optional)                  or <font name size>
```

### Sample

`samples/text_drawing.cpp` demos:

- `<b>` via `set_font` (mapped to ProggyClean as a stand-in face)
- `<font name="ProggyClean">` mid-sentence
- size overrides
- nested font + mapped style
- style composited with wave/color

Layout is arranged so style tags, glow/shadow, and gradients do not overlap.

### Internals

- `Map<CF_TextEffectFn*>` → `Map<CF_TextEffectDef>` (`fn` + optional `font_name`)
- `s_resolve_text_style` walks covering codes at draw/measure time (so remapping fonts does not require re-parsing)
- Word wrap shares that resolver

### Test

`test_markups_font_style` added under the existing `#if 0` graphics-gated markup suite (same CI constraint as other markup tests). Locally verified PASS with the suite enabled.

## Test plan

- [ ] Build framework + `textdrawing` sample
- [ ] Run `textdrawing` and confirm style tags, font spans, nested overrides, and style+wave/color
- [ ] Confirm style block is fully on-screen and not overlapping glow/shadow/gradients
- [ ] Optional: enable `test_markups_font_style` and run `tests` with a local graphics context
- [ ] Smoke: existing markups (color, wave, shake, strike, gradient) still look correct
- [ ] Smoke: `text_width` / wrap with mixed faces looks consistent with rendered text