### PR TITLE
Fix allocator functions not forwarding CF_Allocator udata

### DIFF
--- a/src/cute_alloc.cpp
+++ b/src/cute_alloc.cpp
@@ -64,22 +64,22 @@ void cf_allocator_restore_default(void)
 
 void* cf_alloc(size_t size)
 {
-	return s_allocator.alloc_fn ? s_allocator.alloc_fn(size, NULL) : s_default_alloc(size, NULL);
+	return s_allocator.alloc_fn ? s_allocator.alloc_fn(size, s_allocator.udata) : s_default_alloc(size, s_allocator.udata);
 }
 
 void cf_free(void* ptr)
 {
-	s_allocator.free_fn ? s_allocator.free_fn(ptr, NULL) : s_default_free(ptr, NULL);
+	s_allocator.free_fn ? s_allocator.free_fn(ptr, s_allocator.udata) : s_default_free(ptr, s_allocator.udata);
 }
 
 void* cf_calloc(size_t size, size_t count)
 {
-	return s_allocator.calloc_fn ? s_allocator.calloc_fn(size, count, NULL) : s_default_calloc(size, count, NULL);
+	return s_allocator.calloc_fn ? s_allocator.calloc_fn(size, count, s_allocator.udata) : s_default_calloc(size, count, s_allocator.udata);
 }
 
 void* cf_realloc(void* ptr, size_t size)
 {
-	return s_allocator.realloc_fn ? s_allocator.realloc_fn(ptr, size, NULL) : s_default_realloc(ptr, size, NULL);
+	return s_allocator.realloc_fn ? s_allocator.realloc_fn(ptr, size, s_allocator.udata) : s_default_realloc(ptr, size, s_allocator.udata);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CF_TEST_SRCS
 	main.cpp
+	test_alloc.cpp
 	test_array.cpp
 	test_aseprite.cpp
 	test_audio.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,6 +25,7 @@
 
 #include <cute.h>
 
+TEST_SUITE(test_alloc);
 TEST_SUITE(test_array);
 TEST_SUITE(test_aseprite);
 TEST_SUITE(test_audio);
@@ -68,6 +69,7 @@ int main(int argc, char* argv[])
 	setvbuf(stderr, NULL, _IONBF, 0);
 
 #define RUN_TRACED(suite_fp) fprintf(stderr, ">>> " #suite_fp "\n"); RUN_TEST_SUITE(suite_fp); fprintf(stderr, "<<< " #suite_fp "\n");
+	RUN_TRACED(test_alloc);
 	RUN_TRACED(test_array);
 	RUN_TRACED(test_aseprite);
 	RUN_TRACED(test_audio);

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -42,6 +42,14 @@ static void* s_test_realloc(void* ptr, size_t size, void* udata)
 	return realloc(ptr, size);
 }
 
+// A failed REQUIRE below returns out of the test case early, so restoring the
+// default allocator must happen via RAII rather than a final statement --
+// otherwise the override leaks into every test that runs afterward.
+struct AllocatorRestoreGuard
+{
+	~AllocatorRestoreGuard() { cf_allocator_restore_default(); }
+};
+
 TEST_CASE(test_allocator_forwards_udata)
 {
 	int sentinel = 0;
@@ -54,6 +62,7 @@ TEST_CASE(test_allocator_forwards_udata)
 	allocator.calloc_fn = s_test_calloc;
 	allocator.realloc_fn = s_test_realloc;
 	cf_allocator_override(allocator);
+	AllocatorRestoreGuard restore_guard;
 
 	void* a = cf_alloc(16);
 	REQUIRE(s_last_alloc_udata == expected_udata);
@@ -68,8 +77,6 @@ TEST_CASE(test_allocator_forwards_udata)
 	REQUIRE(s_last_free_udata == expected_udata);
 
 	cf_free(r);
-
-	cf_allocator_restore_default();
 
 	return true;
 }

--- a/test/test_alloc.cpp
+++ b/test/test_alloc.cpp
@@ -1,0 +1,83 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute.h>
+using namespace Cute;
+
+//--------------------------------------------------------------------------------------------------
+// cf_allocator_override must forward CF_Allocator::udata to the custom function pointers.
+
+static void* s_last_alloc_udata = NULL;
+static void* s_last_free_udata = NULL;
+static void* s_last_calloc_udata = NULL;
+static void* s_last_realloc_udata = NULL;
+
+static void* s_test_alloc(size_t size, void* udata)
+{
+	s_last_alloc_udata = udata;
+	return malloc(size);
+}
+
+static void s_test_free(void* ptr, void* udata)
+{
+	s_last_free_udata = udata;
+	free(ptr);
+}
+
+static void* s_test_calloc(size_t size, size_t count, void* udata)
+{
+	s_last_calloc_udata = udata;
+	return calloc(size, count);
+}
+
+static void* s_test_realloc(void* ptr, size_t size, void* udata)
+{
+	s_last_realloc_udata = udata;
+	return realloc(ptr, size);
+}
+
+TEST_CASE(test_allocator_forwards_udata)
+{
+	int sentinel = 0;
+	void* expected_udata = &sentinel;
+
+	CF_Allocator allocator;
+	allocator.udata = expected_udata;
+	allocator.alloc_fn = s_test_alloc;
+	allocator.free_fn = s_test_free;
+	allocator.calloc_fn = s_test_calloc;
+	allocator.realloc_fn = s_test_realloc;
+	cf_allocator_override(allocator);
+
+	void* a = cf_alloc(16);
+	REQUIRE(s_last_alloc_udata == expected_udata);
+
+	void* c = cf_calloc(4, 4);
+	REQUIRE(s_last_calloc_udata == expected_udata);
+
+	void* r = cf_realloc(c, 32);
+	REQUIRE(s_last_realloc_udata == expected_udata);
+
+	cf_free(a);
+	REQUIRE(s_last_free_udata == expected_udata);
+
+	cf_free(r);
+
+	cf_allocator_restore_default();
+
+	return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Test suite.
+
+TEST_SUITE(test_alloc)
+{
+	RUN_TEST_CASE(test_allocator_forwards_udata);
+}


### PR DESCRIPTION
`cf_alloc`/`cf_free`/`cf_calloc`/`cf_realloc` always called the overridden allocator's function pointers with a hardcoded `NULL` instead of forwarding `CF_Allocator::udata`. This made the documented "optional parameter handed back to you in the other function pointers" (`cute_alloc.h`) unusable in practice — any custom allocator relying on `udata` to carry context (e.g. per-allocator stats or a pool handle) silently got `NULL` on every call.

Fixed by passing `s_allocator.udata` through in all four functions. Added `test/test_alloc.cpp` which overrides the allocator and asserts `udata` reaches `alloc_fn`/`free_fn`/`calloc_fn`/`realloc_fn`.

## Test plan
- [x] `cmake --build build --target tests` builds clean
- [x] `./build/tests` — all 175 tests pass (18 suites, 18346 asserts), including the new `test_alloc` suite