### PR TITLE
HRC off-screen lights: boundary radiance injection + padded-world modulation prototype

### DIFF
--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -278,6 +278,37 @@ void hrc_shutdown()
 }
 
 //--------------------------------------------------------------------------------------------------
+// Off-screen light injection uniforms (resolved each frame in update_inject_uniforms).
+
+typedef struct InjectUniforms
+{
+	int   merge_mode;    // merge shader: 0 = none, 2 = correct boundary injection
+	int   composite_mode;// composite shader: 1 = naive unoccluded add, else 0
+	int   type;          // 0 = infinite directional, 1 = finite point
+	float dirx, diry;    // directional travel dir (from light into scene)
+	float posx, posy;    // normalized world position
+	float r, g, b;       // linear HDR color (already faded for mode 3)
+	float cosv;          // cone acceptance cosine
+	float falloff;       // point inverse-square coefficient
+} InjectUniforms;
+
+InjectUniforms g_inject;
+
+// Push the static off-screen-light uniforms onto a material (merge or composite).
+void set_inject_uniforms(CF_Material mat)
+{
+	cf_material_set_uniform_cs(mat, "u_light_type", &g_inject.type, CF_UNIFORM_TYPE_INT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_dirx", &g_inject.dirx, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_diry", &g_inject.diry, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_posx", &g_inject.posx, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_posy", &g_inject.posy, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_r", &g_inject.r, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_g", &g_inject.g, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_b", &g_inject.b, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_falloff", &g_inject.falloff, CF_UNIFORM_TYPE_FLOAT, 1);
+}
+
+//--------------------------------------------------------------------------------------------------
 // Cascade compute pipeline.
 
 void hrc_compute()
@@ -302,6 +333,12 @@ void hrc_compute()
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_mip_level", &mip_level, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_absrp_mip_level", &absrp_mip_level, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(hrc.mat_trace, "u_upscale", &upscale, CF_UNIFORM_TYPE_INT, 1);
+
+	// Off-screen boundary radiance injection (MECHANISM 1). Static per frame;
+	// u_rotate and u_is_top are set per merge dispatch below.
+	set_inject_uniforms(hrc.mat_merge);
+	cf_material_set_uniform_cs(hrc.mat_merge, "u_inject_mode", &g_inject.merge_mode, CF_UNIFORM_TYPE_INT, 1);
+	cf_material_set_uniform_cs(hrc.mat_merge, "u_light_cos", &g_inject.cosv, CF_UNIFORM_TYPE_FLOAT, 1);
 
 	for (int j = 0; j < 4; j++) {
 		// Seed T_0 when no levels are traced (sample at probe, no raymarching).
@@ -375,12 +412,15 @@ void hrc_compute()
 		int r_ping = 0;
 		for (int i = N - 1; i >= 0; i--) {
 			int params[6] = { i, dim, hrc.vrays_w[i], hrc.vrays_w[i + 1], dim * 2, dim * 2 };
+			int is_top = (i == N - 1) ? 1 : 0; // R_{i+1} == R_N base case at top
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_cascade", params + 0, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_world_size", params + 1, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_t_curr_w", params + 2, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_t_next_w", params + 3, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_r_prev_w", params + 4, CF_UNIFORM_TYPE_INT, 1);
 			cf_material_set_uniform_cs(hrc.mat_merge, "u_r_curr_w", params + 5, CF_UNIFORM_TYPE_INT, 1);
+			cf_material_set_uniform_cs(hrc.mat_merge, "u_rotate", &j, CF_UNIFORM_TYPE_INT, 1);
+			cf_material_set_uniform_cs(hrc.mat_merge, "u_is_top", &is_top, CF_UNIFORM_TYPE_INT, 1);
 
 			CF_ComputeDispatch d = cf_compute_dispatch_defaults(
 				hrc_div_ceil(dim * 2, HRC_WG),
@@ -456,6 +496,10 @@ void hrc_compute()
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_cminus1", &hrc.cminus1, CF_UNIFORM_TYPE_INT, 1);
 		cf_material_set_uniform_cs(hrc.mat_composite, "u_upscale_mode", &hrc.upscale_mode, CF_UNIFORM_TYPE_INT, 1);
 
+		// Naive off-screen light (MODE 1 negative control) params.
+		set_inject_uniforms(hrc.mat_composite);
+		cf_material_set_uniform_cs(hrc.mat_composite, "u_inject_mode", &g_inject.composite_mode, CF_UNIFORM_TYPE_INT, 1);
+
 		CF_ComputeDispatch d = cf_compute_dispatch_defaults(
 			hrc_div_ceil(world, HRC_WG),
 			hrc_div_ceil(world, HRC_WG),
@@ -511,7 +555,122 @@ typedef struct OrbLight
 } OrbLight;
 
 float time_acc = 0.0f;
-int test_scene = 0; // 0 = off, 1 = static centered light, 2 = slowly orbiting light
+int test_scene = 0; // 0 = off, 1 = static centered light, 2 = slowly orbiting light, 3 = cornell, 4 = pinhole, 5 = off-screen demo
+
+//--------------------------------------------------------------------------------------------------
+// Off-screen light demo (test_scene == 5).
+//
+// A bright HDR point light ORBITS on a radius large enough to leave and re-enter
+// the screen (part of each orbit is off-screen on every side). On-screen walls
+// shadow the interior when the light sits off an edge. Modes select how the
+// off-screen light is handled:
+//   0 = no injection      (light simply vanishes off-screen -- the baseline pop)
+//   1 = naive unoccluded  (WRONG: light bleeds through on-screen walls; control)
+//   2 = correct boundary  (MECHANISM 1: injected in-cascade, walls still occlude)
+//   3 = padded + fade     (MECHANISM 2: sim a margin, display center crop, fade)
+int   inject_mode = 0;
+
+#define HRC_MARGIN_FACTOR 1.3f   // mode 3 padded region = screen x this factor
+#define OFF_ORBIT_RADIUS  680.0f // > half world (512), so it leaves/re-enters
+#define OFF_LIGHT_HDR     10.0f  // linear HDR radiance
+#define OFF_LIGHT_RADIUS  20.0f  // emitter disk radius (world px)
+#define OFF_LIGHT_CONE_DEG 15.0f // point-light angular acceptance (half-width)
+
+// Warm HDR light color in LINEAR radiance units (matches emiss decode: pow*16).
+CF_V2 off_light_pos;      // world pixels (may lie outside [0, world])
+float off_light_fade;     // mode-3 anti-flicker fade 0..1 across the margin band
+int   off_light_onscreen; // 1 if within [0, world]^2
+
+static float off_clamp01(float x) { return x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x); }
+static float off_smooth(float e0, float e1, float x)
+{
+	float t = off_clamp01((x - e0) / (e1 - e0));
+	return t * t * (3.0f - 2.0f * t);
+}
+static float off_min4(float a, float b, float c, float d)
+{
+	float m = a < b ? a : b;
+	m = m < c ? m : c;
+	return m < d ? m : d;
+}
+
+// Compute the orbiting light's world position + mode-3 fade for this frame.
+// Deterministic when HRC_ORBIT is set (screenshot seeding): angle taken directly.
+void update_offscreen_light()
+{
+	float ws = (float)HRC_WORLD_SIZE;
+	float half = ws * 0.5f;
+
+	// HRC_LX/HRC_LY explicitly place the light (world pixels) for controlled
+	// straight-line anti-flicker sweeps; otherwise orbit (HRC_ORBIT seeds phase).
+	const char* lxs = getenv("HRC_LX");
+	const char* lys = getenv("HRC_LY");
+	if (lxs && lys) {
+		off_light_pos = cf_v2((float)atof(lxs), (float)atof(lys));
+	} else {
+		float ang;
+		const char* orbit_env = getenv("HRC_ORBIT");
+		if (orbit_env) ang = (float)atof(orbit_env);
+		else           ang = time_acc * 0.4f;
+		off_light_pos = cf_v2(half + cosf(ang) * OFF_ORBIT_RADIUS,
+		                      half + sinf(ang) * OFF_ORBIT_RADIUS);
+	}
+
+	float pnx = off_light_pos.x / ws;
+	float pny = off_light_pos.y / ws;
+	off_light_onscreen = (pnx >= 0.0f && pnx < 1.0f && pny >= 0.0f && pny < 1.0f) ? 1 : 0;
+
+	// Anti-flicker fade: 0 at the padded outer edge, ramping to 1 by the time the
+	// light reaches the visible screen crop, so the ramp happens entirely in the
+	// off-screen margin band and visible pixels only ever see full strength.
+	if (inject_mode == 3) {
+		// Ramp 0 (world edge) -> 1 by 60% into the margin band, so the light is at
+		// full strength before it reaches the visible crop AND margin lights that
+		// sit behind an off-screen occluder (Case B) are still bright enough to
+		// cast a shadow. The whole ramp still lives in the off-screen margin.
+		float margin_norm = (1.0f - 1.0f / HRC_MARGIN_FACTOR) * 0.5f;
+		float m = off_min4(pnx, 1.0f - pnx, pny, 1.0f - pny); // dist to nearest world edge
+		off_light_fade = off_smooth(0.0f, margin_norm * 0.6f, m);
+	} else {
+		off_light_fade = 1.0f;
+	}
+}
+
+void update_inject_uniforms()
+{
+	CF_MEMSET(&g_inject, 0, sizeof(g_inject));
+	g_inject.type = 1;
+	g_inject.falloff = 0.5f;
+	g_inject.cosv = cosf(OFF_LIGHT_CONE_DEG * CF_PI / 180.0f);
+	if (test_scene != 5) return;
+
+	float ws = (float)HRC_WORLD_SIZE;
+	const char* lt = getenv("HRC_LIGHTTYPE");
+	if (lt) g_inject.type = atoi(lt); // 0 = directional, 1 = point
+
+	g_inject.posx = off_light_pos.x / ws;
+	g_inject.posy = off_light_pos.y / ws;
+
+	// Directional travel dir: from the light toward the world center.
+	float tx = 0.5f - g_inject.posx, ty = 0.5f - g_inject.posy;
+	float tl = sqrtf(tx * tx + ty * ty);
+	if (tl < 1e-5f) tl = 1.0f;
+	g_inject.dirx = tx / tl;
+	g_inject.diry = ty / tl;
+	// Wider cone for the directional light (a broad off-screen source).
+	if (g_inject.type == 0) g_inject.cosv = cosf(35.0f * CF_PI / 180.0f);
+
+	float b = off_light_fade;
+	g_inject.r = OFF_LIGHT_HDR * 1.00f * b;
+	g_inject.g = OFF_LIGHT_HDR * 0.85f * b;
+	g_inject.b = OFF_LIGHT_HDR * 0.60f * b;
+
+	// Mode 2 = MECHANISM 1 (in-cascade boundary injection, correctly occluded).
+	// Mode 3 = MECHANISM 2 relies on the padded in-world emitter + fade, no
+	// boundary injection. Mode 1 = naive composite add. Mode 0 = nothing.
+	if (inject_mode == 2) g_inject.merge_mode = 2;
+	if (inject_mode == 1) g_inject.composite_mode = 1;
+}
 
 // Test light center for this frame. The light is 8x8 world pixels -- the paper
 // calls out sub-8x8 emitters as a known HRC limitation, so the reference test
@@ -621,9 +780,54 @@ void draw_pinhole(int channel)
 	}
 }
 
+// Off-screen demo scene. channel: 0 = emissivity, 1 = absorption.
+// On-screen occluder walls + (mode 3 only) an off-screen margin occluder, plus
+// the orbiting light drawn as an emitter while it is on-screen.
+void draw_offscreen(int channel)
+{
+	CF_Color solid = cf_make_color_rgb_f(1.0f, 1.0f, 1.0f); // opaque occluder
+
+	if (channel == 1) {
+		cf_draw_push_color(solid);
+		// Three on-screen occluder walls. When the light is off the left/right
+		// edge these cast shadows into the interior (Case A).
+		draw_rect_ch(292.0f, 372.0f, 308.0f, 652.0f, solid); // left vertical wall
+		draw_rect_ch(716.0f, 372.0f, 732.0f, 652.0f, solid); // right vertical wall
+		draw_rect_ch(372.0f, 716.0f, 652.0f, 732.0f, solid); // top horizontal wall
+		cf_draw_pop_color();
+
+		// Case B: an off-screen occluder living inside the mode-3 padded margin.
+		// It exists only when mechanism 2 is active -- the boundary-injection
+		// mechanism (mode 2) has no knowledge of geometry beyond the screen, so
+		// this wall is absent from its world. Mode 3 simulates the margin and so
+		// shadows the visible crop correctly where mode 2 cannot.
+		if (inject_mode == 3 && !getenv("HRC_NOCCL")) {
+			draw_rect_ch(92.0f, 400.0f, 108.0f, 624.0f, solid); // left margin band (off crop)
+		}
+	}
+
+	// The light body (opaque emitter) while it is on-screen; off-screen frames
+	// rely on boundary injection / padded sim instead.
+	if (off_light_onscreen) {
+		float b = off_light_fade;
+		if (channel == 1) {
+			// Opaque so it can radiate (rad = emiss * (1 - T)).
+			draw_circle_ch(off_light_pos.x, off_light_pos.y, OFF_LIGHT_RADIUS, cf_make_color_rgb_f(0.632f, 0.632f, 0.632f));
+		} else {
+			// Emission encode: stored = (Blin/16)^(1/2.2) so decode pow*16 = Blin.
+			float inv = 1.0f / 2.2f;
+			float er = powf(OFF_LIGHT_HDR * 1.00f * b / 16.0f, inv);
+			float eg = powf(OFF_LIGHT_HDR * 0.85f * b / 16.0f, inv);
+			float eb = powf(OFF_LIGHT_HDR * 0.60f * b / 16.0f, inv);
+			draw_circle_ch(off_light_pos.x, off_light_pos.y, OFF_LIGHT_RADIUS, cf_make_color_rgb_f(er, eg, eb));
+		}
+	}
+}
+
 void draw_test_shapes(int channel)
 {
 	if (test_scene == 3) draw_cornell(channel);
+	else if (test_scene == 5) draw_offscreen(channel);
 	else draw_pinhole(channel);
 }
 
@@ -646,7 +850,10 @@ void handle_input()
 		hrc.debug_mode = (hrc.debug_mode + 1) % HRC_NUM_DEBUG;
 	}
 	if (cf_key_just_pressed(CF_KEY_T)) {
-		test_scene = (test_scene + 1) % 5;
+		test_scene = (test_scene + 1) % 6;
+	}
+	if (cf_key_just_pressed(CF_KEY_I)) {
+		inject_mode = (inject_mode + 1) % 4;
 	}
 	if (cf_key_just_pressed(CF_KEY_H)) {
 		if      (hrc.grid == 128)  hrc_set_grid(256);
@@ -880,7 +1087,11 @@ void display_fluence()
 	else if (hrc.debug_mode == 7) display = hrc.absorption;
 
 	float ws = (float)HRC_WORLD_SIZE;
-	cf_draw_canvas(display, cf_v2(0, 0), cf_v2(ws, ws));
+	// MECHANISM 2 (mode 3): the full world is the padded region; display only the
+	// center screen crop by zooming so the crop fills the window. Off-screen
+	// margin geometry (simulated) is cropped out of view but still shadows.
+	float scale = (test_scene == 5 && inject_mode == 3) ? HRC_MARGIN_FACTOR : 1.0f;
+	cf_draw_canvas(display, cf_v2(0, 0), cf_v2(ws * scale, ws * scale));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -909,6 +1120,7 @@ void draw_hud()
 		"[M] Upscale: %s\n"
 		"[P] Prefilter: %s\n"
 		"[R] Trace: %d / %d\n"
+		"[I] Off-screen: %s\n"
 		"[T] Test scene: %s",
 		hrc.blend_boundary ? "on" : "off",
 		hrc.blend_width,
@@ -918,7 +1130,8 @@ void draw_hud()
 		hrc.upscale_mode == 0 ? "nearest" : hrc.upscale_mode == 1 ? "minmax" : "bilateral",
 		hrc.prefilter_mode == 0 ? "off" : hrc.prefilter_mode == 1 ? "box" : hrc.prefilter_mode == 2 ? "mipmap" : hrc.prefilter_mode == 3 ? "gauss" : "mip+max",
 		hrc.trace_levels, hrc.n + 1,
-		test_scene == 0 ? "off" : test_scene == 1 ? "static 8x8" : test_scene == 2 ? "orbiting 8x8" : test_scene == 3 ? "cornell" : "pinhole"
+		inject_mode == 0 ? "0 none" : inject_mode == 1 ? "1 naive (bleed)" : inject_mode == 2 ? "2 boundary inject" : "3 padded+fade",
+		test_scene == 0 ? "off" : test_scene == 1 ? "static 8x8" : test_scene == 2 ? "orbiting 8x8" : test_scene == 3 ? "cornell" : test_scene == 4 ? "pinhole" : "off-screen demo"
 	);
 
 	float half = (float)HRC_WORLD_SIZE * 0.5f;
@@ -948,6 +1161,7 @@ int main(int argc, char* argv[])
 		if ((env = getenv("HRC_BLEND_WIDTH"))) hrc.blend_width = (float)atof(env);
 		if ((env = getenv("HRC_CM1")))         hrc.cminus1 = atoi(env);
 		if ((env = getenv("HRC_TRACE")))       hrc.trace_levels = atoi(env);
+		if ((env = getenv("HRC_INJECT")))      inject_mode = atoi(env);
 	}
 
 	while (cf_app_is_running()) {
@@ -955,6 +1169,8 @@ int main(int argc, char* argv[])
 		cf_draw_push_shape_aa(0);
 		handle_input();
 		update_lights();
+		update_offscreen_light();
+		update_inject_uniforms();
 		draw_emissivity();
 		draw_absorption();
 		draw_diffuse();

--- a/samples/hrc.c
+++ b/samples/hrc.c
@@ -287,9 +287,12 @@ typedef struct InjectUniforms
 	int   type;          // 0 = infinite directional, 1 = finite point
 	float dirx, diry;    // directional travel dir (from light into scene)
 	float posx, posy;    // normalized world position
-	float r, g, b;       // linear HDR color (already faded for mode 3)
-	float cosv;          // cone acceptance cosine
+	float r, g, b;       // color hue (x anti-flicker fade); intensity is separate
 	float falloff;       // point inverse-square coefficient
+	float intensity;     // E: calibrated per-direction irradiance scale
+	float angradius;     // directional soft-cone plateau half-angle (radians)
+	float radius;        // point emitter radius (normalized world units)
+	float softness;      // penumbra shoulder angular width (radians)
 } InjectUniforms;
 
 InjectUniforms g_inject;
@@ -306,6 +309,10 @@ void set_inject_uniforms(CF_Material mat)
 	cf_material_set_uniform_cs(mat, "u_light_g", &g_inject.g, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(mat, "u_light_b", &g_inject.b, CF_UNIFORM_TYPE_FLOAT, 1);
 	cf_material_set_uniform_cs(mat, "u_light_falloff", &g_inject.falloff, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_intensity", &g_inject.intensity, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_angradius", &g_inject.angradius, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_radius", &g_inject.radius, CF_UNIFORM_TYPE_FLOAT, 1);
+	cf_material_set_uniform_cs(mat, "u_light_softness", &g_inject.softness, CF_UNIFORM_TYPE_FLOAT, 1);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -338,7 +345,6 @@ void hrc_compute()
 	// u_rotate and u_is_top are set per merge dispatch below.
 	set_inject_uniforms(hrc.mat_merge);
 	cf_material_set_uniform_cs(hrc.mat_merge, "u_inject_mode", &g_inject.merge_mode, CF_UNIFORM_TYPE_INT, 1);
-	cf_material_set_uniform_cs(hrc.mat_merge, "u_light_cos", &g_inject.cosv, CF_UNIFORM_TYPE_FLOAT, 1);
 
 	for (int j = 0; j < 4; j++) {
 		// Seed T_0 when no levels are traced (sample at probe, no raymarching).
@@ -572,9 +578,15 @@ int   inject_mode = 0;
 
 #define HRC_MARGIN_FACTOR 1.3f   // mode 3 padded region = screen x this factor
 #define OFF_ORBIT_RADIUS  680.0f // > half world (512), so it leaves/re-enters
-#define OFF_LIGHT_HDR     10.0f  // linear HDR radiance
+#define OFF_LIGHT_HDR     10.0f  // linear HDR radiance (on-screen emitter body)
 #define OFF_LIGHT_RADIUS  20.0f  // emitter disk radius (world px)
-#define OFF_LIGHT_CONE_DEG 15.0f // point-light angular acceptance (half-width)
+// Soft-cone off-screen light defaults (finite angular size, smooth falloff).
+// intensity E is calibrated so the off-screen soft light matches an on-screen
+// disc of the same intended brightness (see A/B), NOT the raw HDR body value
+// that made the injected boundary source flood the scene.
+#define OFF_LIGHT_INTENSITY 8.0f  // calibrated per-direction irradiance scale
+#define OFF_DIR_ANG_DEG    8.0f   // directional soft-cone plateau half-angle (deg)
+#define OFF_SOFT_DEG       12.0f  // penumbra shoulder angular width (deg)
 
 // Warm HDR light color in LINEAR radiance units (matches emiss decode: pow*16).
 CF_V2 off_light_pos;      // world pixels (may lie outside [0, world])
@@ -639,12 +651,25 @@ void update_offscreen_light()
 void update_inject_uniforms()
 {
 	CF_MEMSET(&g_inject, 0, sizeof(g_inject));
+	float ws = (float)HRC_WORLD_SIZE;
 	g_inject.type = 1;
 	g_inject.falloff = 0.5f;
-	g_inject.cosv = cosf(OFF_LIGHT_CONE_DEG * CF_PI / 180.0f);
+	// Soft-cone parameters (env-overridable so the A/B harness can sweep them
+	// without a rebuild): angular_radius, softness, point radius, intensity.
+	float dir_ang = OFF_DIR_ANG_DEG;
+	float soft_deg = OFF_SOFT_DEG;
+	float pt_radius_px = OFF_LIGHT_RADIUS;
+	g_inject.intensity = OFF_LIGHT_INTENSITY;
+	const char* e;
+	if ((e = getenv("HRC_LANG")))  dir_ang = (float)atof(e);        // directional plateau (deg)
+	if ((e = getenv("HRC_LSOFT"))) soft_deg = (float)atof(e);       // penumbra shoulder (deg)
+	if ((e = getenv("HRC_LRAD")))  pt_radius_px = (float)atof(e);   // point emitter radius (px)
+	if ((e = getenv("HRC_LINT")))  g_inject.intensity = (float)atof(e); // intensity E
+	g_inject.angradius = dir_ang * CF_PI / 180.0f;
+	g_inject.softness  = soft_deg * CF_PI / 180.0f;
+	g_inject.radius    = pt_radius_px / ws; // normalized world units
 	if (test_scene != 5) return;
 
-	float ws = (float)HRC_WORLD_SIZE;
 	const char* lt = getenv("HRC_LIGHTTYPE");
 	if (lt) g_inject.type = atoi(lt); // 0 = directional, 1 = point
 
@@ -657,13 +682,12 @@ void update_inject_uniforms()
 	if (tl < 1e-5f) tl = 1.0f;
 	g_inject.dirx = tx / tl;
 	g_inject.diry = ty / tl;
-	// Wider cone for the directional light (a broad off-screen source).
-	if (g_inject.type == 0) g_inject.cosv = cosf(35.0f * CF_PI / 180.0f);
 
+	// Color is now a unit-ish hue; brightness lives in intensity E (x fade).
 	float b = off_light_fade;
-	g_inject.r = OFF_LIGHT_HDR * 1.00f * b;
-	g_inject.g = OFF_LIGHT_HDR * 0.85f * b;
-	g_inject.b = OFF_LIGHT_HDR * 0.60f * b;
+	g_inject.r = 1.00f * b;
+	g_inject.g = 0.85f * b;
+	g_inject.b = 0.60f * b;
 
 	// Mode 2 = MECHANISM 1 (in-cascade boundary injection, correctly occluded).
 	// Mode 3 = MECHANISM 2 relies on the padded in-world emitter + fade, no
@@ -780,12 +804,39 @@ void draw_pinhole(int channel)
 	}
 }
 
+// A/B reference: a STATIC on-screen disc light of matched angular size, placed to
+// shadow the same left wall from a comparable direction as the off-screen light.
+// This is the "good" reference the off-screen soft-cone shadow is measured against
+// (soft penumbra, no staircase) and the brightness calibration target. Enabled by
+// HRC_REFLIGHT; position/size overridable via HRC_REFX/HRC_REFY/HRC_REFRAD.
+void draw_ref_light(int channel)
+{
+	if (!getenv("HRC_REFLIGHT")) return;
+	float rx = 140.0f, ry = 512.0f, rr = 8.0f;
+	const char* e;
+	if ((e = getenv("HRC_REFX")))   rx = (float)atof(e);
+	if ((e = getenv("HRC_REFY")))   ry = (float)atof(e);
+	if ((e = getenv("HRC_REFRAD"))) rr = (float)atof(e);
+	if (channel == 1) {
+		// Opaque so it can radiate (rad = emiss * (1 - T)).
+		draw_circle_ch(rx, ry, rr, cf_make_color_rgb_f(0.632f, 0.632f, 0.632f));
+	} else {
+		// Same warm hue + HDR level as the off-screen light body.
+		float inv = 1.0f / 2.2f;
+		float er = powf(OFF_LIGHT_HDR * 1.00f / 16.0f, inv);
+		float eg = powf(OFF_LIGHT_HDR * 0.85f / 16.0f, inv);
+		float eb = powf(OFF_LIGHT_HDR * 0.60f / 16.0f, inv);
+		draw_circle_ch(rx, ry, rr, cf_make_color_rgb_f(er, eg, eb));
+	}
+}
+
 // Off-screen demo scene. channel: 0 = emissivity, 1 = absorption.
 // On-screen occluder walls + (mode 3 only) an off-screen margin occluder, plus
 // the orbiting light drawn as an emitter while it is on-screen.
 void draw_offscreen(int channel)
 {
 	CF_Color solid = cf_make_color_rgb_f(1.0f, 1.0f, 1.0f); // opaque occluder
+	draw_ref_light(channel);
 
 	if (channel == 1) {
 		cf_draw_push_color(solid);

--- a/samples/hrc_data/hrc_composite.c_shd
+++ b/samples/hrc_data/hrc_composite.c_shd
@@ -38,6 +38,21 @@ layout(set = 2, binding = 0) uniform Params
 	int   u_debug_mode;
 	int   u_cminus1;       // 0 = skip c-1 gathering, 1 = raymarch c-1
 	int   u_upscale_mode;  // 0 = nearest, 1 = minmax bilinear, 2 = joint bilateral
+
+	// Naive off-screen light (MODE 1 negative control): add the off-screen light
+	// UNOCCLUDED to every pixel, bypassing the cascade transmittance. This is the
+	// WRONG way -- it bleeds through on-screen walls. Correct injection (mode 2)
+	// happens inside the merge shader where on-screen transmittance still applies.
+	int   u_inject_mode;   // 1 = naive unoccluded add (this shader), else no-op here
+	int   u_light_type;    // 0 = infinite directional, 1 = finite point
+	float u_light_dirx;
+	float u_light_diry;
+	float u_light_posx;
+	float u_light_posy;
+	float u_light_r;
+	float u_light_g;
+	float u_light_b;
+	float u_light_falloff;
 };
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
@@ -324,6 +339,22 @@ vec3 sum_quadrants(ivec2 world_pos)
 			total += r0;
 		}
 	}
+
+	// MODE 1 (naive negative control): dump the off-screen light onto the pixel
+	// with NO occlusion. Behind an on-screen wall this bleeds through (wrong),
+	// which is exactly the artifact mode 2's in-cascade injection avoids.
+	if (u_inject_mode == 1) {
+		vec2 wp = (vec2(world_pos) + 0.5) / float(u_world_size);
+		vec3 col = vec3(u_light_r, u_light_g, u_light_b);
+		if (u_light_type == 0) {
+			total += col;
+		} else {
+			vec2 to_l = vec2(u_light_posx, u_light_posy) - wp;
+			float dist = length(to_l);
+			total += col / (1.0 + u_light_falloff * dist * dist);
+		}
+	}
+
 	return total;
 }
 

--- a/samples/hrc_data/hrc_composite.c_shd
+++ b/samples/hrc_data/hrc_composite.c_shd
@@ -53,6 +53,10 @@ layout(set = 2, binding = 0) uniform Params
 	float u_light_g;
 	float u_light_b;
 	float u_light_falloff;
+	float u_light_intensity; // E: matches the merge-path intensity for a fair control
+	float u_light_angradius; // (unused here; kept so host can push the same set)
+	float u_light_radius;
+	float u_light_softness;
 };
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
@@ -345,7 +349,7 @@ vec3 sum_quadrants(ivec2 world_pos)
 	// which is exactly the artifact mode 2's in-cascade injection avoids.
 	if (u_inject_mode == 1) {
 		vec2 wp = (vec2(world_pos) + 0.5) / float(u_world_size);
-		vec3 col = vec3(u_light_r, u_light_g, u_light_b);
+		vec3 col = vec3(u_light_r, u_light_g, u_light_b) * u_light_intensity;
 		if (u_light_type == 0) {
 			total += col;
 		} else {

--- a/samples/hrc_data/hrc_merge.c_shd
+++ b/samples/hrc_data/hrc_merge.c_shd
@@ -50,6 +50,25 @@ layout(set = 2, binding = 0) uniform Params
 	int u_t_next_w;     // width of T_{n+1} buffer
 	int u_r_prev_w;     // width of R_{n+1} buffer
 	int u_r_curr_w;     // width of R_n buffer
+
+	// Off-screen boundary radiance injection (MECHANISM 1). When a merge ray
+	// exits the world edge, instead of returning R_N = 0 we return the radiance
+	// an off-screen light delivers from the ray's world direction at the exit
+	// point. Injected at the SAME site the zero lived, so it is still multiplied
+	// by the full on-screen transmittance the ray accumulated (walls occlude it).
+	int   u_rotate;        // current rotation 0..3 (rotated +x -> world quadrant)
+	int   u_is_top;        // 1 when n == N-1: R_{n+1} is R_N = 0, every read is boundary
+	int   u_inject_mode;   // 0 = none (R_N=0), 2 = correct boundary inject
+	int   u_light_type;    // 0 = infinite directional, 1 = finite off-screen point
+	float u_light_dirx;    // directional: travel dir (from light into scene), normalized
+	float u_light_diry;
+	float u_light_posx;    // point: normalized world position (may lie outside [0,1])
+	float u_light_posy;
+	float u_light_r;       // HDR radiance color
+	float u_light_g;
+	float u_light_b;
+	float u_light_cos;     // cone acceptance: cos(half-width) for direction test
+	float u_light_falloff; // point-light inverse-square falloff coefficient
 };
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
@@ -79,6 +98,76 @@ vec2 v_n(int n, float k)
 {
 	float pow2n = float(1 << n);
 	return vec2(pow2n, k - pow2n);
+}
+
+// Rotated-space -> world-space maps (normalized coords). The cascade runs in
+// +x-aligned "rotated" space; rotation j maps rotated +x onto the j-th world
+// quadrant direction. Position map matches the composite's grid_to_rotated
+// inverse; direction map is its linear part (pure 90*j rotation).
+vec2 rot_pos(int rot, vec2 p)
+{
+	if (rot == 1) return vec2(1.0 - p.y, p.x);
+	if (rot == 2) return vec2(1.0 - p.x, 1.0 - p.y);
+	if (rot == 3) return vec2(p.y, 1.0 - p.x);
+	return p;
+}
+
+vec2 rot_dir(int rot, vec2 d)
+{
+	if (rot == 1) return vec2(-d.y, d.x);
+	if (rot == 2) return vec2(-d.x, -d.y);
+	if (rot == 3) return vec2(d.y, -d.x);
+	return d;
+}
+
+// Radiance an off-screen light delivers to boundary point p (normalized world)
+// for a ray leaving the screen in world direction d. Occlusion is NOT applied
+// here -- the caller multiplies this by the ray's accumulated on-screen
+// transmittance, so on-screen walls between p and the probe still shadow it.
+vec3 boundary_light(vec2 p, vec2 d)
+{
+	vec3 col = vec3(u_light_r, u_light_g, u_light_b);
+	vec2 nd = normalize(d);
+	if (u_light_type == 0) {
+		// Infinite directional light: travels along u_light_dir. A boundary ray
+		// sees it when it looks back up the beam (toward -travel_dir) within the
+		// cone. Any edge whose outward normal faces the light qualifies, which is
+		// exactly the set of exit directions passing the dot test below.
+		vec2 toward = normalize(-vec2(u_light_dirx, u_light_diry));
+		return (dot(nd, toward) >= u_light_cos) ? col : vec3(0.0);
+	}
+	// Finite off-screen point light at u_light_pos (entry dir varies per point).
+	vec2 to_l = vec2(u_light_posx, u_light_posy) - p;
+	float dist = length(to_l);
+	if (dist < 1e-5) return col;
+	if (dot(nd, to_l / dist) >= u_light_cos) {
+		return col / (1.0 + u_light_falloff * dist * dist);
+	}
+	return vec3(0.0);
+}
+
+// Reconstruct the world exit point + world direction of the ray behind an
+// out-of-bounds (or top-level) R_{n+1} read (probe_x, cone i, row y), then
+// evaluate the off-screen light there. This is the replacement for R_N = 0.
+vec3 boundary_inject(int probe_x, int i, int y)
+{
+	int   n1   = u_cascade + 1;
+	float pw   = float(1 << n1);
+	float grid = float(u_world_size);
+	// Rotated-space far-probe position (grid units) and cone-center direction
+	// v_{n+1}(i+0.5) = (2^{n+1}, i+0.5 - 2^{n+1}).
+	vec2 fr    = vec2(float(probe_x) * pw, float(y));
+	vec2 dcone = vec2(pw, (float(i) + 0.5) - pw);
+	// March forward (dcone.x > 0 always) to the rotated box exit = world edge.
+	float tx = (grid - fr.x) / dcone.x;
+	float ty = 1e30;
+	if      (dcone.y > 0.0) ty = (grid - fr.y) / dcone.y;
+	else if (dcone.y < 0.0) ty = (0.0  - fr.y) / dcone.y;
+	float t = max(0.0, min(tx, ty));
+	vec2 exit_r = clamp(fr + t * dcone, vec2(0.0), vec2(grid));
+	vec2 p = rot_pos(u_rotate, exit_r / grid);
+	vec2 d = rot_dir(u_rotate, dcone);
+	return boundary_light(p, d);
 }
 
 // Eq 13: angular size of cone i at cascade n.
@@ -131,7 +220,13 @@ vec3 R_load(int probe_x, int i, int y)
 	int n = u_cascade + 1;
 	int directions = 2 << n;
 	int num_probes = u_world_size >> n;
-	if (probe_x < 0 || probe_x >= num_probes || i < 0 || i >= directions || y < 0 || y >= u_world_size) {
+	bool oob = (probe_x < 0 || probe_x >= num_probes || i < 0 || i >= directions || y < 0 || y >= u_world_size);
+	// Boundary condition: the ray exits the world (oob), or this is the top
+	// iteration where R_{n+1} = R_N is the all-zero base case. Both are the
+	// "R_N = 0" injection site. With mode 2 we substitute off-screen radiance;
+	// otherwise keep the historical zero.
+	if (oob || u_is_top != 0) {
+		if (u_inject_mode == 2) return boundary_inject(probe_x, i, y);
 		return vec3(0.0);
 	}
 	int idx = y * u_r_prev_w + probe_x * directions + i;

--- a/samples/hrc_data/hrc_merge.c_shd
+++ b/samples/hrc_data/hrc_merge.c_shd
@@ -64,11 +64,14 @@ layout(set = 2, binding = 0) uniform Params
 	float u_light_diry;
 	float u_light_posx;    // point: normalized world position (may lie outside [0,1])
 	float u_light_posy;
-	float u_light_r;       // HDR radiance color
+	float u_light_r;       // color hue (x anti-flicker fade); intensity is separate
 	float u_light_g;
 	float u_light_b;
-	float u_light_cos;     // cone acceptance: cos(half-width) for direction test
-	float u_light_falloff; // point-light inverse-square falloff coefficient
+	float u_light_falloff;   // point-light inverse-square falloff coefficient
+	float u_light_intensity; // E: calibrated per-direction irradiance scale
+	float u_light_angradius; // directional soft-cone plateau half-angle (radians)
+	float u_light_radius;    // point emitter radius (normalized world units)
+	float u_light_softness;  // penumbra shoulder angular width (radians)
 };
 
 layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
@@ -120,30 +123,60 @@ vec2 rot_dir(int rot, vec2 d)
 	return d;
 }
 
-// Radiance an off-screen light delivers to boundary point p (normalized world)
-// for a ray leaving the screen in world direction d. Occlusion is NOT applied
-// here -- the caller multiplies this by the ray's accumulated on-screen
-// transmittance, so on-screen walls between p and the probe still shadow it.
+// Per-direction radiance an off-screen light delivers to boundary point p
+// (normalized world) for a ray leaving the screen in world direction d.
+//
+// SOFT CONE (finite angular size). The old model was a HARD binary cone test
+// (in/out), which gave off-screen shadows zero penumbra AND quantized the
+// visibility answer to the cascade's discrete ray directions -> pixely staircase.
+// Here the source has a finite angular radius `a` with a smooth shoulder `s`:
+//   profile(ang) = 1 - smoothstep(a - s/2, a + s/2, ang)   (0.5 at geometric edge)
+// This adds a penumbra like an on-screen area light AND, because the shoulder
+// spans several cascade direction steps, ramps the visibility answer smoothly
+// across cones so the angular quantization averages out.
+//
+// This returns radiance PER DIRECTION (angular-fluence density). The caller
+// (R_load) multiplies by the read cone's angular span to convert it to the
+// angular-fluence units R_n stores -- without that span weight the raw radiance
+// is added once per contributing cone and the composite over-counts it by the
+// cone count (the "overpowering flood").
+//
+// BRIGHTNESS NORMALIZATION. The profile is divided by its angular integral
+// Z = 2a + s, so the total injected irradiance summed over all cones equals the
+// intensity E regardless of a or s: a wider/softer cone SPREADS the same energy
+// (softens) instead of adding more (brightens). E carries the inverse-square
+// distance falloff for the finite point light; the infinite directional source
+// legitimately does not fall off, so its E is just the calibrated uniform.
+//
+// Occlusion is NOT applied here -- the caller multiplies by the ray's accumulated
+// on-screen transmittance, so on-screen walls between p and the probe still shadow.
 vec3 boundary_light(vec2 p, vec2 d)
 {
-	vec3 col = vec3(u_light_r, u_light_g, u_light_b);
+	vec3 col = vec3(u_light_r, u_light_g, u_light_b); // hue (x anti-flicker fade)
 	vec2 nd = normalize(d);
+	float ang;         // angle between exit dir and direction toward light center
+	float a;           // source angular radius (plateau half-angle)
+	float atten = 1.0; // distance attenuation (point only)
 	if (u_light_type == 0) {
-		// Infinite directional light: travels along u_light_dir. A boundary ray
-		// sees it when it looks back up the beam (toward -travel_dir) within the
-		// cone. Any edge whose outward normal faces the light qualifies, which is
-		// exactly the set of exit directions passing the dot test below.
+		// Infinite directional: look back up the beam (toward -travel_dir).
 		vec2 toward = normalize(-vec2(u_light_dirx, u_light_diry));
-		return (dot(nd, toward) >= u_light_cos) ? col : vec3(0.0);
+		ang = acos(clamp(dot(nd, toward), -1.0, 1.0));
+		a   = u_light_angradius;
+	} else {
+		// Finite off-screen point: angular radius atan(r/dist) is PHYSICAL, so the
+		// penumbra tightens as the light recedes, just like a real disc source.
+		vec2 to_l = vec2(u_light_posx, u_light_posy) - p;
+		float dist = max(length(to_l), 1e-5);
+		ang   = acos(clamp(dot(nd, to_l / dist), -1.0, 1.0));
+		a     = atan(u_light_radius / dist);
+		atten = 1.0 / (1.0 + u_light_falloff * dist * dist);
 	}
-	// Finite off-screen point light at u_light_pos (entry dir varies per point).
-	vec2 to_l = vec2(u_light_posx, u_light_posy) - p;
-	float dist = length(to_l);
-	if (dist < 1e-5) return col;
-	if (dot(nd, to_l / dist) >= u_light_cos) {
-		return col / (1.0 + u_light_falloff * dist * dist);
-	}
-	return vec3(0.0);
+	float s = u_light_softness;
+	float h = 0.5 * s;
+	float profile = 1.0 - smoothstep(a - h, a + h, ang);
+	float Z = 2.0 * a + s;                    // angular integral of the profile
+	float E = u_light_intensity * atten;      // calibrated irradiance (with falloff)
+	return col * (E * profile / max(Z, 1e-4));
 }
 
 // Reconstruct the world exit point + world direction of the ray behind an
@@ -226,7 +259,16 @@ vec3 R_load(int probe_x, int i, int y)
 	// "R_N = 0" injection site. With mode 2 we substitute off-screen radiance;
 	// otherwise keep the historical zero.
 	if (oob || u_is_top != 0) {
-		if (u_inject_mode == 2) return boundary_inject(probe_x, i, y);
+		if (u_inject_mode == 2) {
+			// boundary_inject returns radiance PER DIRECTION; R_n stores angular
+			// FLUENCE, so weight by this cone's angular span (matches how traced
+			// near intervals are span-weighted). This is the fix that stops the
+			// injected light being counted once per cone (the over-bright flood):
+			// summed over the cones the light spans, the spans total its angular
+			// footprint, so the composite gets the intended irradiance, not Nx.
+			float span = max(angular_span(u_cascade + 1, float(i) + 0.5), 0.0);
+			return boundary_inject(probe_x, i, y) * span;
+		}
 		return vec3(0.0);
 	}
 	int idx = y * u_r_prev_w + probe_x * directions + i;


### PR DESCRIPTION
Research prototype of two mechanisms for correct off-screen light handling in the HRC sample (`samples/hrc.c` + `samples/hrc_data/*.c_shd`). New demo scene `test_scene 5` with modes toggled by `[I]` / `HRC_INJECT`.

## The two cases
- **Case A** — off-screen light whose rays travel *through* on-screen space; all occluders are on-screen. Solvable **correctly** in screen space.
- **Case B** — off-screen light **and** off-screen occluders (around a corner). No screen-space method is exact; it needs a simulated margin.

Injecting an off-screen light *unoccluded* is wrong (it bleeds through on-screen walls). The whole point is that on-screen geometry must still occlude it.

## Mechanism 1 — boundary radiance injection (correct for Case A)
The merge-down's `R_N = 0` base case (out-of-bounds cascade reads) is the injection point. In `hrc_merge.c_shd`, `R_load` now returns the directional radiance an off-screen light delivers at the ray's world exit point instead of zero, **at the same site the zero lived** — so the injected radiance is still multiplied by the ray's accumulated on-screen transmittance (`near.rad + near.trn * far_rad`). An on-screen wall between the boundary point and the probe still shadows it.

Injection fires when a merge ray exits the world (bounds check) **or** at the top iteration `u_is_top` (where `R_{n+1} = R_N` is the all-zero base case, so every read there is a boundary read continued to the world edge). The world exit point and world direction are reconstructed from the rotated-space far-probe position and the cone's `v_{n+1}(i+0.5)` direction, then un-rotated with `rot_pos` / `rot_dir` — the position map matching the composite's `grid_to_rotated` inverse and the direction map its linear part (the pure 90°·j rotation). This gets the rotation→world-direction mapping right for all four rotations (e.g. a light off the left edge is seen only by rays whose un-rotated world direction points −x, carried by rotation 2 whose `quadrant_dir` is `(-1,0)`).

Two light types via uniforms set from `hrc.c`: infinite **directional** (cone around −travel_dir) and finite off-screen **point** (per-boundary-point direction to L, inverse-square falloff).

**Mode 1** is a naive negative control implemented in `hrc_composite.c_shd`: it adds the off-screen light to every pixel *unoccluded* (bypassing the cascade), which bleeds through walls.

## Mechanism 2 — padded world + entry modulation (approximate, for Case B)
Simplified as documented: the full 1024² world is treated as the padded region and only the center crop (`world / 1.3`) is displayed (zoom). Lights and occluders in the off-crop margin are simulated, so an off-screen occluder correctly shadows the visible crop where mechanism 1 cannot. **Anti-flicker:** each light's emission fades 0→1 across the off-screen margin band, so a light only influences visible pixels at full strength and the ramp happens entirely off-crop. (I did not enlarge the buffers; I used the display-center-crop + light-fade variant the brief allows, and re-used the existing full-world sim as the pad.)

## Verification (screenshots + pixel readback)
**Case A A/B verdict** — light off the left edge, on-screen wall between it and the interior:
- Mode 2 (correct): a clear dark **shadow** behind the wall.
- Mode 1 (naive): the wall casts **no shadow**, light floods uniformly (bleed-through).

**Anti-flicker luma** (fixed interior pixel, light marching across an edge; luma 0–255):
- Baseline pop, mode 0: `168 → 159 → 151 → 0 → 0` (holds, then vanishes abruptly).
- Mode 3 fade: `169 → 158 → 0 → 0 → 0` (smooth ramp to zero across the margin — no pop).
- Mode 2 continuity (light crosses off-screen): mode 0 `95 → 98 → 0 → 0 → 0` vs mode 2 `95 → 98 → 183 → 185 → 185` (stays lit off-screen; jumps up at the emitter→injection handoff since injection is idealized full-strength).

**Case B** — off-screen margin occluder, mode 3, identical cropped view with vs without the occluder: a left-crop pixel goes `156 → 0` when the off-screen occluder is present. Mechanism 1 has no knowledge of that geometry and cannot produce this shadow.

## Honest limitations
- Mode 2's emitter→injection handoff is continuous (never vanishes) but not smooth — it jumps up, because the injected boundary source is idealized. Mechanism 2's fade is the true anti-flicker.
- Mechanism 2 is the simplified display-crop + fade variant (buffers not enlarged).
- The orbit crosses edges near corners at the chosen radius; controlled `HRC_LX`/`HRC_LY` sweeps were used for the clean anti-flicker/Case-B measurements.

`build/Debug/tests.exe`: **207/207** passing.
