### PR TITLE
Smoke test samples

### DIFF
--- a/.github/scripts/smoke_test.sh
+++ b/.github/scripts/smoke_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Smoke test a Cute Framework sample.
+#
+# Launches a sample, lets it run for a few seconds, and verifies that it does
+# not crash or exit early. This catches regressions that only surface at
+# runtime -- most notably native shader compilation failures (e.g. the MSL
+# backend on macOS), which a plain build cannot detect.
+#
+# A sample runs its own infinite loop until the window is closed, so the
+# strategy is:
+#   * launch it in the background,
+#   * poll for the requested duration,
+#   * if it dies before the timer elapses  -> FAIL (it crashed),
+#   * if it is still alive when time is up  -> PASS (terminate it cleanly).
+#
+# Usage: smoke_test.sh <path-to-sample> [duration-seconds]
+#
+# On Linux this is expected to be wrapped in xvfb-run for a headless display.
+# On macOS and Windows the runners provide a usable desktop session, so the
+# sample can be launched directly.
+
+set -u
+
+APP="${1:?usage: smoke_test.sh <path-to-sample> [duration-seconds]}"
+DURATION="${2:-8}"
+
+# Windows builds produce an .exe; allow callers to omit the suffix.
+if [[ ! -x "$APP" && -x "$APP.exe" ]]; then
+	APP="$APP.exe"
+fi
+
+if [[ ! -e "$APP" ]]; then
+	echo "smoke test: sample '$APP' not found" >&2
+	exit 1
+fi
+
+echo "smoke test: launching '$APP' for ${DURATION}s..."
+"$APP" &
+PID=$!
+
+# Poll once per second. If the process disappears before the timer elapses it
+# exited on its own -- for these samples that means it crashed.
+for ((i = 0; i < DURATION; i++)); do
+	if ! kill -0 "$PID" 2>/dev/null; then
+		wait "$PID"
+		code=$?
+		echo "smoke test: FAILED -- '$APP' exited early after ~${i}s with code ${code}" >&2
+		exit 1
+	fi
+	sleep 1
+done
+
+# Still running after the full duration -- success. Shut it down.
+echo "smoke test: '$APP' survived ${DURATION}s, terminating."
+kill "$PID" 2>/dev/null
+wait "$PID" 2>/dev/null
+echo "smoke test: PASSED"
+exit 0

--- a/.github/scripts/smoke_test.sh
+++ b/.github/scripts/smoke_test.sh
@@ -53,6 +53,16 @@ for ((i = 0; i < DURATION; i++)); do
 	sleep 1
 done
 
+# The loop's last iteration ends with a sleep, so the process could have died
+# during that final second without us noticing. Check once more before
+# declaring success.
+if ! kill -0 "$PID" 2>/dev/null; then
+	wait "$PID"
+	code=$?
+	echo "smoke test: FAILED -- '$APP' exited early after ~${DURATION}s with code ${code}" >&2
+	exit 1
+fi
+
 # Still running after the full duration -- success. Shut it down.
 echo "smoke test: '$APP' survived ${DURATION}s, terminating."
 kill "$PID" 2>/dev/null

--- a/.github/scripts/smoke_test.sh
+++ b/.github/scripts/smoke_test.sh
@@ -25,8 +25,10 @@ set -u
 APP="${1:?usage: smoke_test.sh <path-to-sample> [duration-seconds]}"
 DURATION="${2:-8}"
 
-# Windows builds produce an .exe; allow callers to omit the suffix.
-if [[ ! -x "$APP" && -x "$APP.exe" ]]; then
+# Windows builds produce an .exe; allow callers to omit the suffix. Test with
+# -e rather than -x: Git Bash on Windows reports the executable bit
+# unreliably, which could otherwise skip this fallback for a file that exists.
+if [[ ! -e "$APP" && -e "$APP.exe" ]]; then
 	APP="$APP.exe"
 fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,21 @@ jobs:
       - name: Build
         run: cmake --build build
 
+      # Runtime smoke test: launch a shader-heavy sample and make sure it does
+      # not crash. This catches native shader-compilation regressions (e.g. the
+      # MSL backend on macOS) that a build alone cannot detect. `waves`
+      # exercises both the default draw shader and a custom runtime shader.
+      - name: Smoke test sample (Linux, headless GPU)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a -s "-screen 0 1280x720x24" ./.github/scripts/smoke_test.sh ./build/waves 8
+        env:
+          SDL_AUDIODRIVER: dummy
+          LIBGL_ALWAYS_SOFTWARE: "1"
+
+      - name: Smoke test sample
+        if: runner.os != 'Linux'
+        run: ./.github/scripts/smoke_test.sh ./build/waves 8
+
       - name: Tests (Linux, headless GPU)
         if: runner.os == 'Linux'
         run: xvfb-run -a -s "-screen 0 1280x720x24" ./build/tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,18 +108,18 @@ jobs:
 
       # Runtime smoke test: launch a shader-heavy sample and make sure it does
       # not crash. This catches native shader-compilation regressions (e.g. the
-      # MSL backend on macOS) that a build alone cannot detect. `waves`
-      # exercises both the default draw shader and a custom runtime shader.
+      # MSL backend on macOS) that a build alone cannot detect. `hrc` loads a
+      # suite of compute shaders from source at runtime, exercising that path.
       - name: Smoke test sample (Linux, headless GPU)
         if: runner.os == 'Linux'
-        run: xvfb-run -a -s "-screen 0 1280x720x24" ./.github/scripts/smoke_test.sh ./build/waves 8
+        run: xvfb-run -a -s "-screen 0 1280x720x24" ./.github/scripts/smoke_test.sh ./build/hrc 8
         env:
           SDL_AUDIODRIVER: dummy
           LIBGL_ALWAYS_SOFTWARE: "1"
 
       - name: Smoke test sample
         if: runner.os != 'Linux'
-        run: ./.github/scripts/smoke_test.sh ./build/waves 8
+        run: ./.github/scripts/smoke_test.sh ./build/hrc 8
 
       - name: Tests (Linux, headless GPU)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Building the samples verifies they compile, but not that they actually
run. Native shader compilation happens at runtime (e.g. SDL_gpu
translating to MSL on macOS), so a broken shader path can crash a sample
while the build stays green -- exactly the failure mode we hit before.

Add a portable smoke_test.sh that launches a sample, lets it run for a
few seconds, and fails if it exits early (crash) instead of surviving.
Wire it into build.yml after the build step for every OS. The `hrc`
sample is used because it loads a suite of compute shaders from source
at runtime, exercising the runtime shader-compilation path most
thoroughly -- exactly where the MSL regression we're guarding against
lived. Linux runs it under the existing headless xvfb + software-GPU
setup; macOS and Windows launch it directly.
