### PR TITLE
Fix app-layer bugs: power state, display queries, lifecycle, audio race

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -141,7 +141,7 @@ CF_API CF_Rect CF_CALL cf_display_bounds(CF_DisplayID display_id);
 /**
  * @function cf_display_name
  * @category app
- * @brief    Returns the name of the display.
+ * @brief    Returns the name of the display, or `NULL` on failure (e.g. an invalid display id).
  * @param    display_id    The id of the display. See `cf_get_display_list`.
  * @related  cf_make_app cf_display_count cf_display_x cf_display_y cf_display_width cf_display_height cf_display_refresh_rate cf_display_bounds cf_display_name cf_display_orientation
  */
@@ -843,7 +843,7 @@ CF_API float CF_CALL cf_app_get_framerate(void);
 /**
  * @function cf_app_get_smoothed_framerate
  * @category app
- * @brief    Returns the smoothed framerate of the application. Last 60 frames are averaged. This value is controlled by `CF_FRAMERATE_SMOOTHING`.
+ * @brief    Returns the smoothed framerate of the application. Uses an exponential moving average whose smoothing factor is controlled by `CF_FRAMERATE_SMOOTHING` (default 60).
  * @related  cf_app_get_framerate cf_app_get_smoothed_framerate
  */
 CF_API float CF_CALL cf_app_get_smoothed_framerate(void);

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -881,7 +881,7 @@ void* cf_app_init_imgui()
 	return (void*)::ImGui::GetCurrentContext();
 }
 
-CF_PowerState cf_power_state_from_sdl(SDL_PowerState state)
+CF_PowerState CF_CALL cf_power_state_from_sdl(SDL_PowerState state)
 {
 	CF_PowerState result = CF_POWER_STATE_UNKNOWN;
 	switch (state) {

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -52,7 +52,8 @@ int cf_display_count()
 {
 	s_init_video();
 	int count = 0;
-	SDL_GetDisplays(&count);
+	SDL_DisplayID* ids = SDL_GetDisplays(&count);
+	SDL_free(ids);
 	return count;
 }
 
@@ -72,7 +73,7 @@ void cf_free_display_list(CF_DisplayID* display_list)
 int cf_display_x(CF_DisplayID display_id)
 {
 	s_init_video();
-	SDL_Rect rect;
+	SDL_Rect rect = { 0 };
 	SDL_GetDisplayBounds(display_id, &rect);
 	return rect.x;
 }
@@ -80,7 +81,7 @@ int cf_display_x(CF_DisplayID display_id)
 int cf_display_y(CF_DisplayID display_id)
 {
 	s_init_video();
-	SDL_Rect rect;
+	SDL_Rect rect = { 0 };
 	SDL_GetDisplayBounds(display_id, &rect);
 	return rect.y;
 }
@@ -88,7 +89,7 @@ int cf_display_y(CF_DisplayID display_id)
 int cf_display_width(CF_DisplayID display_id)
 {
 	s_init_video();
-	SDL_Rect rect;
+	SDL_Rect rect = { 0 };
 	SDL_GetDisplayBounds(display_id, &rect);
 	return rect.w;
 }
@@ -96,7 +97,7 @@ int cf_display_width(CF_DisplayID display_id)
 int cf_display_height(CF_DisplayID display_id)
 {
 	s_init_video();
-	SDL_Rect rect;
+	SDL_Rect rect = { 0 };
 	SDL_GetDisplayBounds(display_id, &rect);
 	return rect.h;
 }
@@ -105,13 +106,13 @@ float cf_display_refresh_rate(CF_DisplayID display_id)
 {
 	s_init_video();
 	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_id);
-	return mode->refresh_rate;
+	return mode ? mode->refresh_rate : 0;
 }
 
 CF_Rect cf_display_bounds(CF_DisplayID display_id)
 {
 	s_init_video();
-	SDL_Rect rect;
+	SDL_Rect rect = { 0 };
 	SDL_GetDisplayBounds(display_id, &rect);
 	CF_Rect result = { rect.x, rect.y, rect.w, rect.h };
 	return result;
@@ -230,6 +231,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	}
 
 	if (!SDL_Init(sdl_options)) {
+		SDL_Quit(); // Shut down any subsystems that did initialize (e.g. audio).
 		return cf_result_error("SDL_Init failed");
 	}
 
@@ -275,6 +277,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 
 		if (cf_is_error(init_gfx_result)) {
 			gfx_backend_type = CF_BACKEND_TYPE_INVALID;
+			SDL_Quit();
 			return init_gfx_result;
 		}
 	}
@@ -308,6 +311,13 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 		}
 		window = SDL_CreateWindowWithProperties(props);
 		SDL_DestroyProperties(props);
+		if (!window) {
+#ifndef CF_EMSCRIPTEN
+			if (!use_opengl) cf_sdlgpu_cleanup();
+#endif
+			SDL_Quit();
+			return cf_result_error("Failed to create the application window.");
+		}
 	}
 
 	CF_App* app = (CF_App*)CF_ALLOC(sizeof(CF_App));
@@ -385,6 +395,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 
 void cf_destroy_app()
 {
+	if (!app) return;
 	if (app->using_imgui) {
 		cf_imgui_shutdown();
 		app->using_imgui = false;
@@ -408,13 +419,13 @@ void cf_destroy_app()
 	destroy_mutex(&app->on_sound_finish_mutex);
 	if (app->window) SDL_DestroyWindow(app->window);
 	SDL_Quit();
-	cs_shutdown();
 	CF_Image* easy_sprites = app->easy_sprites.items();
 	for (int i = 0; i < app->easy_sprites.count(); ++i) {
 		cf_image_free(&easy_sprites[i]);
 	}
 	app->~CF_App();
 	CF_FREE(app);
+	app = NULL;
 	cf_fs_destroy();
 }
 
@@ -436,8 +447,7 @@ static void s_on_update(void* udata)
 		cs_update(CF_DELTA_TIME);
 		if (app->on_sound_finish_single_threaded) {
 			mutex_lock(&app->on_sound_finish_mutex);
-			Array<CF_Sound> on_finish = app->on_sound_finish_queue;
-			app->on_sound_finish_queue.clear();
+			Array<CF_Sound> on_finish = cf_move(app->on_sound_finish_queue);
 			mutex_unlock(&app->on_sound_finish_mutex);
 			for (int i = 0; i < on_finish.size(); ++i) {
 				app->on_sound_finish(on_finish[i], app->on_sound_finish_udata);
@@ -871,18 +881,25 @@ void* cf_app_init_imgui()
 	return (void*)::ImGui::GetCurrentContext();
 }
 
+CF_PowerState cf_power_state_from_sdl(SDL_PowerState state)
+{
+	CF_PowerState result = CF_POWER_STATE_UNKNOWN;
+	switch (state) {
+	case SDL_POWERSTATE_ERROR: result = CF_POWER_STATE_ERROR; break;
+	case SDL_POWERSTATE_UNKNOWN: result = CF_POWER_STATE_UNKNOWN; break;
+	case SDL_POWERSTATE_ON_BATTERY: result = CF_POWER_STATE_ON_BATTERY; break;
+	case SDL_POWERSTATE_NO_BATTERY: result = CF_POWER_STATE_NO_BATTERY; break;
+	case SDL_POWERSTATE_CHARGING: result = CF_POWER_STATE_CHARGING; break;
+	case SDL_POWERSTATE_CHARGED: result = CF_POWER_STATE_CHARGED; break;
+	}
+	return result;
+}
+
 CF_PowerInfo cf_app_power_info()
 {
 	CF_PowerInfo info;
 	SDL_PowerState state = SDL_GetPowerInfo(&info.seconds_left, &info.percentage_left);
-	switch (state) {
-	case SDL_POWERSTATE_ERROR: info.state = CF_POWER_STATE_ERROR;
-	case SDL_POWERSTATE_UNKNOWN: info.state = CF_POWER_STATE_UNKNOWN;
-	case SDL_POWERSTATE_ON_BATTERY: info.state = CF_POWER_STATE_ON_BATTERY;
-	case SDL_POWERSTATE_NO_BATTERY: info.state = CF_POWER_STATE_NO_BATTERY;
-	case SDL_POWERSTATE_CHARGING: info.state = CF_POWER_STATE_CHARGING;
-	case SDL_POWERSTATE_CHARGED: info.state = CF_POWER_STATE_CHARGED;
-	}
+	info.state = cf_power_state_from_sdl(state);
 	return info;
 }
 

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -448,12 +448,13 @@ static void s_on_update(void* udata)
 		if (app->on_sound_finish_single_threaded) {
 			mutex_lock(&app->on_sound_finish_mutex);
 			Array<CF_Sound> on_finish = cf_move(app->on_sound_finish_queue);
+			bool music_finished = app->on_music_finish_signal;
+			app->on_music_finish_signal = false;
 			mutex_unlock(&app->on_sound_finish_mutex);
 			for (int i = 0; i < on_finish.size(); ++i) {
 				app->on_sound_finish(on_finish[i], app->on_sound_finish_udata);
 			}
-			if (app->on_music_finish && app->on_music_finish_signal) {
-				app->on_music_finish_signal = false;
+			if (app->on_music_finish && music_finished) {
 				app->on_music_finish(app->on_music_finish_udata);
 			}
 		}

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -881,20 +881,6 @@ void* cf_app_init_imgui()
 	return (void*)::ImGui::GetCurrentContext();
 }
 
-CF_PowerState CF_CALL cf_power_state_from_sdl(SDL_PowerState state)
-{
-	CF_PowerState result = CF_POWER_STATE_UNKNOWN;
-	switch (state) {
-	case SDL_POWERSTATE_ERROR: result = CF_POWER_STATE_ERROR; break;
-	case SDL_POWERSTATE_UNKNOWN: result = CF_POWER_STATE_UNKNOWN; break;
-	case SDL_POWERSTATE_ON_BATTERY: result = CF_POWER_STATE_ON_BATTERY; break;
-	case SDL_POWERSTATE_NO_BATTERY: result = CF_POWER_STATE_NO_BATTERY; break;
-	case SDL_POWERSTATE_CHARGING: result = CF_POWER_STATE_CHARGING; break;
-	case SDL_POWERSTATE_CHARGED: result = CF_POWER_STATE_CHARGED; break;
-	}
-	return result;
-}
-
 CF_PowerInfo cf_app_power_info()
 {
 	CF_PowerInfo info;

--- a/src/cute_audio.cpp
+++ b/src/cute_audio.cpp
@@ -193,7 +193,10 @@ void s_on_finish(CF_Sound snd, void* udata)
 void s_on_finish_music(void* udata)
 {
 	if (app->on_sound_finish_single_threaded) {
+		// Runs on the audio/mixer thread -- the main thread drains this under the same mutex.
+		cf_mutex_lock(&app->on_sound_finish_mutex);
 		app->on_music_finish_signal = true;
+		cf_mutex_unlock(&app->on_sound_finish_mutex);
 	} else {
 		app->on_music_finish(udata);
 	}

--- a/src/cute_audio.cpp
+++ b/src/cute_audio.cpp
@@ -181,7 +181,10 @@ CF_Sound cf_play_sound(CF_Audio audio_source, CF_SoundParams params)
 void s_on_finish(CF_Sound snd, void* udata)
 {
 	if (app->on_sound_finish_single_threaded) {
+		// Runs on the audio/mixer thread -- the main thread drains this queue under the same mutex.
+		cf_mutex_lock(&app->on_sound_finish_mutex);
 		app->on_sound_finish_queue.add(snd);
+		cf_mutex_unlock(&app->on_sound_finish_mutex);
 	} else {
 		app->on_sound_finish(snd, udata);
 	}

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -35,9 +35,22 @@ CF_API extern struct CF_App* app;
 // an explicit size via cf_app_set_canvas_size(). Called on init and whenever pixel_scale changes.
 void cf_app_recreate_default_canvas_if_needed();
 
-// Maps an SDL_PowerState to the corresponding CF_PowerState. Unit-tested in
-// test/test_app.cpp. CF_API so the tests still link when CF builds as a shared library.
-CF_API CF_PowerState CF_CALL cf_power_state_from_sdl(SDL_PowerState state);
+// Maps an SDL_PowerState to the corresponding CF_PowerState. Header-inline (rather than
+// CF_API) so it stays testable from test/test_app.cpp without crossing the shared-library
+// export boundary.
+CF_INLINE CF_PowerState cf_power_state_from_sdl(SDL_PowerState state)
+{
+	CF_PowerState result = CF_POWER_STATE_UNKNOWN;
+	switch (state) {
+	case SDL_POWERSTATE_ERROR: result = CF_POWER_STATE_ERROR; break;
+	case SDL_POWERSTATE_UNKNOWN: result = CF_POWER_STATE_UNKNOWN; break;
+	case SDL_POWERSTATE_ON_BATTERY: result = CF_POWER_STATE_ON_BATTERY; break;
+	case SDL_POWERSTATE_NO_BATTERY: result = CF_POWER_STATE_NO_BATTERY; break;
+	case SDL_POWERSTATE_CHARGING: result = CF_POWER_STATE_CHARGING; break;
+	case SDL_POWERSTATE_CHARGED: result = CF_POWER_STATE_CHARGED; break;
+	}
+	return result;
+}
 
 struct CF_MouseState
 {

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -35,8 +35,9 @@ CF_API extern struct CF_App* app;
 // an explicit size via cf_app_set_canvas_size(). Called on init and whenever pixel_scale changes.
 void cf_app_recreate_default_canvas_if_needed();
 
-// Maps an SDL_PowerState to the corresponding CF_PowerState.
-CF_PowerState cf_power_state_from_sdl(SDL_PowerState state);
+// Maps an SDL_PowerState to the corresponding CF_PowerState. Unit-tested in
+// test/test_app.cpp. CF_API so the tests still link when CF builds as a shared library.
+CF_API CF_PowerState CF_CALL cf_power_state_from_sdl(SDL_PowerState state);
 
 struct CF_MouseState
 {

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -35,6 +35,9 @@ CF_API extern struct CF_App* app;
 // an explicit size via cf_app_set_canvas_size(). Called on init and whenever pixel_scale changes.
 void cf_app_recreate_default_canvas_if_needed();
 
+// Maps an SDL_PowerState to the corresponding CF_PowerState.
+CF_PowerState cf_power_state_from_sdl(SDL_PowerState state);
+
 struct CF_MouseState
 {
 	int left_button = 0;
@@ -92,12 +95,12 @@ struct CF_App
 	CF_Filter canvas_blit_filter = CF_FILTER_NEAREST; // Filter used when blitting the app canvas onto the screen, if their sizes differ (e.g. a pinned retro canvas). Defaults to nearest for a crisp/blocky pixel-art look.
 	bool sync_window = false;
 	int draw_call_count = 0;
-	int w;
-	int h;
-	int x;
-	int y;
-	int canvas_w;
-	int canvas_h;
+	int w = 0;
+	int h = 0;
+	int x = 0;
+	int y = 0;
+	int canvas_w = 0;
+	int canvas_h = 0;
 	CF_Color clear_color = { 0, 0, 0, 0 };
 	float clear_depth = 1.0f;
 	uint32_t clear_stencil = 0;

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -10,6 +10,72 @@
 #include <cute.h>
 using namespace Cute;
 
+#include <internal/cute_app_internal.h>
+
+TEST_CASE(test_app_destroy_safety)
+{
+	// Destroying when no app was ever created must be a safe no-op.
+	cf_destroy_app();
+	// Create and destroy an app, then destroy again -- the second call must be a no-op.
+	CHECK(cf_is_error(cf_make_app(NULL, 0, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_GFX_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+	cf_destroy_app();
+	cf_destroy_app();
+	return true;
+}
+
+TEST_CASE(test_app_power_state_mapping)
+{
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_ERROR) == CF_POWER_STATE_ERROR);
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_UNKNOWN) == CF_POWER_STATE_UNKNOWN);
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_ON_BATTERY) == CF_POWER_STATE_ON_BATTERY);
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_NO_BATTERY) == CF_POWER_STATE_NO_BATTERY);
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_CHARGING) == CF_POWER_STATE_CHARGING);
+	REQUIRE(cf_power_state_from_sdl(SDL_POWERSTATE_CHARGED) == CF_POWER_STATE_CHARGED);
+	return true;
+}
+
+TEST_CASE(test_app_no_gfx_state_defaults)
+{
+	CHECK(cf_is_error(cf_make_app(NULL, 0, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_GFX_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+	int x = -1, y = -1;
+	cf_app_get_position(&x, &y);
+	REQUIRE(x == 0);
+	REQUIRE(y == 0);
+	REQUIRE(cf_app_get_canvas_width() == 0);
+	REQUIRE(cf_app_get_canvas_height() == 0);
+	cf_destroy_app();
+	return true;
+}
+
+TEST_CASE(test_display_count_matches_list)
+{
+	int count = cf_display_count();
+	REQUIRE(count >= 1);
+	CF_DisplayID* list = cf_get_display_list();
+	REQUIRE(list != NULL);
+	int n = 0;
+	while (list[n]) ++n;
+	REQUIRE(n == count);
+	cf_free_display_list(list);
+	return true;
+}
+
+TEST_CASE(test_display_invalid_id_is_safe)
+{
+	CF_DisplayID bogus = (CF_DisplayID)0xFFFFFFFFu;
+	REQUIRE(cf_display_refresh_rate(bogus) == 0);
+	REQUIRE(cf_display_x(bogus) == 0);
+	REQUIRE(cf_display_y(bogus) == 0);
+	REQUIRE(cf_display_width(bogus) == 0);
+	REQUIRE(cf_display_height(bogus) == 0);
+	CF_Rect r = cf_display_bounds(bogus);
+	REQUIRE(r.x == 0);
+	REQUIRE(r.y == 0);
+	REQUIRE(r.w == 0);
+	REQUIRE(r.h == 0);
+	return true;
+}
+
 TEST_CASE(test_app_present_mode_vsync_always_supported)
 {
 	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
@@ -68,6 +134,12 @@ TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state)
 
 TEST_SUITE(test_app)
 {
+	RUN_TEST_CASE(test_app_destroy_safety);
+	RUN_TEST_CASE(test_app_power_state_mapping);
+	RUN_TEST_CASE(test_app_no_gfx_state_defaults);
+	RUN_TEST_CASE(test_display_count_matches_list);
+	RUN_TEST_CASE(test_display_invalid_id_is_safe);
+
 	// Requires headless GPU context support in CI -- see
 	// https://github.com/RandyGaul/cute_framework/pull/517
 	RUN_TEST_CASE(test_app_present_mode_vsync_always_supported);


### PR DESCRIPTION
## Summary

Bug-hunt pass over `cute_app.cpp` / `cute_app.h` / `cute_app_internal.h`, with each claim verified against the vendored SDL3/cute_sound sources:

- **`cf_app_power_info`** — the switch had no `break`s, so every power state fell through and was reported as `CF_POWER_STATE_CHARGED`. The mapping now lives in `cf_power_state_from_sdl` (internal, unit-testable) with proper breaks.
- **`cf_display_refresh_rate`** — `SDL_GetCurrentDisplayMode` returns NULL on failure (e.g. invalid display id) and was dereferenced unconditionally; now returns 0 on failure.
- **`cf_display_x/y/width/height/bounds`** — `SDL_GetDisplayBounds` leaves the rect untouched on failure, so these returned uninitialized stack memory for an invalid display id; rects are now zero-initialized.
- **`cf_display_count`** — leaked the caller-owned array returned by `SDL_GetDisplays` on every call.
- **`CF_App`** — `w/h/x/y/canvas_w/canvas_h` had no default initializers; under `CF_APP_OPTIONS_NO_GFX_BIT`, `cf_app_get_position` and the canvas getters read uninitialized memory.
- **`cf_destroy_app`** — crashed when called with no live app (NULL deref) and left the global `app` pointer dangling after free (UAF on double-destroy or any later `cf_app_*` call). Now guarded and nulled. Also removed the dead second `cs_shutdown` call.
- **`cf_make_app` error paths** — a failed `SDL_Init` leaked the already-initialized audio subsystem, a failed gfx init leaked all SDL subsystems, and a failed `SDL_CreateWindowWithProperties` was silently ignored, yielding a broken app with no error. All three paths now clean up and report.
- **Sound-finish queue race** — `s_on_finish` runs on the audio/mixer thread and appended to `on_sound_finish_queue` without the mutex that the main-thread consumer holds; a concurrent `add` can realloc mid-drain. The producer now locks. The drain also uses `cf_move` instead of a per-frame deep copy.
- **Docs** — `cf_app_get_smoothed_framerate` is an exponential moving average (not a 60-frame window); `cf_display_name` can return NULL.

## Testing

- New `test/test_app.cpp` (5 cases): power-state mapping, invalid-display safety, NO_GFX state defaults, display count/list consistency, destroy-safety (no-app and double destroy).
- Written test-first: the mapping test failed on the fall-through, and the invalid-display + destroy-safety tests crashed (SIGSEGV) before the fixes.
- Full suite: 180/180 passing on macOS (Ninja build, `./build/tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuXca3bCLvpEqhEowd5EVW