### PR TITLE
Trim unused Linux CI dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,14 +42,10 @@ jobs:
       - name: Install Linux Dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends build-essential git make \
-          pkg-config gnome-desktop-testing \
-          libaudio-dev libfribidi-dev \
-          libxkbcommon-dev libgl1-mesa-dev libgles2-mesa-dev \
-          libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev \
-          liburing-dev \
-          libx11-dev libxext-dev libxrandr-dev libxi-dev libxcursor-dev libxfixes-dev libxinerama-dev libxss-dev libxtst-dev \
-          xvfb mesa-vulkan-drivers libvulkan1 vulkan-tools
+          sudo apt-get install -y --no-install-recommends \
+          libgl1-mesa-dev libudev-dev \
+          libx11-dev libxext-dev libxrandr-dev libxi-dev libxcursor-dev libxfixes-dev libxinerama-dev \
+          xvfb mesa-vulkan-drivers libvulkan1
         if: runner.os == 'Linux'
 
       - uses: actions/checkout@master
@@ -103,6 +99,8 @@ jobs:
           -DSDL_SNDIO=OFF
           -DSDL_WAYLAND=OFF
           -DSDL_X11=ON
+          -DSDL_X11_XSCRNSAVER=OFF
+          -DSDL_X11_XTEST=OFF
           -DCF_FRAMEWORK_STATIC=${{ matrix.framework_static }}
 
       - name: Build

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev \
             libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev pngquant
 
       - name: Compile docsparser


### PR DESCRIPTION
Most of the Linux apt list predated the current CMake config: all SDL audio backends, Wayland, and GL/GLES are disabled, so packages like NAS, fribidi, thai, and xkbcommon supported features that never compile. Compilers, git, make, and pkg-config are preinstalled on the runner images. The docs job's GL packages were left over from native builds — it only needs the mkdocs-material social-card imaging stack.

XSCRNSAVER and XTEST are the two SDL X11 sub-features that hard-error on a missing dev package instead of auto-disabling, so they are now explicitly OFF alongside the existing SDL_*=OFF flags.

Validated on my fork: the full build matrix and the Documentation workflow are green with the trimmed lists ([build run](https://github.com/pusewicz/cute_framework/actions/runs/29899779262), [docs run](https://github.com/pusewicz/cute_framework/actions/runs/29897407729)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYwZpABncrwzZuKcZovt1e
