### PR TITLE
Speed up Emscripten web build links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,10 +191,11 @@ jobs:
 
       - name: Configure
         run: >
-          emcmake cmake -B build
+          emcmake cmake -B build -GNinja
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_SCAN_FOR_MODULES=OFF
           -DCF_FRAMEWORK_STATIC=ON
 
       - name: Build
-        run: cmake --build build
+        run: cmake --build build -j

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -64,7 +64,7 @@ jobs:
             -DCF_BUILD_DOCSPARSER=OFF
 
       - name: Build Emscripten samples
-        run: cmake --build build-emscripten
+        run: cmake --build build-emscripten -j
 
       - name: Generate sample pages
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,12 @@ if(EMSCRIPTEN)
 		-sFILESYSTEM=1
 		-sASYNCIFY=1
 		-sASYNCIFY_STACK_SIZE=2040000
+		# Skip ASYNCIFY instrumentation for functions proven never to suspend
+		# (never reach cf_sleep / a coroutine yield / a fiber swap). This severs
+		# the allocator hub (cf_alloc & co, an indirect call) and the cspv shader
+		# compiler from the instrumented set, shrinking the wasm-opt link pass and
+		# the output module. See cmake/asyncify_remove.txt for the list + contract.
+		-sASYNCIFY_REMOVE=@${CMAKE_CURRENT_SOURCE_DIR}/cmake/asyncify_remove.txt
 	)
 
 	target_compile_options(cute PRIVATE -O1 -fno-rtti -fno-exceptions)

--- a/cmake/asyncify_remove.txt
+++ b/cmake/asyncify_remove.txt
@@ -1,0 +1,26 @@
+# ASYNCIFY_REMOVE list for Emscripten (web) builds.
+#
+# These functions are proven to NEVER reach a suspend point -- they never
+# transitively call cf_sleep(), a coroutine yield, or an Emscripten fiber swap.
+# Removing them from ASYNCIFY instrumentation shrinks the wasm-opt pass (faster
+# link) and the output module (smaller/faster wasm), without affecting the paths
+# that genuinely suspend (the WebGL fence wait, the frame limiter, coroutines).
+#
+# Safety contract: a custom allocator installed via cf_allocator_override() must
+# not yield. The default allocator is malloc, which trivially satisfies this.
+#
+# Validate/extend this list with:  emcc ... -sASYNCIFY_ADVISE=1
+
+# Allocator hub -- indirect call through CF_Allocator.*_fn drags most of CF in.
+cf_alloc
+cf_free
+cf_calloc
+cf_realloc
+
+# cspv: CF's GLSL->SPIR-V compiler + GLSL-ES/HLSL/MSL transpiler backends.
+# Pure compute; instrumented only via its own internal indirect calls.
+cspv_*
+
+# Candidates to validate with -sASYNCIFY_ADVISE before enabling:
+# yyjson_*
+# cute_shader_*

--- a/include/cute_alloc.h
+++ b/include/cute_alloc.h
@@ -51,6 +51,11 @@ typedef struct CF_Allocator
  * @remarks  The default allocator simply calls malloc/free and friends. You may override this behavior by passing
  *           a `CF_Allocator` to this function. This lets you hook up your own custom allocator. Usually you only want
  *           to do this on certain platforms for performance optimizations, but is not a necessary thing to do for many games.
+ *
+ *           On web (Emscripten) builds, your allocator's functions must never suspend/yield (e.g. never call
+ *           `cf_sleep`, or otherwise perform a coroutine yield or fiber swap). The default allocator's functions
+ *           are excluded from Emscripten's ASYNCIFY instrumentation on the assumption that allocation never
+ *           suspends; a custom allocator that yields would corrupt the ASYNCIFY call stack instead of failing loudly.
  * @related  CF_Allocator cf_allocator_override cf_allocator_restore_default cf_alloc cf_free cf_calloc cf_realloc
  */
 CF_API void CF_CALL cf_allocator_override(CF_Allocator allocator);

--- a/web.cmd
+++ b/web.cmd
@@ -1,3 +1,3 @@
 @echo off
 mkdir build_web >nul 2>nul
-emcmake cmake -S . -B build_web -DCMAKE_BUILD_TYPE=Release
+emcmake cmake -S . -B build_web -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_SCAN_FOR_MODULES=OFF


### PR DESCRIPTION
Two independent, additive wins for web (Emscripten) link time:

1. **`ASYNCIFY_REMOVE`** for the `cf_alloc` allocator hub and the `cspv` shader compiler — both are indirect-call-heavy but provably never reach a suspend point (`cf_sleep`, a coroutine yield, or a fiber swap), so ASYNCIFY doesn't need to instrument them. Verified with `-sASYNCIFY_ADVISE=1` that both are caught by the initial heuristic scan and then correctly suppressed by the remove-list, and smoke-tested in a browser that the WebGL fence-wait / frame-limiter `cf_sleep` paths still resume correctly.
2. **Parallel Ninja links** for the 54 independent samples — CI (and `web.cmd`) configured without `-GNinja` and built without `-j`, so links ran serialized.

Measured on a clean build:
- `ASYNCIFY_REMOVE`: ~17-24% faster link, ~11-12% smaller `.wasm` (`hello_triangle`, `waves`)
- `-GNinja -j`: 33.4s → 6.6s for cute + 3 samples (~5x)