### PR TITLE
MSL: thread-qualify cf_shader member functions

### DIFF
--- a/libraries/cute/cute_spirv.h
+++ b/libraries/cute/cute_spirv.h
@@ -7669,7 +7669,11 @@ static void cspv_msl_func(cspv_tp* g, cspv_decl* d)
 		}
 		apush(g->shadows, pn);
 	}
-	sappend(ctx->tp_out, ")\n");
+	// Member functions default to address-space-generic in MSL, which breaks
+	// binding member arrays/variables (GLSL globals) to `thread` pointer and
+	// reference parameters. The cf_shader instance always lives in a main0
+	// local, so `thread` is the right space for every function.
+	sappend(ctx->tp_out, ") thread\n");
 	g->indent = 1;
 	cspv_tp_block(g, d->body);
 	g->indent = 0;

--- a/tools/cute_spirv_test.c
+++ b/tools/cute_spirv_test.c
@@ -1245,6 +1245,29 @@ static void test_emitters(void)
 		}
 		cspv_free(&r);
 	}
+	// MSL emits shader functions as cf_shader member functions. Without a
+	// `thread` address-space qualifier they compile as address-space-generic,
+	// so passing a member array (a GLSL global) to a `thread T*` array
+	// parameter is rejected by Metal ("cannot initialize a parameter of type
+	// 'thread float2 *' with an lvalue of type '__metal_generic float2[8]'"
+	// -- the builtin draw shader's distance_polygon idiom). HLSL has no
+	// address spaces and must stay unqualified.
+	{
+		CSPV_Result r = s_emit_all(CSPV_STAGE_FRAGMENT,
+			"vec2 pts[8];\n"
+			"layout(location = 0) out vec4 result;\n"
+			"float poly(vec2 p, vec2 v[8], int n) { return v[0].x + p.x + float(n); }\n"
+			"void main() {\n"
+			"	pts[0] = vec2(1.0);\n"
+			"	result = vec4(poly(gl_FragCoord.xy, pts, 8));\n"
+			"}\n");
+		if (r.success) {
+			CHECK(strstr(r.msl, "thread float2* v, int n) thread\n") != NULL);
+			CHECK(strstr(r.msl, "cf_main_() thread\n") != NULL);
+			CHECK(strstr(r.hlsl, ") thread") == NULL);
+		}
+		cspv_free(&r);
+	}
 	// Struct-typed ternaries lower to cf_select_<name> in HLSL (FXC's ?: only
 	// accepts numeric operands, error X3020); MSL keeps the plain ternary.
 	{


### PR DESCRIPTION
On macOS every CF app crashed at boot: the MSL emitter prints the user's functions as `cf_shader` member functions, which are address-space-generic by default, so the builtin draw shader's polygon helper couldn't accept a member array (`__metal_generic float2[8]` doesn't bind to `thread float2*`). Metal rejected the shader and `cf_load_internal_shaders()` hit `CF_ASSERT(sdl_shader)`. Since the `cf_shader` instance always lives in a `main0` local, every member function is now emitted with the `thread` qualifier.

Verified on Metal hardware (the backend's first hardware run): 879 compiler checks including a new emitter-text regression test, 204/204 runtime tests, and a 21-sample sweep — all the compute demos included — boots and renders clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3vTZbtbvr4jvFyp3uihzx
