### PR TITLE
HRC performance: benchmark mode, per-grid allocation, minmax-mip marching, c-1 selectivity, level caps

### DIFF
--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -93,6 +93,7 @@ typedef struct Hrc
 	CF_ComputeShader cs_minmax_mip;
 	int mip_march;               // minmax-mip cell skipping on the trace DDA + c-1 march
 	int c1_selective;            // skip the c-1 march in uniform-open cells (use R_0 only)
+	int max_levels;              // cap the cascade this many levels (-1 = full N); R at cap is the R_N=0 boundary
 	CF_Canvas emissivity_filtered;
 	CF_Canvas absorption_filtered;
 	CF_Material mat_prefilter;
@@ -243,6 +244,7 @@ void hrc_init()
 	// (measured spoke/neighborhood ratios: blend off 0.98-1.05, blend on 0.90-0.96).
 	hrc.blend_boundary = 0;
 	hrc.mip_march = 1; // minmax-mip cell skipping on by default
+	hrc.max_levels = -1; // full cascade by default
 	// Mip+max: mipmap-averaged emissivity (smooth lights) + max-absorption
 	// (conservative occlusion). Pure mipmap averaging melts thin opaque walls:
 	// a 2px absorption-4 wall box-filtered at 2x becomes absorption 2 and leaks
@@ -349,6 +351,12 @@ void hrc_compute()
 	int dim = hrc.grid;
 	int N = hrc.n;
 
+	// Cascade level cap: stop early and treat R at the cap as the R_N=0 boundary.
+	// Only T_0..T_cap are built and only R_{cap-1}..R_0 are merged. This drops the
+	// longest-range (lowest-frequency) light in exchange for fewer extend/merge passes.
+	int cap = N;
+	if (hrc.max_levels >= 1 && hrc.max_levels < N) cap = hrc.max_levels;
+
 	// Build the coarse minmax mip (absMin, absMax, emisMax per block) from the
 	// final scene textures. The trace DDA and c-1 march sample it to skip
 	// uniform blocks. Built after feedback so it reflects this frame's emission.
@@ -430,9 +438,9 @@ void hrc_compute()
 			cf_dispatch_compute(hrc.cs_trace, hrc.mat_trace, d);
 		}
 
-		// Extend remaining levels.
+		// Extend remaining levels (up to the cap).
 		int ext_start = hrc.trace_levels > 0 ? hrc.trace_levels : 1;
-		for (int i = ext_start; i <= N; i++) {
+		for (int i = ext_start; i <= cap; i++) {
 			int params[4] = { i, dim, hrc.vrays_w[i - 1], hrc.vrays_w[i] };
 			cf_material_set_uniform_cs(hrc.mat_extend, "u_cascade", params + 0, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_extend, "u_world_size", params + 1, CF_UNIFORM_TYPE_INT, 1);
@@ -453,9 +461,10 @@ void hrc_compute()
 			cf_dispatch_compute(hrc.cs_extend, hrc.mat_extend, d);
 		}
 
-		// Merge R_{N-1} down to R_0. R rows hold 2 * dim entries (dense directions).
+		// Merge R_{cap-1} down to R_0. R rows hold 2 * dim entries (dense directions).
+		// R at the cap is the zero boundary (r_zero), same role R_N=0 plays at full depth.
 		int r_ping = 0;
-		for (int i = N - 1; i >= 0; i--) {
+		for (int i = cap - 1; i >= 0; i--) {
 			int params[6] = { i, dim, hrc.vrays_w[i], hrc.vrays_w[i + 1], dim * 2, dim * 2 };
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_cascade", params + 0, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_world_size", params + 1, CF_UNIFORM_TYPE_INT, 1);
@@ -469,7 +478,7 @@ void hrc_compute()
 				hrc_div_ceil(dim, HRC_WG),
 				1
 			);
-			CF_StorageBuffer r_prev = (i == N - 1) ? hrc.r_zero : hrc.r_rad[1 - r_ping];
+			CF_StorageBuffer r_prev = (i == cap - 1) ? hrc.r_zero : hrc.r_rad[1 - r_ping];
 			CF_StorageBuffer ro[5] = {
 				hrc.vrays_rad[i], hrc.vrays_trn[i],
 				hrc.vrays_rad[i + 1], hrc.vrays_trn[i + 1],
@@ -1108,6 +1117,12 @@ void bench_init()
 		bench_add(scene, 512, 1, 1, 0, "mip")->mip_march = 1;
 		// c-1 selectivity at grid 512 (item 4): skip the c-1 march in open cells.
 		bench_add(scene, 512, 1, 1, 0, "c1sel")->c1_selective = 1;
+		// Cascade level cap (item 5): stop N-1 / N-2 levels deep at grid 512 (N=9).
+		{
+			int N = POW2_LOG2(512);
+			bench_add(scene, 512, 1, 1, 0, "cap_N-1")->max_levels = N - 1;
+			bench_add(scene, 512, 1, 1, 0, "cap_N-2")->max_levels = N - 2;
+		}
 	}
 
 	printf("scene,grid,prefilter,upscale,cm1,mip,cap,c1sel,extras,frame_ms,rmse,maxdiff\n");
@@ -1132,6 +1147,7 @@ void bench_apply(BenchConfig* c)
 	hrc.cminus1 = c->cminus1;
 	hrc.mip_march = c->mip_march;
 	hrc.c1_selective = c->c1_selective;
+	hrc.max_levels = c->max_levels;
 	bench_clear_feedback();
 }
 
@@ -1264,6 +1280,7 @@ int main(int argc, char* argv[])
 		if ((env = getenv("HRC_FREEZE")))      freeze_time = atoi(env);
 		if ((env = getenv("HRC_MIP")))         hrc.mip_march = atoi(env);
 		if ((env = getenv("HRC_CM1SEL")))      hrc.c1_selective = atoi(env);
+		if ((env = getenv("HRC_MAX_LEVELS")))  hrc.max_levels = atoi(env);
 	}
 
 	if (getenv("HRC_BENCH")) bench_init();

--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -146,6 +146,83 @@ void hrc_set_grid(int grid)
 	}
 }
 
+// Total bytes of all grid-dependent cascade SSBOs at a given grid resolution.
+// uvec2 = 8 bytes/texel; two T buffers per level (rad+trn), three R buffers
+// (ping-pong pair + zero), four frustum buffers. Buffer height = grid rows.
+size_t hrc_buffer_bytes(int grid)
+{
+	int n = POW2_LOG2(grid);
+	size_t total = 0;
+	for (int i = 0; i <= n; i++) {
+		int rays = 2 * (1 << i) + 1;
+		int probes = grid >> i;
+		size_t w = (size_t)probes * rays;
+		total += (size_t)2 * w * grid * 8; // rad + trn
+	}
+	size_t r_row = (size_t)grid * 2 * grid * 8;
+	total += 3 * r_row; // r_rad[2] + r_zero
+	total += 4 * r_row; // frustum[4]
+	return total;
+}
+
+// Allocate the grid-dependent cascade SSBOs for the currently-set grid.
+void hrc_alloc_buffers()
+{
+	int grid = hrc.grid;
+	int n = hrc.n;
+	for (int i = 0; i <= n; i++) {
+		hrc.vrays_rad[i] = hrc_make_buf(hrc.vrays_w[i], grid);
+		hrc.vrays_trn[i] = hrc_make_buf(hrc.vrays_w[i], grid);
+	}
+	for (int i = 0; i < 2; i++)
+		hrc.r_rad[i] = hrc_make_buf(grid * 2, grid);
+	hrc.r_zero = hrc_make_buf(grid * 2, grid);
+	{
+		int sz = grid * 2 * grid * 8;
+		void* zeros = cf_calloc(sz, 1);
+		cf_update_storage_buffer(hrc.r_zero, zeros, sz);
+		cf_free(zeros);
+	}
+	for (int i = 0; i < 4; i++)
+		hrc.frustum[i] = hrc_make_buf(grid * 2, grid);
+}
+
+// Destroy all grid-dependent cascade SSBOs (guarded so unused levels are skipped).
+void hrc_free_buffers()
+{
+	for (int i = 0; i <= HRC_MAX_N; i++) {
+		if (hrc.vrays_rad[i].id) { cf_destroy_storage_buffer(hrc.vrays_rad[i]); hrc.vrays_rad[i].id = 0; }
+		if (hrc.vrays_trn[i].id) { cf_destroy_storage_buffer(hrc.vrays_trn[i]); hrc.vrays_trn[i].id = 0; }
+	}
+	for (int i = 0; i < 2; i++)
+		if (hrc.r_rad[i].id) { cf_destroy_storage_buffer(hrc.r_rad[i]); hrc.r_rad[i].id = 0; }
+	if (hrc.r_zero.id) { cf_destroy_storage_buffer(hrc.r_zero); hrc.r_zero.id = 0; }
+	for (int i = 0; i < 4; i++)
+		if (hrc.frustum[i].id) { cf_destroy_storage_buffer(hrc.frustum[i]); hrc.frustum[i].id = 0; }
+}
+
+// Change grid and reallocate the cascade buffers to fit (destroy + recreate).
+void hrc_resize(int grid)
+{
+	size_t before = hrc_buffer_bytes(hrc.grid);
+	hrc_free_buffers();
+	hrc_set_grid(grid);
+	hrc_alloc_buffers();
+	// Report to stderr so the bench CSV on stdout stays clean.
+	fprintf(stderr, "[hrc] grid -> %d: cascade buffers %.1f MB -> %.1f MB\n",
+		grid, before / (1024.0 * 1024.0), hrc_buffer_bytes(grid) / (1024.0 * 1024.0));
+}
+
+// Analytical per-grid memory report (printed once at init).
+void hrc_print_memory_table()
+{
+	printf("[hrc] per-grid cascade buffer footprint:\n");
+	int grids[4] = { 128, 256, 512, 1024 };
+	for (int i = 0; i < 4; i++)
+		printf("[hrc]   grid %4d: %7.1f MB\n", grids[i], hrc_buffer_bytes(grids[i]) / (1024.0 * 1024.0));
+	fflush(stdout);
+}
+
 void hrc_init()
 {
 	CF_MEMSET(&hrc, 0, sizeof(hrc));
@@ -166,41 +243,15 @@ void hrc_init()
 	hrc.prefilter_mode = 4;
 	hrc.blend_width = 4.0f;
 
-	// Precompute max T cascade dimensions for allocation.
-	int max_vrays_w[HRC_MAX_N + 1];
-	for (int i = 0; i <= HRC_MAX_N; i++) {
-		int interval = 1 << i;
-		int rays = 2 * interval + 1; // dense directions
-		int probes = HRC_WORLD_SIZE >> i;
-		max_vrays_w[i] = probes * rays;
-	}
-
 	// Scene input canvases (nearest-neighbor: discrete pixel grid, no sRGB-space blending).
 	// Mipmaps allocated for hardware mipmap prefilter mode.
 	hrc.emissivity = hrc_make_canvas(HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_PIXEL_FORMAT_R16G16B16A16_FLOAT, CF_FILTER_NEAREST, true);
 	hrc.absorption = hrc_make_canvas(HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_PIXEL_FORMAT_R16G16B16A16_FLOAT, CF_FILTER_NEAREST, true);
 
-	// Per-cascade T SSBOs (uvec2 per texel = 8 bytes, f16-packed). Allocated at max size.
-	for (int i = 0; i <= HRC_MAX_N; i++) {
-		hrc.vrays_rad[i] = hrc_make_buf(max_vrays_w[i], HRC_WORLD_SIZE);
-		hrc.vrays_trn[i] = hrc_make_buf(max_vrays_w[i], HRC_WORLD_SIZE);
-	}
-
-	// R ping-pong SSBOs + zero buffer for R_N = 0.
-	// Dense directions: R_n holds (grid >> n) * 2^(n+1) = 2 * grid entries per row.
-	for (int i = 0; i < 2; i++)
-		hrc.r_rad[i] = hrc_make_buf(HRC_WORLD_SIZE * 2, HRC_WORLD_SIZE);
-	hrc.r_zero = hrc_make_buf(HRC_WORLD_SIZE * 2, HRC_WORLD_SIZE);
-	{
-		int sz = HRC_WORLD_SIZE * 2 * HRC_WORLD_SIZE * 8;
-		void* zeros = cf_calloc(sz, 1);
-		cf_update_storage_buffer(hrc.r_zero, zeros, sz);
-		cf_free(zeros);
-	}
-
-	// Per-frustum output SSBOs (4 rotations, 2 cones per probe).
-	for (int i = 0; i < 4; i++)
-		hrc.frustum[i] = hrc_make_buf(HRC_WORLD_SIZE * 2, HRC_WORLD_SIZE);
+	// Per-grid cascade SSBOs (T levels, R ping-pong + zero, frustum outputs).
+	// Allocated for the ACTIVE grid only and reallocated on [H] grid change,
+	// instead of the old max-world-size allocation (~400MB with dense directions).
+	hrc_alloc_buffers();
 
 	// Final output canvas (linear filtering for smooth display).
 	hrc.fluence = hrc_make_canvas(HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_PIXEL_FORMAT_R8G8B8A8_UNORM, CF_FILTER_LINEAR, false);
@@ -243,15 +294,7 @@ void hrc_shutdown()
 {
 	cf_destroy_canvas(hrc.emissivity);
 	cf_destroy_canvas(hrc.absorption);
-	for (int i = 0; i <= HRC_MAX_N; i++) {
-		cf_destroy_storage_buffer(hrc.vrays_rad[i]);
-		cf_destroy_storage_buffer(hrc.vrays_trn[i]);
-	}
-	for (int i = 0; i < 2; i++)
-		cf_destroy_storage_buffer(hrc.r_rad[i]);
-	cf_destroy_storage_buffer(hrc.r_zero);
-	for (int i = 0; i < 4; i++)
-		cf_destroy_storage_buffer(hrc.frustum[i]);
+	hrc_free_buffers();
 	cf_destroy_canvas(hrc.fluence);
 	cf_destroy_canvas(hrc.minmax);
 	cf_destroy_canvas(hrc.emissivity_filtered);
@@ -651,10 +694,10 @@ void handle_input()
 		test_scene = (test_scene + 1) % 5;
 	}
 	if (cf_key_just_pressed(CF_KEY_H)) {
-		if      (hrc.grid == 128)  hrc_set_grid(256);
-		else if (hrc.grid == 256)  hrc_set_grid(512);
-		else if (hrc.grid == 512)  hrc_set_grid(1024);
-		else                       hrc_set_grid(128);
+		if      (hrc.grid == 128)  hrc_resize(256);
+		else if (hrc.grid == 256)  hrc_resize(512);
+		else if (hrc.grid == 512)  hrc_resize(1024);
+		else                       hrc_resize(128);
 		if (hrc.trace_levels > hrc.n + 1)
 			hrc.trace_levels = hrc.n + 1;
 	}
@@ -1025,7 +1068,7 @@ void bench_clear_feedback()
 void bench_apply(BenchConfig* c)
 {
 	test_scene = c->scene;
-	hrc_set_grid(c->grid);
+	if (c->grid != hrc.grid) hrc_resize(c->grid);
 	hrc.trace_levels = c->trace_levels;
 	hrc.upscale_mode = c->upscale_mode;
 	hrc.cminus1 = c->cminus1;
@@ -1136,6 +1179,7 @@ int main(int argc, char* argv[])
 	cf_make_app("HRC - Holographic Radiance Cascades", 0, 0, 0, HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT, argv[0]);
 
 	hrc_init();
+	hrc_print_memory_table();
 	scene_init();
 
 	// Dev overrides for headless/scripted runs (same toggles as the HUD keys).

--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -14,6 +14,7 @@
 // https://github.com/entropylost/amitabha
 
 #include <cute.h>
+#include <stdio.h>
 
 //--------------------------------------------------------------------------------------------------
 // Configuration.
@@ -511,6 +512,7 @@ typedef struct OrbLight
 } OrbLight;
 
 float time_acc = 0.0f;
+int freeze_time = 0; // HRC_FREEZE=1: hold time_acc fixed (freezes the pinhole gap sweep etc.)
 int test_scene = 0; // 0 = off, 1 = static centered light, 2 = slowly orbiting light
 
 // Test light center for this frame. The light is 8x8 world pixels -- the paper
@@ -733,7 +735,7 @@ void update_lights()
 	float half = (float)HRC_WORLD_SIZE * 0.5f;
 	float ws = (float)HRC_WORLD_SIZE;
 	float dt = CF_DELTA_TIME;
-	time_acc += dt;
+	if (!freeze_time) time_acc += dt;
 	frame_light_count = 0;
 
 	// Orbiting lights.
@@ -930,6 +932,203 @@ void draw_hud()
 }
 
 //--------------------------------------------------------------------------------------------------
+// Benchmark mode (HRC_BENCH=1).
+//
+// Iterates a fixed config sweep over deterministic scenes. For each config the
+// sample renders warmup frames (long enough for cornell's multibounce feedback
+// to settle), then times BENCH_TIMED frames with the wall clock, reads back the
+// fluence canvas, and prints one CSV row with average frame ms plus quality vs
+// the in-run 1x-grid reference for the same scene (RMSE on tonemapped luma +
+// max channel diff, both on the displayed rgba8 output). Exits when the sweep
+// completes. Run a Release build for meaningful timings.
+
+typedef struct BenchConfig
+{
+	int scene;        // HRC_TEST scene id (1 static, 3 cornell, 4 pinhole)
+	int grid;
+	int trace_levels;
+	int upscale_mode;
+	int cminus1;
+	int is_reference; // first row per scene; its readback becomes the quality baseline
+	const char* extras;
+} BenchConfig;
+
+#define BENCH_MAX_CONFIGS 128
+#define BENCH_WARMUP 30           // pipeline compile + steady state
+#define BENCH_WARMUP_FEEDBACK 120 // cornell: multibounce feedback settles ~60 frames; use 2x margin
+#define BENCH_TIMED 60
+
+typedef struct Bench
+{
+	int active;
+	int index;
+	int count;
+	BenchConfig configs[BENCH_MAX_CONFIGS];
+	int state;       // 0 = apply config, 1 = warmup, 2 = timed, 3 = wait on readback
+	int frames_left;
+	uint64_t t0;
+	double frame_ms;
+	CF_Readback readback;
+	uint8_t* ref[5]; // per-scene reference pixels, indexed by scene id
+} Bench;
+
+Bench bench;
+
+void bench_add(int scene, int grid, int upscale, int cm1, int is_ref, const char* extras)
+{
+	CF_ASSERT(bench.count < BENCH_MAX_CONFIGS);
+	BenchConfig* c = &bench.configs[bench.count++];
+	c->scene = scene;
+	c->grid = grid;
+	c->trace_levels = 3;
+	c->upscale_mode = upscale;
+	c->cminus1 = cm1;
+	c->is_reference = is_ref;
+	c->extras = extras;
+}
+
+void bench_init()
+{
+	bench.active = 1;
+	bench.state = 0;
+	freeze_time = 1;
+	time_acc = 1.0f; // fixed pinhole gap position
+	cf_app_set_present_mode(CF_PRESENT_MODE_IMMEDIATE); // uncap present so GPU time is measurable
+
+	int scenes[3] = { 1, 3, 4 };
+	for (int s = 0; s < 3; s++) {
+		int scene = scenes[s];
+		// 1x-grid reference row (quality baseline for this scene).
+		bench_add(scene, HRC_WORLD_SIZE, 1, 1, 1, "reference");
+		int grids[2] = { 512, 256 };
+		for (int g = 0; g < 2; g++) {
+			bench_add(scene, grids[g], 0, 1, 0, "");
+			bench_add(scene, grids[g], 1, 1, 0, "");
+			bench_add(scene, grids[g], 2, 1, 0, "");
+			bench_add(scene, grids[g], 1, 0, 0, "");
+		}
+	}
+
+	printf("scene,grid,prefilter,upscale,cm1,extras,frame_ms,rmse,maxdiff\n");
+	fflush(stdout);
+}
+
+// Clear last frame's fluence so cornell's feedback loop always converges from
+// the same starting state regardless of which config ran before.
+void bench_clear_feedback()
+{
+	begin_canvas_draw();
+	cf_render_to(hrc.fluence_lin, true);
+	end_canvas_draw();
+}
+
+void bench_apply(BenchConfig* c)
+{
+	test_scene = c->scene;
+	hrc_set_grid(c->grid);
+	hrc.trace_levels = c->trace_levels;
+	hrc.upscale_mode = c->upscale_mode;
+	hrc.cminus1 = c->cminus1;
+	bench_clear_feedback();
+}
+
+void bench_metrics(const uint8_t* test, const uint8_t* ref, double* rmse, double* maxdiff)
+{
+	int n = HRC_WORLD_SIZE * HRC_WORLD_SIZE;
+	double sum_sq = 0.0;
+	int md = 0;
+	for (int i = 0; i < n; i++) {
+		const uint8_t* a = test + i * 4;
+		const uint8_t* b = ref + i * 4;
+		// Tonemapped luma on the displayed sRGB bytes.
+		double la = (0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2]) / 255.0;
+		double lb = (0.2126 * b[0] + 0.7152 * b[1] + 0.0722 * b[2]) / 255.0;
+		double d = la - lb;
+		sum_sq += d * d;
+		for (int ch = 0; ch < 3; ch++) {
+			int cd = abs((int)a[ch] - (int)b[ch]);
+			if (cd > md) md = cd;
+		}
+	}
+	*rmse = sqrt(sum_sq / (double)n);
+	*maxdiff = (double)md / 255.0;
+}
+
+const char* bench_scene_name(int scene)
+{
+	return scene == 1 ? "static" : scene == 2 ? "orbiting" : scene == 3 ? "cornell" : "pinhole";
+}
+
+// Called after cf_app_update, before the frame's draws (config must be in
+// place before the scene canvases render).
+void bench_pre_frame()
+{
+	if (bench.state == 0) {
+		bench_apply(&bench.configs[bench.index]);
+		BenchConfig* c = &bench.configs[bench.index];
+		bench.frames_left = (c->scene == 3) ? BENCH_WARMUP_FEEDBACK : BENCH_WARMUP;
+		bench.state = 1;
+	}
+}
+
+// Called after hrc_compute (the frame's GPU work has been submitted).
+void bench_post_frame()
+{
+	BenchConfig* c = &bench.configs[bench.index];
+	switch (bench.state) {
+	case 1: // warmup
+		if (--bench.frames_left <= 0) {
+			bench.frames_left = BENCH_TIMED;
+			bench.t0 = cf_get_ticks();
+			bench.state = 2;
+		}
+		break;
+	case 2: // timed
+		if (--bench.frames_left <= 0) {
+			uint64_t t1 = cf_get_ticks();
+			bench.frame_ms = (double)(t1 - bench.t0) / (double)cf_get_tick_frequency() * 1000.0 / (double)BENCH_TIMED;
+			bench.readback = cf_canvas_readback(hrc.fluence);
+			bench.state = 3;
+		}
+		break;
+	case 3: // wait on async readback (scene keeps rendering; it's static)
+		if (cf_readback_ready(bench.readback)) {
+			int size = cf_readback_size(bench.readback);
+			CF_ASSERT(size == HRC_WORLD_SIZE * HRC_WORLD_SIZE * 4);
+			uint8_t* pixels = (uint8_t*)cf_alloc(size);
+			cf_readback_data(bench.readback, pixels, size);
+			cf_destroy_readback(bench.readback);
+
+			double rmse = 0.0, maxdiff = 0.0;
+			if (c->is_reference) {
+				cf_free(bench.ref[c->scene]);
+				bench.ref[c->scene] = pixels; // take ownership
+			} else {
+				CF_ASSERT(bench.ref[c->scene]);
+				bench_metrics(pixels, bench.ref[c->scene], &rmse, &maxdiff);
+				cf_free(pixels);
+			}
+
+			printf("%s,%d,%d,%d,%d,%s,%.3f,%.5f,%.4f\n",
+				bench_scene_name(c->scene), c->grid, hrc.prefilter_mode, c->upscale_mode, c->cminus1,
+				c->extras, bench.frame_ms, rmse, maxdiff);
+			fflush(stdout);
+
+			bench.index++;
+			bench.state = 0;
+			if (bench.index >= bench.count) {
+				printf("BENCH DONE\n");
+				fflush(stdout);
+				for (int i = 0; i < 5; i++) cf_free(bench.ref[i]);
+				bench.active = 0;
+				cf_app_signal_shutdown();
+			}
+		}
+		break;
+	}
+}
+
+//--------------------------------------------------------------------------------------------------
 // Entry point.
 
 int main(int argc, char* argv[])
@@ -948,11 +1147,15 @@ int main(int argc, char* argv[])
 		if ((env = getenv("HRC_BLEND_WIDTH"))) hrc.blend_width = (float)atof(env);
 		if ((env = getenv("HRC_CM1")))         hrc.cminus1 = atoi(env);
 		if ((env = getenv("HRC_TRACE")))       hrc.trace_levels = atoi(env);
+		if ((env = getenv("HRC_FREEZE")))      freeze_time = atoi(env);
 	}
+
+	if (getenv("HRC_BENCH")) bench_init();
 
 	while (cf_app_is_running()) {
 		cf_app_update(NULL);
 		cf_draw_push_shape_aa(0);
+		if (bench.active) bench_pre_frame();
 		handle_input();
 		update_lights();
 		draw_emissivity();
@@ -961,8 +1164,9 @@ int main(int argc, char* argv[])
 		if (test_scene == 3) hrc_feedback();
 		hrc_compute();
 		display_fluence();
-		draw_hud();
+		if (!bench.active) draw_hud();
 		cf_app_draw_onto_screen(true);
+		if (bench.active) bench_post_frame();
 	}
 
 	hrc_shutdown();

--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -15,6 +15,7 @@
 
 #include <cute.h>
 #include <stdio.h>
+#include <string.h>
 
 //--------------------------------------------------------------------------------------------------
 // Configuration.
@@ -39,6 +40,7 @@
 #define HRC_WG            16
 #define HRC_ABS_THRESHOLD 0.1f
 #define HRC_NUM_DEBUG 8   // debug modes 0..7
+#define HRC_MIP_BLOCK 8   // minmax-mip block size (world px) ~ "8px cells"
 
 //--------------------------------------------------------------------------------------------------
 // Shader loading.
@@ -87,6 +89,9 @@ typedef struct Hrc
 	CF_Canvas minmax;
 	CF_Material mat_minmax;
 	CF_ComputeShader cs_minmax;
+	CF_Canvas minmax_mip;        // coarse (absMin, absMax, emisMax) blocks for marching
+	CF_ComputeShader cs_minmax_mip;
+	int mip_march;               // minmax-mip cell skipping on the trace DDA + c-1 march
 	CF_Canvas emissivity_filtered;
 	CF_Canvas absorption_filtered;
 	CF_Material mat_prefilter;
@@ -236,6 +241,7 @@ void hrc_init()
 	// quadrant seams already balance, and the blend only carves dark diagonals
 	// (measured spoke/neighborhood ratios: blend off 0.98-1.05, blend on 0.90-0.96).
 	hrc.blend_boundary = 0;
+	hrc.mip_march = 1; // minmax-mip cell skipping on by default
 	// Mip+max: mipmap-averaged emissivity (smooth lights) + max-absorption
 	// (conservative occlusion). Pure mipmap averaging melts thin opaque walls:
 	// a 2px absorption-4 wall box-filtered at 2x becomes absorption 2 and leaks
@@ -258,6 +264,10 @@ void hrc_init()
 
 	// Min/max absorption canvas (grid-res, allocated at world size to handle runtime grid changes).
 	hrc.minmax = hrc_make_canvas(HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_PIXEL_FORMAT_R16G16_FLOAT, CF_FILTER_NEAREST, false);
+
+	// Coarse minmax mip for accelerated marching: (absMin, absMax, emisMax) per
+	// HRC_MIP_BLOCK-sized world block, at world/block resolution.
+	hrc.minmax_mip = hrc_make_canvas(HRC_WORLD_SIZE / HRC_MIP_BLOCK, HRC_WORLD_SIZE / HRC_MIP_BLOCK, CF_PIXEL_FORMAT_R16G16B16A16_FLOAT, CF_FILTER_NEAREST, false);
 
 	// Prefiltered scene inputs (grid-res, allocated at world size).
 	hrc.emissivity_filtered = hrc_make_canvas(HRC_WORLD_SIZE, HRC_WORLD_SIZE, CF_PIXEL_FORMAT_R16G16B16A16_FLOAT, CF_FILTER_NEAREST, false);
@@ -285,6 +295,7 @@ void hrc_init()
 	hrc.cs_copy = load_compute_shader("/hrc_data/hrc_copy.c_shd");
 	hrc.cs_composite = load_compute_shader("/hrc_data/hrc_composite.c_shd");
 	hrc.cs_minmax = load_compute_shader("/hrc_data/hrc_minmax.c_shd");
+	hrc.cs_minmax_mip = load_compute_shader("/hrc_data/hrc_minmax_mip.c_shd");
 	hrc.cs_prefilter = load_compute_shader("/hrc_data/hrc_prefilter.c_shd");
 	hrc.cs_prefilter_gauss = load_compute_shader("/hrc_data/hrc_prefilter_gauss.c_shd");
 	hrc.cs_feedback = load_compute_shader("/hrc_data/hrc_feedback.c_shd");
@@ -297,6 +308,8 @@ void hrc_shutdown()
 	hrc_free_buffers();
 	cf_destroy_canvas(hrc.fluence);
 	cf_destroy_canvas(hrc.minmax);
+	cf_destroy_canvas(hrc.minmax_mip);
+	cf_destroy_compute_shader(hrc.cs_minmax_mip);
 	cf_destroy_canvas(hrc.emissivity_filtered);
 	cf_destroy_canvas(hrc.absorption_filtered);
 	cf_destroy_canvas(hrc.diffuse);
@@ -330,9 +343,29 @@ void hrc_compute()
 	CF_Texture absrp_tex = cf_canvas_get_target(hrc.absorption);
 	CF_Texture fluence_tex = cf_canvas_get_target(hrc.fluence);
 	CF_Texture minmax_tex = cf_canvas_get_target(hrc.minmax);
+	CF_Texture minmax_mip_tex = cf_canvas_get_target(hrc.minmax_mip);
 
 	int dim = hrc.grid;
 	int N = hrc.n;
+
+	// Build the coarse minmax mip (absMin, absMax, emisMax per block) from the
+	// final scene textures. The trace DDA and c-1 march sample it to skip
+	// uniform blocks. Built after feedback so it reflects this frame's emission.
+	if (hrc.mip_march) {
+		int world = HRC_WORLD_SIZE;
+		int block = HRC_MIP_BLOCK;
+		int blocks = world / block;
+		cf_material_set_texture_cs(hrc.mat_minmax, "u_absorption", absrp_tex);
+		cf_material_set_texture_cs(hrc.mat_minmax, "u_emissivity", emiss_tex);
+		cf_material_set_uniform_cs(hrc.mat_minmax, "u_world_size", &world, CF_UNIFORM_TYPE_INT, 1);
+		cf_material_set_uniform_cs(hrc.mat_minmax, "u_block", &block, CF_UNIFORM_TYPE_INT, 1);
+		CF_ComputeDispatch d = cf_compute_dispatch_defaults(
+			hrc_div_ceil(blocks, HRC_WG), hrc_div_ceil(blocks, HRC_WG), 1);
+		CF_Texture rw_tex[1] = { minmax_mip_tex };
+		d.rw_textures = rw_tex;
+		d.rw_texture_count = 1;
+		cf_dispatch_compute(hrc.cs_minmax_mip, hrc.mat_minmax, d);
+	}
 
 	// The trace shader marches raw full-resolution scene textures (prefiltering
 	// quantizes moving emitters into visible flicker and melts thin occluders),
@@ -346,6 +379,10 @@ void hrc_compute()
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_mip_level", &mip_level, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_absrp_mip_level", &absrp_mip_level, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_upscale", &upscale, CF_UNIFORM_TYPE_INT, 1);
+	int mip_block = HRC_MIP_BLOCK;
+	cf_material_set_texture_cs(hrc.mat_trace, "u_minmax_mip", minmax_mip_tex);
+	cf_material_set_uniform_cs(hrc.mat_trace, "u_use_mip", &hrc.mip_march, CF_UNIFORM_TYPE_INT, 1);
+	cf_material_set_uniform_cs(hrc.mat_trace, "u_mip_block", &mip_block, CF_UNIFORM_TYPE_INT, 1);
 
 	for (int j = 0; j < 4; j++) {
 		// Seed T_0 when no levels are traced (sample at probe, no raymarching).
@@ -490,15 +527,19 @@ void hrc_compute()
 		int world = HRC_WORLD_SIZE;
 		float abs_thresh = HRC_ABS_THRESHOLD;
 		int debug = hrc.debug_mode <= 5 ? hrc.debug_mode : 0;
+		int mip_block = HRC_MIP_BLOCK;
 		cf_material_set_texture_cs(hrc.mat_composite, "u_emissivity", emiss_tex);
 		cf_material_set_texture_cs(hrc.mat_composite, "u_absorption", absrp_tex);
 		cf_material_set_texture_cs(hrc.mat_composite, "u_minmax", minmax_tex);
+		cf_material_set_texture_cs(hrc.mat_composite, "u_minmax_mip", minmax_mip_tex);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_world_size", &world, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_grid_size", &dim, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_abs_threshold", &abs_thresh, CF_UNIFORM_TYPE_FLOAT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_debug_mode", &debug, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_cminus1", &hrc.cminus1, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_upscale_mode", &hrc.upscale_mode, CF_UNIFORM_TYPE_INT, 1);
+		cf_material_set_uniform_cs(hrc.mat_composite, "u_use_mip", &hrc.mip_march, CF_UNIFORM_TYPE_INT, 1);
+		cf_material_set_uniform_cs(hrc.mat_composite, "u_mip_block", &mip_block, CF_UNIFORM_TYPE_INT, 1);
 
 		CF_ComputeDispatch d = cf_compute_dispatch_defaults(
 			hrc_div_ceil(world, HRC_WG),
@@ -992,6 +1033,9 @@ typedef struct BenchConfig
 	int trace_levels;
 	int upscale_mode;
 	int cminus1;
+	int mip_march;    // minmax-mip cell skipping
+	int max_levels;   // cascade level cap (-1 = full)
+	int c1_selective; // c-1 selectivity (item 4)
 	int is_reference; // first row per scene; its readback becomes the quality baseline
 	const char* extras;
 } BenchConfig;
@@ -1012,12 +1056,13 @@ typedef struct Bench
 	uint64_t t0;
 	double frame_ms;
 	CF_Readback readback;
-	uint8_t* ref[5]; // per-scene reference pixels, indexed by scene id
+	uint8_t* ref[5];    // per-scene reference pixels, indexed by scene id
+	uint8_t* ab_ref[5]; // per-scene "nomip" image, for the mip-neutrality A/B diff
 } Bench;
 
 Bench bench;
 
-void bench_add(int scene, int grid, int upscale, int cm1, int is_ref, const char* extras)
+BenchConfig* bench_add(int scene, int grid, int upscale, int cm1, int is_ref, const char* extras)
 {
 	CF_ASSERT(bench.count < BENCH_MAX_CONFIGS);
 	BenchConfig* c = &bench.configs[bench.count++];
@@ -1026,8 +1071,12 @@ void bench_add(int scene, int grid, int upscale, int cm1, int is_ref, const char
 	c->trace_levels = 3;
 	c->upscale_mode = upscale;
 	c->cminus1 = cm1;
+	c->mip_march = 1;      // mip on by default
+	c->max_levels = -1;    // full cascade by default
+	c->c1_selective = 0;   // off by default
 	c->is_reference = is_ref;
 	c->extras = extras;
+	return c;
 }
 
 void bench_init()
@@ -1050,9 +1099,14 @@ void bench_init()
 			bench_add(scene, grids[g], 2, 1, 0, "");
 			bench_add(scene, grids[g], 1, 0, 0, "");
 		}
+		// Minmax-mip marching A/B at grid 512 (item 3 correctness/perf gate).
+		// nomip runs first and stashes its image; the mip row's rmse/maxdiff are
+		// measured DIRECTLY against that nomip image (neutrality), not the reference.
+		bench_add(scene, 512, 1, 1, 0, "nomip")->mip_march = 0;
+		bench_add(scene, 512, 1, 1, 0, "mip")->mip_march = 1;
 	}
 
-	printf("scene,grid,prefilter,upscale,cm1,extras,frame_ms,rmse,maxdiff\n");
+	printf("scene,grid,prefilter,upscale,cm1,mip,cap,c1sel,extras,frame_ms,rmse,maxdiff\n");
 	fflush(stdout);
 }
 
@@ -1072,6 +1126,7 @@ void bench_apply(BenchConfig* c)
 	hrc.trace_levels = c->trace_levels;
 	hrc.upscale_mode = c->upscale_mode;
 	hrc.cminus1 = c->cminus1;
+	hrc.mip_march = c->mip_march;
 	bench_clear_feedback();
 }
 
@@ -1146,15 +1201,25 @@ void bench_post_frame()
 			if (c->is_reference) {
 				cf_free(bench.ref[c->scene]);
 				bench.ref[c->scene] = pixels; // take ownership
+			} else if (strcmp(c->extras, "nomip") == 0) {
+				// Measure vs reference AND stash the image for the mip A/B.
+				bench_metrics(pixels, bench.ref[c->scene], &rmse, &maxdiff);
+				cf_free(bench.ab_ref[c->scene]);
+				bench.ab_ref[c->scene] = pixels; // take ownership
+			} else if (strcmp(c->extras, "mip") == 0) {
+				// Direct neutrality diff against the nomip image (not the reference).
+				CF_ASSERT(bench.ab_ref[c->scene]);
+				bench_metrics(pixels, bench.ab_ref[c->scene], &rmse, &maxdiff);
+				cf_free(pixels);
 			} else {
 				CF_ASSERT(bench.ref[c->scene]);
 				bench_metrics(pixels, bench.ref[c->scene], &rmse, &maxdiff);
 				cf_free(pixels);
 			}
 
-			printf("%s,%d,%d,%d,%d,%s,%.3f,%.5f,%.4f\n",
+			printf("%s,%d,%d,%d,%d,%d,%d,%d,%s,%.3f,%.5f,%.4f\n",
 				bench_scene_name(c->scene), c->grid, hrc.prefilter_mode, c->upscale_mode, c->cminus1,
-				c->extras, bench.frame_ms, rmse, maxdiff);
+				c->mip_march, c->max_levels, c->c1_selective, c->extras, bench.frame_ms, rmse, maxdiff);
 			fflush(stdout);
 
 			bench.index++;
@@ -1162,7 +1227,7 @@ void bench_post_frame()
 			if (bench.index >= bench.count) {
 				printf("BENCH DONE\n");
 				fflush(stdout);
-				for (int i = 0; i < 5; i++) cf_free(bench.ref[i]);
+				for (int i = 0; i < 5; i++) { cf_free(bench.ref[i]); cf_free(bench.ab_ref[i]); }
 				bench.active = 0;
 				cf_app_signal_shutdown();
 			}
@@ -1192,6 +1257,7 @@ int main(int argc, char* argv[])
 		if ((env = getenv("HRC_CM1")))         hrc.cminus1 = atoi(env);
 		if ((env = getenv("HRC_TRACE")))       hrc.trace_levels = atoi(env);
 		if ((env = getenv("HRC_FREEZE")))      freeze_time = atoi(env);
+		if ((env = getenv("HRC_MIP")))         hrc.mip_march = atoi(env);
 	}
 
 	if (getenv("HRC_BENCH")) bench_init();

--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -92,6 +92,7 @@ typedef struct Hrc
 	CF_Canvas minmax_mip;        // coarse (absMin, absMax, emisMax) blocks for marching
 	CF_ComputeShader cs_minmax_mip;
 	int mip_march;               // minmax-mip cell skipping on the trace DDA + c-1 march
+	int c1_selective;            // skip the c-1 march in uniform-open cells (use R_0 only)
 	CF_Canvas emissivity_filtered;
 	CF_Canvas absorption_filtered;
 	CF_Material mat_prefilter;
@@ -540,6 +541,7 @@ void hrc_compute()
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_upscale_mode", &hrc.upscale_mode, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_use_mip", &hrc.mip_march, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_mip_block", &mip_block, CF_UNIFORM_TYPE_INT, 1);
+		cf_material_set_uniform_cs(hrc.mat_composite, "u_c1_selective", &hrc.c1_selective, CF_UNIFORM_TYPE_INT, 1);
 
 		CF_ComputeDispatch d = cf_compute_dispatch_defaults(
 			hrc_div_ceil(world, HRC_WG),
@@ -1104,6 +1106,8 @@ void bench_init()
 		// measured DIRECTLY against that nomip image (neutrality), not the reference.
 		bench_add(scene, 512, 1, 1, 0, "nomip")->mip_march = 0;
 		bench_add(scene, 512, 1, 1, 0, "mip")->mip_march = 1;
+		// c-1 selectivity at grid 512 (item 4): skip the c-1 march in open cells.
+		bench_add(scene, 512, 1, 1, 0, "c1sel")->c1_selective = 1;
 	}
 
 	printf("scene,grid,prefilter,upscale,cm1,mip,cap,c1sel,extras,frame_ms,rmse,maxdiff\n");
@@ -1127,6 +1131,7 @@ void bench_apply(BenchConfig* c)
 	hrc.upscale_mode = c->upscale_mode;
 	hrc.cminus1 = c->cminus1;
 	hrc.mip_march = c->mip_march;
+	hrc.c1_selective = c->c1_selective;
 	bench_clear_feedback();
 }
 
@@ -1258,6 +1263,7 @@ int main(int argc, char* argv[])
 		if ((env = getenv("HRC_TRACE")))       hrc.trace_levels = atoi(env);
 		if ((env = getenv("HRC_FREEZE")))      freeze_time = atoi(env);
 		if ((env = getenv("HRC_MIP")))         hrc.mip_march = atoi(env);
+		if ((env = getenv("HRC_CM1SEL")))      hrc.c1_selective = atoi(env);
 	}
 
 	if (getenv("HRC_BENCH")) bench_init();

--- a/samples/hrc_data/hrc_composite.c_shd
+++ b/samples/hrc_data/hrc_composite.c_shd
@@ -41,6 +41,7 @@ layout(set = 2, binding = 0) uniform Params
 	int   u_upscale_mode;  // 0 = nearest, 1 = minmax bilinear, 2 = joint bilateral
 	int   u_use_mip;       // 1 = minmax-mip cell skipping on the c-1 march
 	int   u_mip_block;     // block size (world px) of the minmax mip
+	int   u_c1_selective;  // 1 = skip the c-1 march in uniform-open cells (use R_0 only)
 };
 
 #define MIP_EPS_EMPTY   0.01
@@ -307,6 +308,17 @@ vec3 sum_quadrants(ivec2 world_pos)
 		}
 	}
 
+	// c-1 selectivity: in a fully-uniform OPEN cell the c-1 march degenerates to
+	// (rad 0, transmittance 1), so the merge with R_0 is just R_0. Classify the
+	// pixel's own cell via the minmax mip and skip the march there. Open cells
+	// are never emissive (emitters are opaque), so no emission term is dropped.
+	bool c1_skip = false;
+	if (u_c1_selective != 0 && u_cminus1 != 0) {
+		vec2 uvp = (vec2(world_pos) + 0.5) / float(u_world_size);
+		float amax = textureLod(u_minmax_mip, uvp, 0.0).g;
+		c1_skip = amax < MIP_EPS_EMPTY;
+	}
+
 	vec3 total = vec3(0.0);
 	for (int rot = 0; rot < 4; rot++) {
 		vec3 r0;
@@ -350,7 +362,7 @@ vec3 sum_quadrants(ivec2 world_pos)
 		}
 
 		// c-1 gathering: trace to nearest probe, merge with (possibly interpolated) R_0.
-		if (u_cminus1 != 0) {
+		if (u_cminus1 != 0 && !c1_skip) {
 			Interval cminus1 = trace_cminus1(world_pos, rot);
 			total += cminus1.rad + cminus1.trn * r0;
 		} else {

--- a/samples/hrc_data/hrc_composite.c_shd
+++ b/samples/hrc_data/hrc_composite.c_shd
@@ -23,10 +23,11 @@
 layout(set = 0, binding = 0) uniform sampler2D u_emissivity;
 layout(set = 0, binding = 1) uniform sampler2D u_absorption;
 layout(set = 0, binding = 2) uniform sampler2D u_minmax;
-layout(std430, set = 0, binding = 3) readonly buffer F0 { uvec2 data[]; } u_f0;
-layout(std430, set = 0, binding = 4) readonly buffer F1 { uvec2 data[]; } u_f1;
-layout(std430, set = 0, binding = 5) readonly buffer F2 { uvec2 data[]; } u_f2;
-layout(std430, set = 0, binding = 6) readonly buffer F3 { uvec2 data[]; } u_f3;
+layout(set = 0, binding = 3) uniform sampler2D u_minmax_mip; // (absMin, absMax, emisMax) per block
+layout(std430, set = 0, binding = 4) readonly buffer F0 { uvec2 data[]; } u_f0;
+layout(std430, set = 0, binding = 5) readonly buffer F1 { uvec2 data[]; } u_f1;
+layout(std430, set = 0, binding = 6) readonly buffer F2 { uvec2 data[]; } u_f2;
+layout(std430, set = 0, binding = 7) readonly buffer F3 { uvec2 data[]; } u_f3;
 layout(set = 1, binding = 0, rgba8) uniform writeonly image2D u_fluence;
 layout(set = 1, binding = 1, rgba16f) uniform image2D u_fluence_lin; // linear copy (feeds multibounce feedback)
 
@@ -38,7 +39,13 @@ layout(set = 2, binding = 0) uniform Params
 	int   u_debug_mode;
 	int   u_cminus1;       // 0 = skip c-1 gathering, 1 = raymarch c-1
 	int   u_upscale_mode;  // 0 = nearest, 1 = minmax bilinear, 2 = joint bilateral
+	int   u_use_mip;       // 1 = minmax-mip cell skipping on the c-1 march
+	int   u_mip_block;     // block size (world px) of the minmax mip
 };
+
+#define MIP_EPS_EMPTY   0.01
+#define MIP_EPS_UNIFORM 0.02
+#define MIP_EPS_EMIS    0.001 // any emission (incl. faint multibounce) forces fine steps
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
@@ -137,9 +144,34 @@ Interval trace_cminus1(ivec2 world_pos, int rot)
 	vec3 acc_rad = vec3(0.0);
 	vec3 acc_trn = vec3(1.0);
 
-	for (int i = 0; i < num_steps; i++) {
+	int sgn = dir.x + dir.y; // ±1 along the march axis
+
+	int i = 0;
+	while (i < num_steps) {
 		ivec2 p = world_pos + dir * i;
 		vec2 uv = (vec2(p) + 0.5) / world;
+
+		// Minmax-mip cell skip on the short c-1 march (same logic as the trace DDA).
+		if (u_use_mip != 0) {
+			vec3 mm = textureLod(u_minmax_mip, uv, 0.0).rgb;
+			bool uniform_empty = mm.y < MIP_EPS_EMPTY;
+			bool uniform_fog   = mm.x > MIP_EPS_EMPTY && (mm.y - mm.x) < MIP_EPS_UNIFORM && mm.z < MIP_EPS_EMIS;
+			if (uniform_empty || uniform_fog) {
+				int B = u_mip_block;
+				int along = (dir.x != 0) ? p.x : p.y;
+				int bpos = along / B;
+				int steps_to_edge = (sgn > 0) ? (bpos + 1) * B - along : along - bpos * B + 1;
+				int M = min(steps_to_edge, num_steps - i);
+				if (M < 1) M = 1;
+				if (uniform_fog) {
+					vec3 op = texture(u_absorption, uv).rgb;
+					vec3 absrp = -log(max(vec3(1.0) - op, vec3(1e-7)));
+					acc_trn *= exp(-absrp * (step_abs * float(M)));
+				}
+				i += M;
+				continue;
+			}
+		}
 
 		// Decode emission/16 + opacity encoding (see hrc_trace.c_shd).
 		vec3 emiss = linear_from_srgb(texture(u_emissivity, uv).rgb) * 16.0;
@@ -149,6 +181,7 @@ Interval trace_cminus1(ivec2 world_pos, int rot)
 		vec3 trans = exp(-absrp * step_abs);
 		acc_rad += acc_trn * emiss * (vec3(1.0) - trans);
 		acc_trn *= trans;
+		i++;
 	}
 
 	return Interval(acc_rad, acc_trn);

--- a/samples/hrc_data/hrc_minmax_mip.c_shd
+++ b/samples/hrc_data/hrc_minmax_mip.c_shd
@@ -1,0 +1,62 @@
+// Min/max absorption + max emission per coarse block, for accelerated marching.
+//
+// Dispatched at (world_size / block) resolution. Each thread reduces one
+// block x block region of the WORLD-resolution scene and writes:
+//   .r = min absorption (max channel)   .g = max absorption (max channel)
+//   .b = max emission   (max channel)   .a = 0
+//
+// The trace DDA and the c-1 march sample this to classify a block as
+// uniform-empty (max abs ~0), uniform-fog (max-min abs ~0 and no emission),
+// or mixed. Uniform blocks are crossed with a single analytic Beer step;
+// only mixed/emissive blocks are fine-stepped. Because emitters in these
+// scenes are opaque (they absorb to emit), any block containing an emitter
+// has high absorption AND non-zero emission, so it is never skipped.
+//
+// Absorption is stored as a per-pixel OPACITY (1 - exp(-absorption)); decode
+// to the coefficient before reducing (see hrc_trace.c_shd).
+//
+// Pipeline:  minmax_mip -> [trace] -> [extend] -> [merge] -> [composite]
+//            ^^^^^^^^^^
+
+layout(set = 0, binding = 0) uniform sampler2D u_absorption;
+layout(set = 0, binding = 1) uniform sampler2D u_emissivity;
+layout(set = 1, binding = 0, rgba16f) uniform writeonly image2D u_mip;
+
+layout(set = 2, binding = 0) uniform Params
+{
+	int u_world_size;
+	int u_block;
+};
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+vec3 linear_from_srgb(vec3 c) { return pow(c, vec3(2.2)); }
+
+void main()
+{
+	ivec2 gid = ivec2(gl_GlobalInvocationID.xy);
+	int blocks = u_world_size / u_block;
+	if (gid.x >= blocks || gid.y >= blocks) return;
+
+	ivec2 base = gid * u_block;
+	float world = float(u_world_size);
+
+	float amin = 1e30;
+	float amax = 0.0;
+	float emax = 0.0;
+	for (int dy = 0; dy < u_block; dy++) {
+		for (int dx = 0; dx < u_block; dx++) {
+			ivec2 p = base + ivec2(dx, dy);
+			vec2 uv = (vec2(p) + 0.5) / world;
+			vec3 op = texture(u_absorption, uv).rgb;
+			vec3 absrp = -log(max(vec3(1.0) - op, vec3(1e-7)));
+			float a = max(max(absrp.r, absrp.g), absrp.b);
+			amin = min(amin, a);
+			amax = max(amax, a);
+			vec3 em = linear_from_srgb(texture(u_emissivity, uv).rgb) * 16.0;
+			emax = max(emax, max(max(em.r, em.g), em.b));
+		}
+	}
+
+	imageStore(u_mip, gid, vec4(amin, amax, emax, 0.0));
+}

--- a/samples/hrc_data/hrc_trace.c_shd
+++ b/samples/hrc_data/hrc_trace.c_shd
@@ -19,6 +19,7 @@
 
 layout(set = 0, binding = 0) uniform sampler2D u_emissivity;
 layout(set = 0, binding = 1) uniform sampler2D u_absorption;
+layout(set = 0, binding = 2) uniform sampler2D u_minmax_mip; // (absMin, absMax, emisMax) per block
 
 layout(std430, set = 1, binding = 0) writeonly buffer OutRad { uvec2 data[]; } u_out_rad;
 layout(std430, set = 1, binding = 1) writeonly buffer OutTrn { uvec2 data[]; } u_out_trn;
@@ -34,7 +35,14 @@ layout(set = 2, binding = 0) uniform Params
 	float u_mip_level;         // emissivity mipmap LOD (0.0 = base level)
 	float u_absrp_mip_level;   // absorption mipmap LOD (0.0 = base level)
 	int u_upscale;             // world pixels per grid cell (march substeps)
+	int u_use_mip;             // 1 = minmax-mip cell skipping enabled
+	int u_mip_block;           // block size (world px) of the minmax mip
 };
+
+// Uniform-cell classification thresholds (absorption coefficient / emission).
+#define MIP_EPS_EMPTY   0.01
+#define MIP_EPS_UNIFORM 0.02
+#define MIP_EPS_EMIS    0.001 // any emission (incl. faint multibounce) forces fine steps
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 
@@ -137,10 +145,56 @@ void main()
 
 	float fy = y0;
 	int cy = int(floor(fy));
+	int world_i = u_world_size * S;
 
-	for (int s = 0; s < num_steps; s++) {
+	int s = 0;
+	while (s < num_steps) {
 		float px = x0 + float(s);
 		if (px >= world) break;
+
+		// Minmax-mip cell skip: cross a uniform block with one analytic Beer
+		// step instead of fine-stepping every world column. Empty blocks are a
+		// pure no-op (transmittance 1, no emission); uniform-fog blocks apply a
+		// single per-channel Beer term. Emitters are opaque, so any block that
+		// emits also has high absorption and never classifies as uniform-empty,
+		// and the emission check keeps uniform-fog off emissive blocks -- so all
+		// radiance-bearing cells still get exact fine steps.
+		if (u_use_mip != 0 && cy >= 0 && cy < world_i) {
+			vec2 uv_c = rotate_uv((vec2(px, float(cy)) + 0.5) / world, u_rotate, 1.0);
+			vec3 mm = textureLod(u_minmax_mip, uv_c, 0.0).rgb; // (absMin, absMax, emisMax)
+			bool uniform_empty = mm.y < MIP_EPS_EMPTY;
+			// Require amin above the empty floor so blocks straddling empty and
+			// fog (range small only because the fog is faint) are NOT skipped --
+			// a single sample can't represent a mixed empty/fog column run.
+			bool uniform_fog   = mm.x > MIP_EPS_EMPTY && (mm.y - mm.x) < MIP_EPS_UNIFORM && mm.z < MIP_EPS_EMIS;
+			if (uniform_empty || uniform_fog) {
+				int B = u_mip_block;
+				int ipx = int(px);
+				int bx = ipx / B;
+				int cols_x = (bx + 1) * B - ipx; // columns until x leaves block (>=1)
+				int by = cy / B;
+				int cols_y;
+				if (slope.y > 1e-6) {
+					cols_y = int(floor((float((by + 1) * B) - fy) / slope.y));
+				} else if (slope.y < -1e-6) {
+					cols_y = int(floor((fy - float(by * B)) / (-slope.y)));
+				} else {
+					cols_y = num_steps;
+				}
+				int M = min(min(cols_x, max(cols_y, 1)), num_steps - s);
+				if (M < 1) M = 1;
+				if (uniform_fog) {
+					// Uniform block: one real sample gives the per-channel coefficient.
+					vec3 op = textureLod(u_absorption, uv_c, u_absrp_mip_level).rgb;
+					vec3 absrp = -log(max(vec3(1.0) - op, vec3(1e-7)));
+					acc_trn *= exp(-absrp * (float(M) * step_length));
+				}
+				s += M;
+				fy = y0 + slope.y * float(s);
+				cy = int(floor(fy));
+				continue;
+			}
+		}
 
 		float next_fy = y0 + slope.y * float(s + 1);
 		int next_cy = int(floor(next_fy));
@@ -160,6 +214,7 @@ void main()
 
 		fy = next_fy;
 		cy = next_cy;
+		s++;
 	}
 
 	// Blend boundary: near-boundary rays (small k or k near 2*pow2n) get reduced

--- a/snap_hrc.ps1
+++ b/snap_hrc.ps1
@@ -1,0 +1,28 @@
+param([string]$Out, [int]$Wait = 6)
+$exe = "C:\randy\cf-hrc-perf\build\Release\hrc.exe"
+$p = Start-Process -FilePath $exe -WorkingDirectory "C:\randy\cf-hrc-perf\build\Release" -PassThru
+Start-Sleep -Seconds $Wait
+$p.Refresh()
+Add-Type -AssemblyName System.Drawing
+Add-Type @'
+using System;
+using System.Runtime.InteropServices;
+public class W {
+  [DllImport("user32.dll")] public static extern bool PrintWindow(IntPtr h, IntPtr dc, uint flags);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out RECT r);
+  public struct RECT { public int L, T, R, B; }
+}
+'@
+$hwnd = $p.MainWindowHandle
+if ($hwnd -eq [IntPtr]::Zero) { Write-Output "NO WINDOW"; Stop-Process -Id $p.Id -Force; exit 1 }
+$r = New-Object W+RECT
+[W]::GetWindowRect($hwnd, [ref]$r) | Out-Null
+$w = $r.R - $r.L; $h = $r.B - $r.T
+$bmp = New-Object System.Drawing.Bitmap($w, $h)
+$g = [System.Drawing.Graphics]::FromImage($bmp)
+$dc = $g.GetHdc()
+[W]::PrintWindow($hwnd, $dc, 2) | Out-Null
+$g.ReleaseHdc($dc)
+$bmp.Save($Out, [System.Drawing.Imaging.ImageFormat]::Png)
+Write-Output "saved $w x $h -> $Out"
+Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Implements and **measures** a set of HRC performance strategies in the `hrc.c` sample, each behind an env/bench toggle so quality is verified against an in-run reference rather than assumed.

## What's here (one commit each)

1. **In-app benchmark mode** (`HRC_BENCH=1`) — sweeps `(scene, grid, upscale, cm1, mip, cap, c1sel)` configs; for each it renders warmup + 60 timed frames of a deterministic scene (static light / cornell settled ~120 frames / pinhole with the gap frozen via `HRC_FREEZE`), times with `cf_get_ticks` under `IMMEDIATE` present, reads back the fluence canvas, and prints a CSV row with average frame ms + RMSE on tonemapped luma + max channel diff vs the in-run 1x-grid reference. Release build.
2. **Per-grid allocation** — cascade SSBOs were allocated at max world size (~496 MB) regardless of grid; now allocated for the active grid and destroy+recreate on `[H]` change. Footprint: grid 128 **6.2 MB**, 256 **27 MB**, 512 **116 MB**, 1024 **496 MB**. Default grid 512 drops **496 → 116 MB**.
3. **Minmax-mip marching** — new 8px-block `(absMin, absMax, emisMax)` pyramid; the trace DDA and the c-1 march cross uniform blocks in one analytic Beer step (empty = no-op, uniform-fog = single per-channel term) and fine-step only mixed/emissive cells. Emitters are opaque and any emission disqualifies the skip, so all radiance-bearing cells keep exact fine steps.
4. **c-1 selectivity** (`HRC_CM1SEL`) — in uniform-open cells the c-1 interval degenerates to `(0, 1)`, so it's replaced by the interpolated R_0 directly; full march only in mixed/emissive cells.
5. **Cascade level cap** (`HRC_MAX_LEVELS`) — stop the cascade early, treating R at the cap as the R_N=0 boundary; fewer extend/merge passes at the cost of far-field GI.

### Correctness gates (verified, not assumed)
- **Minmax-mip neutrality** measured by a direct A/B against the non-mip image at grid 512: static and pinhole **bit-identical (RMSE 0.00000)**, cornell **RMSE 0.00097** (fp residual in the translucent fog box). ~13–17% faster.
- **Sealed-wall pinhole** (`HRC_NOGAP=1`) with mip on stays **pitch black on the far side** — no leak. Walls live in mixed cells and still get exact fine steps.
- **c-1 selectivity** quality-neutral: static/pinhole bit-identical to the full-march grid-512 baseline; cornell within noise (0.01363 vs 0.01377).
- **Test suite: 207/207 pass** (Debug), untouched by these changes.

### Skipped (honest)
Stretch items 6 (temporal staggering) and 7 (sparse-directions budget mode) were **skipped**. Staggering needs partial merge state persisted across frames, which conflicts with the per-grid reallocation added in item 2; sparse-directions needs the direction-indexing rewritten across every shader. Both are high-risk relative to the remaining budget and correctness bar.

## Results (grid 1024 = reference; RMSE/maxdiff on tonemapped sRGB output; frame ms on this laptop GPU)

Notes: `mip` rows are a **direct A/B vs the non-mip image** (neutrality); all other rows are vs the grid-1024 reference. `cap` column is the effective top level (N=9 at grid 512); `-1` = full.

| scene | grid | upscale | cm1 | mip | cap | c1sel | extras | frame ms | RMSE | max diff |
|---|---|---|---|---|---|---|---|---|---|---|
| static | 1024 | minmax | 1 | 1 | – | 0 | reference | 12.750 | 0.00000 | 0.0000 |
| static | 512 | nearest | 1 | 1 | – | 0 | | 2.239 | 0.00561 | 0.0314 |
| static | 512 | minmax | 1 | 1 | – | 0 | | 2.685 | 0.00559 | 0.0431 |
| static | 512 | bilateral | 1 | 1 | – | 0 | | 2.552 | 0.00559 | 0.0353 |
| static | 512 | minmax | 0 | 1 | – | 0 | | 2.543 | 0.00560 | 0.0745 |
| static | 256 | nearest | 1 | 1 | – | 0 | | 1.044 | 0.01165 | 0.0902 |
| static | 256 | minmax | 1 | 1 | – | 0 | | 1.509 | 0.01155 | 0.0824 |
| static | 256 | bilateral | 1 | 1 | – | 0 | | 1.520 | 0.01155 | 0.0824 |
| static | 256 | minmax | 0 | 1 | – | 0 | | 1.502 | 0.01155 | 0.0863 |
| static | 512 | minmax | 1 | 0 | – | 0 | nomip | 3.175 | 0.00559 | 0.0431 |
| static | 512 | minmax | 1 | 1 | – | 0 | **mip (A/B)** | 2.577 | 0.00000 | 0.0000 |
| static | 512 | minmax | 1 | 1 | – | 1 | c1sel | 2.597 | 0.00559 | 0.0431 |
| static | 512 | minmax | 1 | 1 | 8 | 0 | cap N-1 | 2.461 | 0.01008 | 0.0431 |
| static | 512 | minmax | 1 | 1 | 7 | 0 | cap N-2 | 2.280 | 0.04867 | 0.1176 |
| cornell | 1024 | minmax | 1 | 1 | – | 0 | reference | 11.368 | 0.00000 | 0.0000 |
| cornell | 512 | nearest | 1 | 1 | – | 0 | | 2.303 | 0.01062 | 0.3765 |
| cornell | 512 | minmax | 1 | 1 | – | 0 | | 2.782 | 0.01363 | 0.5059 |
| cornell | 512 | bilateral | 1 | 1 | – | 0 | | 2.759 | 0.01304 | 0.5020 |
| cornell | 512 | minmax | 0 | 1 | – | 0 | | 2.742 | 0.03065 | 0.5922 |
| cornell | 256 | nearest | 1 | 1 | – | 0 | | 1.197 | 0.02215 | 0.5569 |
| cornell | 256 | minmax | 1 | 1 | – | 0 | | 1.757 | 0.02700 | 0.6392 |
| cornell | 256 | bilateral | 1 | 1 | – | 0 | | 1.690 | 0.02547 | 0.6392 |
| cornell | 256 | minmax | 0 | 1 | – | 0 | | 1.624 | 0.04359 | 0.6588 |
| cornell | 512 | minmax | 1 | 0 | – | 0 | nomip | 3.185 | 0.01377 | 0.5059 |
| cornell | 512 | minmax | 1 | 1 | – | 0 | **mip (A/B)** | 2.774 | 0.00097 | 0.0314 |
| cornell | 512 | minmax | 1 | 1 | – | 1 | c1sel | 2.766 | 0.01363 | 0.5059 |
| cornell | 512 | minmax | 1 | 1 | 8 | 0 | cap N-1 | 2.628 | 0.06058 | 0.5020 |
| cornell | 512 | minmax | 1 | 1 | 7 | 0 | cap N-2 | 2.419 | 0.29105 | 0.5843 |
| pinhole | 1024 | minmax | 1 | 1 | – | 0 | reference | 11.215 | 0.00000 | 0.0000 |
| pinhole | 512 | nearest | 1 | 1 | – | 0 | | 2.181 | 0.00722 | 0.5451 |
| pinhole | 512 | minmax | 1 | 1 | – | 0 | | 2.655 | 0.00813 | 0.6275 |
| pinhole | 512 | bilateral | 1 | 1 | – | 0 | | 2.625 | 0.00817 | 0.6275 |
| pinhole | 512 | minmax | 0 | 1 | – | 0 | | 2.612 | 0.02799 | 0.7922 |
| pinhole | 256 | nearest | 1 | 1 | – | 0 | | 1.095 | 0.01510 | 0.5490 |
| pinhole | 256 | minmax | 1 | 1 | – | 0 | | 1.583 | 0.01641 | 0.5529 |
| pinhole | 256 | bilateral | 1 | 1 | – | 0 | | 1.542 | 0.01607 | 0.5529 |
| pinhole | 256 | minmax | 0 | 1 | – | 0 | | 1.526 | 0.03373 | 0.7137 |
| pinhole | 512 | minmax | 1 | 0 | – | 0 | nomip | 3.143 | 0.00813 | 0.6275 |
| pinhole | 512 | minmax | 1 | 1 | – | 0 | **mip (A/B)** | 2.642 | 0.00000 | 0.0000 |
| pinhole | 512 | minmax | 1 | 1 | – | 1 | c1sel | 2.606 | 0.00813 | 0.6275 |
| pinhole | 512 | minmax | 1 | 1 | 8 | 0 | cap N-1 | 2.497 | 0.04076 | 0.6235 |
| pinhole | 512 | minmax | 1 | 1 | 7 | 0 | cap N-2 | 2.326 | 0.14532 | 0.7020 |

(`maxdiff` in the cornell/pinhole rows is dominated by a few clipped HDR emitter/beam pixels, not a broad error — see the low RMSE.)

## Recommended mediocre-GPU preset (2–4 ms GI budget)

**Grid 512 + minmax-mip marching on + c-1 selectivity on + upscale = minmax + full cascade.**

- Measured **~2.6 ms** per frame vs **11–13 ms** for the grid-1024 reference (**~4.5× faster**), and vs **~3.1–3.2 ms** for the same config without mip marching.
- Memory **116 MB** (vs 496 MB at grid 1024).
- Quality delta vs the grid-1024 reference: RMSE **static 0.0056 / cornell 0.0136 / pinhole 0.0081** on tonemapped luma — small, and mip marching + c-1 selectivity add essentially **zero** error on top of the grid-512 downscale (static/pinhole bit-identical, cornell within noise).
- **Tighter budget?** Drop upscale to nearest (**~2.2 ms**, slightly blockier) or cap at N-1 (**~2.5 ms**, RMSE roughly doubles). Cap N-2 is **not** recommended for diffuse scenes — cornell RMSE jumps to 0.29 as far-field GI is lost.
