### PR TITLE
Replace vsync/vsync_mailbox setters with a unified present mode API

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -656,6 +656,45 @@ CF_INLINE const char* cf_msaa_string(CF_MSAA msaa) {
 }
 
 /**
+ * @enum     CF_PresentMode
+ * @category app
+ * @brief    Describes a swapchain present mode -- vsync off, plain vsync, or low-latency mailbox vsync.
+ * @related  cf_app_get_present_mode cf_app_set_present_mode cf_present_mode_string
+ */
+#define CF_PRESENT_MODE_DEFS \
+	/* @entry Vsync is off; frames present immediately (tearing may occur). */ \
+	CF_ENUM(PRESENT_MODE_IMMEDIATE, 0) \
+	/* @entry Vsync is on; frames present synchronized to the display refresh. */ \
+	CF_ENUM(PRESENT_MODE_VSYNC,     1) \
+	/* @entry Low-latency vsync; the swapchain may be updated more than once before a frame is presented. */ \
+	CF_ENUM(PRESENT_MODE_MAILBOX,   2) \
+	/* @end */
+
+typedef enum CF_PresentMode
+{
+	#define CF_ENUM(K, V) CF_##K = V,
+	CF_PRESENT_MODE_DEFS
+	#undef CF_ENUM
+} CF_PresentMode;
+
+/**
+ * @function cf_present_mode_string
+ * @category app
+ * @brief    Returns a `CF_PresentMode` value as a string.
+ * @param    mode       The present mode to convert to a string.
+ * @return   Returns a string representing `mode`, e.g. `CF_PRESENT_MODE_VSYNC` returns "CF_PRESENT_MODE_VSYNC".
+ * @related  cf_app_get_present_mode CF_PresentMode
+ */
+CF_INLINE const char* cf_present_mode_string(CF_PresentMode mode) {
+	switch (mode) {
+	#define CF_ENUM(K, V) case CF_##K: return CF_STRINGIZE(CF_##K);
+	CF_PRESENT_MODE_DEFS
+	#undef CF_ENUM
+	default: return NULL;
+	}
+}
+
+/**
  * @function cf_app_set_msaa
  * @category app
  * @brief    Sets the MSAA sample count for the app's offscreen canvas.
@@ -679,7 +718,7 @@ CF_API bool CF_CALL cf_app_set_msaa(int sample_count);
  *           calling `cf_app_set_canvas_size`, as it will invalidate any references to the app's canvas.
  *           
  *           If you fetch this canvas and have MSAA on (see `cf_app_set_msaa`) you may *not* sample from the canvas.
- * @related  cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_present_mode cf_app_get_present_mode
  */
 CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
 
@@ -693,7 +732,7 @@ CF_API CF_Canvas CF_CALL cf_app_get_canvas(void);
  *           Calling this pins the canvas to an exact device-pixel size and opts out of CF's automatic pixel-density-based
  *           canvas scaling -- the canvas will no longer auto-resize if the window moves to a display with a different
  *           pixel density.
- * @related  cf_app_get_canvas cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas cf_app_get_canvas_width cf_app_get_canvas_height cf_app_set_present_mode cf_app_get_present_mode
  */
 CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
 
@@ -701,7 +740,7 @@ CF_API void CF_CALL cf_app_set_canvas_size(int w, int h);
  * @function cf_app_get_canvas_width
  * @category app
  * @brief    Gets the app's canvas width in pixels.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_height cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_height cf_app_set_present_mode cf_app_get_present_mode
  */
 CF_API int CF_CALL cf_app_get_canvas_width(void);
 
@@ -709,7 +748,7 @@ CF_API int CF_CALL cf_app_get_canvas_width(void);
  * @function cf_app_get_canvas_height
  * @category app
  * @brief    Gets the app's canvas height in pixels.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync
+ * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_present_mode cf_app_get_present_mode
  */
 CF_API int CF_CALL cf_app_get_canvas_height(void);
 
@@ -726,30 +765,30 @@ CF_API int CF_CALL cf_app_get_canvas_height(void);
 CF_API void CF_CALL cf_app_set_canvas_blit_filter(CF_Filter filter);
 
 /**
- * @function cf_app_set_vsync
+ * @function cf_app_set_present_mode
  * @category app
- * @brief    Turns on vsync via the graphical backend (if supported).
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
- */
-CF_API void CF_CALL cf_app_set_vsync(bool true_turn_on_vsync);
-
-/**
- * @function cf_app_set_vsync_mailbox
- * @category app
- * @brief    Turns on vsync via the graphical backend (if supported) in mailbox mode.
- * @remarks  Similar to vsync but with reduced latency. When rendering too quickly the frame may be updated
+ * @brief    Sets the swapchain present mode via the graphical backend (if supported).
+ * @param    mode       The present mode to switch to -- `CF_PRESENT_MODE_IMMEDIATE`, `CF_PRESENT_MODE_VSYNC`, or `CF_PRESENT_MODE_MAILBOX`.
+ * @return   Returns true if `mode` was actually applied by the backend. Returns false if the backend rejected
+ *           the request (e.g. mailbox is unsupported on the Metal backend), in which case the present mode is
+ *           left unchanged -- see `cf_app_get_present_mode`. `CF_PRESENT_MODE_VSYNC` is always supported.
+ * @remarks  Present modes are mutually exclusive -- there is only ever one active mode at a time. Mailbox is
+ *           similar to vsync but with reduced latency: when rendering too quickly the frame may be updated
  *           more than once before it is sent off the GPU.
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
+ * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_get_present_mode CF_PresentMode
  */
-CF_API void CF_CALL cf_app_set_vsync_mailbox(bool true_turn_on_mailbox);
+CF_API bool CF_CALL cf_app_set_present_mode(CF_PresentMode mode);
 
 /**
- * @function cf_app_get_vsync
+ * @function cf_app_get_present_mode
  * @category app
- * @brief    Returns the vsync state (true for on).
- * @related  cf_app_get_canvas cf_app_set_canvas_size cf_app_get_canvas_width cf_app_set_vsync cf_app_get_vsync cf_app_set_vsync_mailbox
+ * @brief    Returns the swapchain present mode currently in effect.
+ * @return   Returns the currently active `CF_PresentMode`.
+ * @remarks  Reflects the mode actually applied by the backend, not merely the last one requested -- if a call
+ *           to `cf_app_set_present_mode` fails, the present mode is unchanged.
+ * @related  cf_app_set_present_mode CF_PresentMode
  */
-CF_API bool CF_CALL cf_app_get_vsync(void);
+CF_API CF_PresentMode CF_CALL cf_app_get_present_mode(void);
 
 /**
  * @function cf_app_set_windowed_mode
@@ -951,9 +990,8 @@ CF_INLINE bool app_mouse_exited() { return cf_app_mouse_exited(); }
 CF_INLINE bool app_mouse_inside() { return cf_app_mouse_inside(); }
 CF_INLINE int app_get_canvas_width() { return cf_app_get_canvas_width(); }
 CF_INLINE int app_get_canvas_height() { return cf_app_get_canvas_height(); }
-CF_INLINE void app_set_vsync(bool true_turn_on_vsync) { cf_app_set_vsync(true_turn_on_vsync); }
-CF_INLINE void app_set_vsync_mailbox(bool true_turn_on_vsync) { cf_app_set_vsync_mailbox(true_turn_on_vsync); }
-CF_INLINE bool app_get_vsync() { return cf_app_get_vsync(); }
+CF_INLINE bool app_set_present_mode(CF_PresentMode mode) { return cf_app_set_present_mode(mode); }
+CF_INLINE CF_PresentMode app_get_present_mode() { return cf_app_get_present_mode(); }
 CF_INLINE void app_set_windowed_mode() { cf_app_set_windowed_mode(); }
 CF_INLINE void app_set_borderless_fullscreen_mode() { cf_app_set_borderless_fullscreen_mode(); }
 CF_INLINE void app_set_fullscreen_mode() { cf_app_set_fullscreen_mode(); }

--- a/samples/rainbow_liquid.cpp
+++ b/samples/rainbow_liquid.cpp
@@ -331,7 +331,7 @@ int main(int argc, char* argv[])
 	make_app("Liquid Rainbow", 0, 0, 0, (int)(w * scale), (int)(h * scale), options | CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
 	cf_set_fixed_timestep(60);
 	cf_set_target_framerate(60);
-	cf_app_set_vsync(false);
+	cf_app_set_present_mode(CF_PRESENT_MODE_IMMEDIATE);
 
 	CF_Threadpool* tp = cf_make_threadpool(cf_core_count());
 	physics_t physics = {};

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -792,33 +792,27 @@ void cf_app_set_canvas_blit_filter(CF_Filter filter)
 	app->canvas_blit_filter = filter;
 }
 
-void cf_app_set_vsync(bool true_turn_on_vsync)
+bool cf_app_set_present_mode(CF_PresentMode mode)
 {
-	app->vsync = true_turn_on_vsync;
+	bool applied;
 	if (app->gfx_backend_type == CF_BACKEND_TYPE_GLES3) {
-		cf_gles_set_vsync(true_turn_on_vsync);
+		applied = cf_gles_set_present_mode(mode);
 	} else {
 #ifndef CF_EMSCRIPTEN
-		cf_sdlgpu_set_vsync(true_turn_on_vsync);
+		applied = cf_sdlgpu_set_present_mode(mode);
+#else
+		applied = false;
 #endif
 	}
-}
-
-void cf_app_set_vsync_mailbox(bool true_turn_on_mailbox)
-{
-	app->vsync = true_turn_on_mailbox;
-	if (app->gfx_backend_type == CF_BACKEND_TYPE_GLES3) {
-		CF_ASSERT(!"This is only implemented on SDL_Gpu backends (Metal/DX11/DX12/Vulkan).");
-	} else {
-#ifndef CF_EMSCRIPTEN
-		cf_sdlgpu_set_vsync_mailbox(true_turn_on_mailbox);
-#endif
+	if (applied) {
+		app->present_mode = mode;
 	}
+	return applied;
 }
 
-bool cf_app_get_vsync()
+CF_PresentMode cf_app_get_present_mode()
 {
-	return app->vsync;
+	return app->present_mode;
 }
 
 void cf_app_set_windowed_mode()

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -699,9 +699,13 @@ void cf_gles_gpu_sync()
 	glFinish();
 }
 
-void cf_gles_set_vsync(bool true_turn_on_vsync)
+bool cf_gles_set_present_mode(CF_PresentMode mode)
 {
-	SDL_GL_SetSwapInterval(true_turn_on_vsync ? 1 : 0);
+	switch (mode) {
+	case CF_PRESENT_MODE_IMMEDIATE: return SDL_GL_SetSwapInterval(0);
+	case CF_PRESENT_MODE_VSYNC:     return SDL_GL_SetSwapInterval(1);
+	default:                        return false; // Mailbox isn't supported on the GLES3 backend.
+	}
 }
 
 void cf_gles_begin_frame()

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -793,7 +793,7 @@ void cf_sdlgpu_attach(SDL_Window* window)
 {
 	SDL_ClaimWindowForGPUDevice(g_ctx.device, window);
 	g_ctx.window = window;
-	cf_sdlgpu_set_vsync_mailbox(false);
+	cf_sdlgpu_set_present_mode(CF_PRESENT_MODE_IMMEDIATE);
 	g_ctx.cmd = SDL_AcquireGPUCommandBuffer(g_ctx.device);
 }
 
@@ -823,14 +823,16 @@ void cf_sdlgpu_gpu_sync()
 	}
 }
 
-void cf_sdlgpu_set_vsync(bool vsync)
+bool cf_sdlgpu_set_present_mode(CF_PresentMode mode)
 {
-	SDL_SetGPUSwapchainParameters(g_ctx.device, g_ctx.window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, vsync ? SDL_GPU_PRESENTMODE_VSYNC : SDL_GPU_PRESENTMODE_IMMEDIATE);
-}
-
-void cf_sdlgpu_set_vsync_mailbox(bool vsync)
-{
-	SDL_SetGPUSwapchainParameters(g_ctx.device, g_ctx.window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, vsync ? SDL_GPU_PRESENTMODE_MAILBOX : SDL_GPU_PRESENTMODE_IMMEDIATE);
+	SDL_GPUPresentMode sdl_mode;
+	switch (mode) {
+	case CF_PRESENT_MODE_IMMEDIATE: sdl_mode = SDL_GPU_PRESENTMODE_IMMEDIATE; break;
+	case CF_PRESENT_MODE_VSYNC:     sdl_mode = SDL_GPU_PRESENTMODE_VSYNC;     break;
+	case CF_PRESENT_MODE_MAILBOX:   sdl_mode = SDL_GPU_PRESENTMODE_MAILBOX;   break;
+	default:                        return false;
+	}
+	return SDL_SetGPUSwapchainParameters(g_ctx.device, g_ctx.window, SDL_GPU_SWAPCHAINCOMPOSITION_SDR, sdl_mode);
 }
 
 void cf_sdlgpu_begin_frame()

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -107,7 +107,7 @@ struct CF_App
 	int sample_count = 0;
 	bool use_depth_stencil = false;
 	uint64_t default_image_id = CF_CUSTOM_SPRITE_ID_RANGE_LO;
-	bool vsync = false;
+	CF_PresentMode present_mode = CF_PRESENT_MODE_IMMEDIATE;
 	bool audio_needs_updates = false;
 	void* update_udata = NULL;
 	bool on_sound_finish_single_threaded = false;

--- a/src/internal/cute_graphics_internal.h
+++ b/src/internal/cute_graphics_internal.h
@@ -8,6 +8,7 @@
 #ifndef CF_GRAPHICS_INTERNAL_H
 #define CF_GRAPHICS_INTERNAL_H
 
+#include <cute_app.h>
 #include <cute_array.h>
 #include <cute_result.h>
 #include <cute_graphics.h>
@@ -242,8 +243,7 @@ void cf_sdlgpu_attach(SDL_Window* window);
 bool cf_sdlgpu_supports_msaa(int sample_count);
 void cf_sdlgpu_flush();
 void cf_sdlgpu_gpu_sync();
-void cf_sdlgpu_set_vsync(bool true_turn_on_vsync);
-void cf_sdlgpu_set_vsync_mailbox(bool true_turn_on_vsync);
+bool cf_sdlgpu_set_present_mode(CF_PresentMode mode);
 void cf_sdlgpu_begin_frame();
 void cf_sdlgpu_blit_canvas(CF_Canvas canvas);
 void cf_sdlgpu_end_frame();
@@ -257,7 +257,7 @@ void cf_gles_attach(SDL_Window* window);
 bool cf_gles_supports_msaa(int sample_count);
 void cf_gles_flush();
 void cf_gles_gpu_sync();
-void cf_gles_set_vsync(bool true_turn_on_vsync);
+bool cf_gles_set_present_mode(CF_PresentMode mode);
 void cf_gles_begin_frame();
 void cf_gles_blit_canvas(CF_Canvas canvas);
 void cf_gles_end_frame();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CF_TEST_SRCS
 	main.cpp
 	test_alloc.cpp
+	test_app.cpp
 	test_array.cpp
 	test_aseprite.cpp
 	test_audio.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -26,6 +26,7 @@
 #include <cute.h>
 
 TEST_SUITE(test_alloc);
+TEST_SUITE(test_app);
 TEST_SUITE(test_array);
 TEST_SUITE(test_aseprite);
 TEST_SUITE(test_audio);
@@ -70,6 +71,7 @@ int main(int argc, char* argv[])
 
 #define RUN_TRACED(suite_fp) fprintf(stderr, ">>> " #suite_fp "\n"); RUN_TEST_SUITE(suite_fp); fprintf(stderr, "<<< " #suite_fp "\n");
 	RUN_TRACED(test_alloc);
+	RUN_TRACED(test_app);
 	RUN_TRACED(test_array);
 	RUN_TRACED(test_aseprite);
 	RUN_TRACED(test_audio);

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -68,10 +68,9 @@ TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state)
 
 TEST_SUITE(test_app)
 {
-	// Don't submit this to GitHub as the build machines can't init a graphics context.
-#if 0
+	// Requires headless GPU context support in CI -- see
+	// https://github.com/RandyGaul/cute_framework/pull/517
 	RUN_TEST_CASE(test_app_present_mode_vsync_always_supported);
 	RUN_TEST_CASE(test_app_present_mode_off_round_trip);
 	RUN_TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state);
-#endif
 }

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -1,0 +1,77 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute.h>
+using namespace Cute;
+
+TEST_CASE(test_app_present_mode_vsync_always_supported)
+{
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	// SDL guarantees VSYNC + SDR composition is always supported on every backend.
+	REQUIRE(cf_app_set_present_mode(CF_PRESENT_MODE_VSYNC));
+	REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_VSYNC);
+
+	destroy_app();
+
+	return true;
+}
+
+TEST_CASE(test_app_present_mode_off_round_trip)
+{
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	REQUIRE(cf_app_set_present_mode(CF_PRESENT_MODE_VSYNC));
+	REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_VSYNC);
+
+	bool ok = cf_app_set_present_mode(CF_PRESENT_MODE_IMMEDIATE);
+	if (ok) {
+		REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_IMMEDIATE);
+	} else {
+		// IMMEDIATE isn't guaranteed by SDL on every backend -- a rejection must leave the prior mode intact.
+		REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_VSYNC);
+	}
+
+	destroy_app();
+
+	return true;
+}
+
+// Regression test: cf_app_set_vsync_mailbox(true) used to silently report success even when the backend
+// (e.g. Metal) rejected SDL_GPU_PRESENTMODE_MAILBOX, leaving the app lying about its vsync state. A
+// rejected request must never be reflected by cf_app_get_present_mode().
+TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state)
+{
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	REQUIRE(cf_app_set_present_mode(CF_PRESENT_MODE_VSYNC));
+	REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_VSYNC);
+
+	bool ok = cf_app_set_present_mode(CF_PRESENT_MODE_MAILBOX);
+	if (ok) {
+		REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_MAILBOX);
+	} else {
+		REQUIRE(cf_app_get_present_mode() == CF_PRESENT_MODE_VSYNC);
+		REQUIRE(cf_app_get_present_mode() != CF_PRESENT_MODE_MAILBOX);
+	}
+
+	destroy_app();
+
+	return true;
+}
+
+TEST_SUITE(test_app)
+{
+	// Don't submit this to GitHub as the build machines can't init a graphics context.
+#if 0
+	RUN_TEST_CASE(test_app_present_mode_vsync_always_supported);
+	RUN_TEST_CASE(test_app_present_mode_off_round_trip);
+	RUN_TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state);
+#endif
+}


### PR DESCRIPTION
Fixes `cf_app_set_vsync_mailbox(true)` silently no-op'ing on Metal: SDL's Metal driver rejects mailbox present mode, `SDL_SetGPUSwapchainParameters` returns `false`, but the old code discarded that return value and unconditionally cached `app->vsync = true` — so the app believed mailbox was active when the swapchain never actually changed.

`SDL_GPUPresentMode` is a plain enum, not a bitmask — only one mode is ever active on the swapchain. The old `cf_app_set_vsync`/`cf_app_set_vsync_mailbox` pair modeled this as two independent booleans over one shared state, which couldn't distinguish vsync from mailbox, couldn't represent a rejected request, and could silently clobber each other's result.

This replaces them with a single `cf_app_set_present_mode(CF_PresentMode)` / `cf_app_get_present_mode()` pair mirroring SDL's own model. The setter only commits the new mode when the backend actually applies it, so a rejected mailbox request on Metal now returns `false` and leaves the previous mode untouched instead of lying.

**Breaking change:** `cf_app_set_vsync`, `cf_app_set_vsync_mailbox`, and `cf_app_get_vsync` are removed rather than deprecated — this codebase has no compat-shim convention, and three overlapping boolean setters over one underlying state wasn't worth keeping around.

**⚠️ CI dependency on #517:** `test/test_app.cpp` needs a real swapchain and isn't gated behind `#if 0`, so Linux CI is expected to fail until #517 (headless GPU context via Xvfb + lavapipe) merges first. macOS/Windows CI should be unaffected.
