### PR TITLE
Route vendored single-header libs through cf_alloc/cf_free

### DIFF
--- a/src/cute_aseprite_cache.cpp
+++ b/src/cute_aseprite_cache.cpp
@@ -16,6 +16,8 @@
 #include <internal/cute_app_internal.h>
 
 #define CUTE_ASEPRITE_IMPLEMENTATION
+#define CUTE_ASEPRITE_ALLOC(size, ctx) cf_alloc(size)
+#define CUTE_ASEPRITE_FREE(mem, ctx) cf_free(mem)
 #include <cute/cute_aseprite.h>
 
 #include <internal/cute_aseprite_cache_internal.h>

--- a/src/cute_audio.cpp
+++ b/src/cute_audio.cpp
@@ -24,6 +24,8 @@
 #define CUTE_SOUND_IMPLEMENTATION
 #define CUTE_SOUND_FORCE_SDL
 #define CUTE_SOUND_ASSERT CF_ASSERT
+#define CUTE_SOUND_ALLOC(size, ctx) cf_alloc(size)
+#define CUTE_SOUND_FREE(mem, ctx) cf_free(mem)
 #include <cute/cute_sound.h>
 
 CF_Audio cf_audio_load_ogg(const char* path)

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -24,6 +24,16 @@ struct CF_Draw* s_draw;
 static const char* s_text_without_markups = NULL;
 
 //#define SPRITEBATCH_LOG printf
+// cute_spritebatch.h's default SPRITEBATCH_MALLOC/FREE live inside its outer
+// include guard, so the header-only include pulled in transitively above
+// (via cute_app_internal.h -> cute_draw_internal.h) already defines them to
+// malloc/free before we get here. #undef first so our override doesn't just
+// silently lose to that earlier default (and to avoid a macro-redefined
+// warning).
+#undef SPRITEBATCH_MALLOC
+#undef SPRITEBATCH_FREE
+#define SPRITEBATCH_MALLOC(size, ctx) cf_alloc(size)
+#define SPRITEBATCH_FREE(ptr, ctx) cf_free(ptr)
 #define SPRITEBATCH_IMPLEMENTATION
 #include <cute/cute_spritebatch.h>
 
@@ -37,6 +47,8 @@ static const char* s_text_without_markups = NULL;
 
 #define STB_TRUETYPE_IMPLEMENTATION
 #define STBTT_assert CF_ASSERT
+#define STBTT_malloc(x, u) cf_alloc(x)
+#define STBTT_free(x, u) cf_free(x)
 #include <stb/stb_truetype.h>
 
 #define IM_ASSERT CF_ASSERT

--- a/src/cute_https.cpp
+++ b/src/cute_https.cpp
@@ -20,6 +20,8 @@
 
 #ifndef CF_APPLE
 #	define CUTE_TLS_IMPLEMENTATION
+#	define TLS_MALLOC cf_alloc
+#	define TLS_FREE cf_free
 	// .m file is used to compile this on apple.
 #	include <cute/cute_tls.h>
 #else

--- a/src/cute_multithreading.cpp
+++ b/src/cute_multithreading.cpp
@@ -12,8 +12,8 @@
 
 #define CUTE_SYNC_IMPLEMENTATION
 #define CUTE_SYNC_SDL
-#define CUTE_THREAD_ALLOC CF_ALLOC
-#define CUTE_THREAD_FREE CF_FREE
+#define CUTE_SYNC_ALLOC(size, ctx) cf_alloc(size)
+#define CUTE_SYNC_FREE(ptr, ctx) cf_free(ptr)
 #include <cute/cute_sync.h>
 
 CF_Mutex cf_make_mutex()

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -6,11 +6,14 @@
 */
 
 #include <cute_networking.h>
+#include <cute_alloc.h>
 
 // This entire file makes no sense for web builds, since web doesn't allow UDP.
 #ifndef CF_EMSCRIPTEN
 
 #define CUTE_NET_IMPLEMENTATION
+#define CN_ALLOC(size, ctx) cf_alloc(size)
+#define CN_FREE(mem, ctx) cf_free(mem)
 #include <cute/cute_net.h>
 
 static CF_INLINE CF_Result cf_wrap(cn_result_t cn_result)

--- a/src/internal/cute_tls.m
+++ b/src/internal/cute_tls.m
@@ -19,5 +19,9 @@
 	3. This notice may not be removed or altered from any source distribution.
 */
 
+#include <cute_alloc.h>
+
 #define CUTE_TLS_IMPLEMENTATION
+#define TLS_MALLOC cf_alloc
+#define TLS_FREE cf_free
 #include <cute/cute_tls.h>


### PR DESCRIPTION
## Summary
- `cute_spritebatch`, `stb_truetype`, `cute_sound`, `cute_aseprite`, `cute_net`, `cute_sync`, and `cute_tls` all defaulted to raw `malloc`/`free`, silently bypassing `cf_allocator_override`. This defines each lib's allocator macro to `cf_alloc`/`cf_free` before its `IMPLEMENTATION` include, mirroring the existing `cute_png`/`ckit` pattern already in the codebase.
- `cute_spritebatch.h`'s default macro lives inside its outer declarations guard (not the `IMPLEMENTATION`-only guard like the others), and an earlier declarations-only include in the same TU (`cute_draw.cpp`, via `cute_app_internal.h` -> `cute_draw_internal.h`) bakes in `malloc`/`free` first. Added an explicit `#undef` before the override there to avoid silently losing to that default (and the resulting `-Wmacro-redefined` warning).
- Found and fixed a stale, dead override in `cute_multithreading.cpp`: it defined `CUTE_THREAD_ALLOC`/`CUTE_THREAD_FREE`, a customization point `cute_sync.h` no longer has (renamed at some point to `CUTE_SYNC_ALLOC`/`CUTE_SYNC_FREE`), so it silently no-op'd and `cute_sync` had been falling back to `malloc`/`free` the whole time.
- Deliberately left out of scope: `minicoro.h`'s `MCO_ALLOC` (dead code — CF uses the mmap/VirtualAlloc path via `MCO_USE_VMEM_ALLOCATOR` instead, since coroutine stacks need real paged OS memory, not a heap allocator), `pico_qt.h` (unused, not compiled anywhere), and imgui's own allocator (a separate runtime-wiring change, not a header macro).

## Test plan
- [x] `cmake --build build --target cute` — clean, no new warnings
- [x] `cmake --build build` (full project, 121/121 targets) — clean
- [x] `./build/tests` — 174/174 suites, 18342 asserts, 0 failures (incl. `test_aseprite`, `test_audio`)
- [x] Verified no `-Wmacro-redefined` warnings for any of the new overrides via `grep -iE "error|redefin"` over a full rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YUwNNNbdQjPJHn1tts22v1