### PR TITLE
Route the GLSL->SPIR-V shader compiler through cf_alloc/cf_free

### DIFF
--- a/libraries/cute/cute_spirv.h
+++ b/libraries/cute/cute_spirv.h
@@ -513,7 +513,7 @@ static void* cspv_arena_alloc(cspv_arena* arena, size_t size)
 	if (!b || b->used + size > b->capacity) {
 		size_t cap = 64 * 1024;
 		if (cap < size) cap = size;
-		b = (cspv_arena_block*)malloc(sizeof(cspv_arena_block) + cap);
+		b = (cspv_arena_block*)CK_ALLOC(sizeof(cspv_arena_block) + cap);
 		b->next = arena->head;
 		b->used = 0;
 		b->capacity = cap;
@@ -529,7 +529,7 @@ static void cspv_arena_free(cspv_arena* arena)
 	cspv_arena_block* b = arena->head;
 	while (b) {
 		cspv_arena_block* next = b->next;
-		free(b);
+		CK_FREE(b);
 		b = next;
 	}
 	arena->head = NULL;

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -294,7 +294,7 @@ static CF_ShaderBytecode cf_compile_shader_to_bytecode_internal(const char* shad
 		char* preprocessed = cute_shader_preprocess(user_shd, config);
 		if (preprocessed) {
 			payload_binding = cf_compute_payload_binding(preprocessed);
-			free(preprocessed);
+			cf_free(preprocessed);
 		}
 	}
 	snprintf(payload_binding_str, sizeof(payload_binding_str), "%d", payload_binding);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -25,6 +25,12 @@ if (CF_CUTE_SHADERC)
 	# Standalone tools need a ckit implementation TU (CF apps get it from the
 	# cute library's src/cute_ckit.cpp).
 	list(APPEND CUTE_SHADERC_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/cute_shader_ckit.cpp)
+	# ...and cf_alloc/cf_free themselves, so allocations go through the same
+	# knob as everywhere else in CF (CF apps get it from the cute library),
+	# plus the CF_ASSERT handler cute_alloc.cpp relies on.
+	list(APPEND CUTE_SHADERC_SRCS
+		${CMAKE_CURRENT_SOURCE_DIR}/../src/cute_alloc.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/cute_shader_assert.cpp)
 	add_executable(cute-shaderc ${CUTE_SHADERC_SRCS})
 	target_include_directories(cute-shaderc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 	set_target_properties(cute-shaderc PROPERTIES FOLDER "tools")

--- a/tools/cute_shader.cpp
+++ b/tools/cute_shader.cpp
@@ -17,11 +17,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <cute_alloc.h>
 #include "cute/ckit.h"
 #define CUTE_SPIRV_IMPLEMENTATION
 #include "cute/cute_spirv.h"
 
 #include "cute_shader.h"
+
+static char* s_cf_strdup(const char* s)
+{
+	size_t len = strlen(s) + 1;
+	char* copy = (char*)cf_alloc(len);
+	memcpy(copy, s, len);
+	return copy;
+}
 
 //--------------------------------------------------------------------------------------------------
 // Default filesystem VFS (mirrors cute_shader.cpp's libc vfs).
@@ -34,11 +43,11 @@ static char* s_libc_read_file_content(const char* path, size_t* len, void* conte
 	fseek(file, 0, SEEK_END);
 	long size = ftell(file);
 	fseek(file, 0, SEEK_SET);
-	char* content = (char*)malloc(size + 1);
+	char* content = (char*)cf_alloc(size + 1);
 	size_t num_read = fread(content, 1, size, file);
 	fclose(file);
 	if (num_read != (size_t)size) {
-		free(content);
+		cf_free(content);
 		return NULL;
 	}
 	content[size] = '\0';
@@ -49,7 +58,7 @@ static char* s_libc_read_file_content(const char* path, size_t* len, void* conte
 static void s_libc_free_file_content(char* content, void* context)
 {
 	(void)context;
-	free(content);
+	cf_free(content);
 }
 
 static CF_ShaderCompilerVfs s_libc_vfs = {
@@ -116,7 +125,7 @@ static CF_ShaderCompilerResult s_failure(const char* header, const char* detail)
 	CF_ShaderCompilerResult result;
 	memset(&result, 0, sizeof(result));
 	result.success = false;
-	result.error_message = strdup(msg);
+	result.error_message = s_cf_strdup(msg);
 	sfree(msg);
 	return result;
 }
@@ -154,7 +163,7 @@ char* cute_shader_preprocess(const char* source, CF_ShaderCompilerConfig config)
 
 	char* out = NULL;
 	if (r.success && r.preprocessed) {
-		out = strdup(r.preprocessed);
+		out = s_cf_strdup(r.preprocessed);
 	}
 	cspv_free(&r);
 	return out;
@@ -210,9 +219,9 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 		return result;
 	}
 
-	// Bytecode blob (plain malloc; freed with free() by cute_shader_free_result).
+	// Bytecode blob (cf_alloc'd; freed with cf_free() by cute_shader_free_result).
 	size_t bytecode_size = r.word_count * sizeof(uint32_t);
-	void* bytecode = malloc(bytecode_size);
+	void* bytecode = cf_alloc(bytecode_size);
 	memcpy(bytecode, r.spirv, bytecode_size);
 
 	// GLSL 300 es source, from cute_spirv's transpiler backend (requested via
@@ -221,7 +230,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	size_t glsl300_src_size = 0;
 	if (r.glsl300) {
 		glsl300_src_size = strlen(r.glsl300);
-		glsl300_src = (char*)malloc(glsl300_src_size + 1);
+		glsl300_src = (char*)cf_alloc(glsl300_src_size + 1);
 		memcpy(glsl300_src, r.glsl300, glsl300_src_size + 1);
 	}
 
@@ -230,7 +239,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	size_t hlsl_src_size = 0;
 	if (r.hlsl) {
 		hlsl_src_size = strlen(r.hlsl);
-		hlsl_src = (char*)malloc(hlsl_src_size + 1);
+		hlsl_src = (char*)cf_alloc(hlsl_src_size + 1);
 		memcpy(hlsl_src, r.hlsl, hlsl_src_size + 1);
 	}
 
@@ -239,11 +248,11 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	size_t msl_src_size = 0;
 	if (r.msl) {
 		msl_src_size = strlen(r.msl);
-		msl_src = (char*)malloc(msl_src_size + 1);
+		msl_src = (char*)cf_alloc(msl_src_size + 1);
 		memcpy(msl_src, r.msl, msl_src_size + 1);
 	}
 
-	// Reflection: map CSPV_Reflection to CF_ShaderInfo. Arrays are malloc'd (freed by
+	// Reflection: map CSPV_Reflection to CF_ShaderInfo. Arrays are cf_alloc'd (freed by
 	// cute_shader_free_result); names are interned strings from the compiler, which
 	// are immortal -- no copies, and free_result must not free them.
 	CSPV_Reflection* rf = &r.reflection;
@@ -267,8 +276,8 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	const char** image_names = NULL;
 	int* image_binding_slots = NULL;
 	if (num_images > 0) {
-		image_names = (const char**)malloc(sizeof(char*) * num_images);
-		image_binding_slots = (int*)malloc(sizeof(int) * num_images);
+		image_names = (const char**)cf_alloc(sizeof(char*) * num_images);
+		image_binding_slots = (int*)cf_alloc(sizeof(int) * num_images);
 		for (int i = 0; i < num_images; ++i) {
 			image_names[i] = rf->samplers[i].name;
 			image_binding_slots[i] = rf->samplers[i].binding;
@@ -286,7 +295,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	int num_uniforms = (int)asize(rf->uniform_blocks);
 	CF_ShaderUniformInfo* uniforms = NULL;
 	if (num_uniforms > 0) {
-		uniforms = (CF_ShaderUniformInfo*)malloc(sizeof(CF_ShaderUniformInfo) * num_uniforms);
+		uniforms = (CF_ShaderUniformInfo*)cf_alloc(sizeof(CF_ShaderUniformInfo) * num_uniforms);
 		for (int i = 0; i < num_uniforms; ++i) {
 			uniforms[i].block_name = rf->uniform_blocks[i].name;
 			uniforms[i].block_index = rf->uniform_blocks[i].binding;
@@ -298,7 +307,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	int num_uniform_members = (int)asize(rf->uniform_members);
 	CF_ShaderUniformMemberInfo* uniform_members = NULL;
 	if (num_uniform_members > 0) {
-		uniform_members = (CF_ShaderUniformMemberInfo*)malloc(sizeof(CF_ShaderUniformMemberInfo) * num_uniform_members);
+		uniform_members = (CF_ShaderUniformMemberInfo*)cf_alloc(sizeof(CF_ShaderUniformMemberInfo) * num_uniform_members);
 		for (int i = 0; i < num_uniform_members; ++i) {
 			uniform_members[i].name = rf->uniform_members[i].name;
 			uniform_members[i].type = (CF_ShaderInfoDataType)rf->uniform_members[i].type;
@@ -310,7 +319,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	int num_inputs = (int)asize(rf->inputs);
 	CF_ShaderInputInfo* inputs = NULL;
 	if (num_inputs > 0) {
-		inputs = (CF_ShaderInputInfo*)malloc(sizeof(CF_ShaderInputInfo) * num_inputs);
+		inputs = (CF_ShaderInputInfo*)cf_alloc(sizeof(CF_ShaderInputInfo) * num_inputs);
 		for (int i = 0; i < num_inputs; ++i) {
 			inputs[i].name = rf->inputs[i].name;
 			inputs[i].location = rf->inputs[i].location;
@@ -322,7 +331,7 @@ CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompile
 	size_t preprocessed_size = 0;
 	if (config.return_preprocessed_source && r.preprocessed) {
 		preprocessed_size = slen(r.preprocessed);
-		preprocessed_copy = (char*)malloc(preprocessed_size + 1);
+		preprocessed_copy = (char*)cf_alloc(preprocessed_size + 1);
 		memcpy(preprocessed_copy, r.preprocessed, preprocessed_size + 1);
 	}
 
@@ -368,16 +377,16 @@ void cute_shader_free_result(CF_ShaderCompilerResult result)
 {
 	// Reflection names are interned strings (immortal) -- only the arrays are freed.
 	CF_ShaderInfo* shader_info = &result.bytecode.shader_info;
-	free(shader_info->inputs);
-	free(shader_info->uniform_members);
-	free(shader_info->uniforms);
-	free(shader_info->image_names);
-	free(shader_info->image_binding_slots);
+	cf_free(shader_info->inputs);
+	cf_free(shader_info->uniform_members);
+	cf_free(shader_info->uniforms);
+	cf_free(shader_info->image_names);
+	cf_free(shader_info->image_binding_slots);
 
-	free((void*)result.bytecode.glsl300_src);
-	free((void*)result.bytecode.hlsl_src);
-	free((void*)result.bytecode.msl_src);
-	free((void*)result.bytecode.content);
-	free((char*)result.preprocessed_source);
-	free((char*)result.error_message);
+	cf_free((void*)result.bytecode.glsl300_src);
+	cf_free((void*)result.bytecode.hlsl_src);
+	cf_free((void*)result.bytecode.msl_src);
+	cf_free((void*)result.bytecode.content);
+	cf_free((char*)result.preprocessed_source);
+	cf_free((char*)result.error_message);
 }

--- a/tools/cute_shader.h
+++ b/tools/cute_shader.h
@@ -82,7 +82,7 @@ extern "C" {
 CF_ShaderCompilerResult cute_shader_compile(const char* source, CF_ShaderCompilerStage stage, CF_ShaderCompilerConfig config);
 
 // Runs only the preprocessor (comments stripped, macros expanded, includes
-// resolved). Returns a malloc'd string (free with free()), or NULL on error.
+// resolved). Returns a cf_alloc'd string (free with cf_free()), or NULL on error.
 // Useful for scanning declared resources without a hand-rolled parser.
 char* cute_shader_preprocess(const char* source, CF_ShaderCompilerConfig config);
 

--- a/tools/cute_shader_assert.cpp
+++ b/tools/cute_shader_assert.cpp
@@ -1,0 +1,26 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+
+	Default CF_ASSERT handler for standalone shader tools (cute-shaderc), needed
+	because cute_alloc.cpp's CF_ASSERT calls reference g_assert_fn. CF apps get
+	g_assert_fn from src/cute_app.cpp instead; this must only be linked into
+	executables that do not link the cute library.
+*/
+
+#include <stdio.h>
+
+#include <cute_defines.h>
+#include <scottt/debugbreak.h>
+
+static void s_default_assert(bool expr, const char* message, const char* file, int line)
+{
+	if (!expr) {
+		fprintf(stderr, "CF_ASSERT(%s) : %s, line %d\n", message, file, line);
+		debug_break();
+	}
+}
+
+cf_assert_fn* g_assert_fn = s_default_assert;

--- a/tools/cute_shader_ckit.cpp
+++ b/tools/cute_shader_ckit.cpp
@@ -9,5 +9,7 @@
 	only be linked into executables that do not link the cute library.
 */
 
+#include <cute_alloc.h>
+
 #define CKIT_IMPLEMENTATION
 #include "cute/ckit.h"

--- a/tools/cute_shaderc.cpp
+++ b/tools/cute_shaderc.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <cute_alloc.h>
 #include "cute_shader.h"
 #include "builtin_shaders.h"
 
@@ -64,10 +65,10 @@ static char* read_file(const char* path)
 		fclose(file);
 		return NULL;
 	}
-	char* content = (char*)malloc(size + 1);
+	char* content = (char*)cf_alloc(size + 1);
 	fread(content, size, 1, file);
 	if (ferror(file)) {
-		free(content);
+		cf_free(content);
 		fclose(file);
 		return NULL;
 	}
@@ -563,7 +564,7 @@ int main(int argc, const char* argv[])
 			char* preprocessed = cute_shader_preprocess(input_content, config);
 			if (preprocessed) {
 				payload_binding = cf_compute_payload_binding(preprocessed);
-				free(preprocessed);
+				cf_free(preprocessed);
 			}
 		}
 		snprintf(payload_binding_str, sizeof(payload_binding_str), "%d", payload_binding);
@@ -701,7 +702,7 @@ int main(int argc, const char* argv[])
 
 	return_code = 0;
 end:
-	if (input_content != NULL) { free(input_content); }
+	if (input_content != NULL) { cf_free(input_content); }
 
 	return return_code;
 }


### PR DESCRIPTION
`cute_spirv.h`, `cute_shader.cpp`, and `cute_shaderc.cpp` were the last holdouts using raw `malloc`/`free`/`strdup` instead of CF's allocator, so `cf_allocator_override` didn't capture their allocations. This follows the same pattern already used for ckit and the other vendored single-header libs.

The arena allocator in `cute_spirv.h` now goes through ckit's own `CK_ALLOC`/`CK_FREE` (already a hard dependency, no new macro needed). Everything in `cute_shader.cpp`/`cute_shaderc.cpp` (bytecode blob, transpiled sources, reflection arrays, error strings, file reads) now goes through `cf_alloc`/`cf_free`.

The standalone `cute-shaderc` tool doesn't link the `cute` library, so routing it required adding `src/cute_alloc.cpp` to its build plus a small `g_assert_fn` shim (`tools/cute_shader_assert.cpp`) for the `CF_ASSERT` calls inside `cute_alloc.cpp` — otherwise it'd need to pull in the SDL-heavy `cute_app.cpp`.

## Test plan
- [x] `cmake --build build --target cute cute-shaderc cute-spirv-tests tests` — clean, no new warnings
- [x] `./build/cute-spirv-tests` — 873/873 checks
- [x] `./build/cute-shaderc` — manual round-trip compile (bytecode + header output)
- [x] `./build/tests` — hits a pre-existing, unrelated Metal shader-creation crash on this machine, confirmed identical on unmodified master via `git stash` A/B

https://claude.ai/code/session_01VeTrfxFPUDbsAmbKdpRBFi