### PR TITLE
Expand web Samples nav from 3 to 46 samples

### DIFF
--- a/docs/samples/basic_camera.md
+++ b/docs/samples/basic_camera.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Basic Camera
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/basic_camera.html" title="Basic Camera Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/basic_camera.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/basic_camera.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/basicindexedrendering.md
+++ b/docs/samples/basicindexedrendering.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Basic Indexed Rendering
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/basicindexedrendering.html" title="Basic Indexed Rendering Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/basicindexedrendering.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/basic_indexed_rendering.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/basicinstancing.md
+++ b/docs/samples/basicinstancing.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Basic Instancing
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/basicinstancing.html" title="Basic Instancing Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/basicinstancing.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/basic_instancing.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/basicshapes.md
+++ b/docs/samples/basicshapes.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Basic Shapes
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/basicshapes.html" title="Basic Shapes Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/basicshapes.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/basic_shapes.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/basicsprite.md
+++ b/docs/samples/basicsprite.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Basic Sprite
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/basicsprite.html" title="Basic Sprite Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/basicsprite.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/basic_sprite.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/blend_modes.md
+++ b/docs/samples/blend_modes.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Blend Modes
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/blend_modes.html" title="Blend Modes Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/blend_modes.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/blend_modes.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/clay.md
+++ b/docs/samples/clay.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Clay UI
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/clay.html" title="Clay UI Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/clay.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/clay.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/clay_ui_animations.md
+++ b/docs/samples/clay_ui_animations.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Clay UI Animations
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/clay_ui_animations.html" title="Clay UI Animations Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/clay_ui_animations.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/clay_ui_animations.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/custom_shapes.md
+++ b/docs/samples/custom_shapes.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Custom Shapes
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/custom_shapes.html" title="Custom Shapes Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/custom_shapes.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/custom_shapes.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/customsprite.md
+++ b/docs/samples/customsprite.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Custom Sprite
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/customsprite.html" title="Custom Sprite Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/customsprite.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/custom_sprite.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/draw_lists.md
+++ b/docs/samples/draw_lists.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Draw Lists
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/draw_lists.html" title="Draw Lists Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/draw_lists.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/draw_lists.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/draw_to_texture.md
+++ b/docs/samples/draw_to_texture.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Draw to Texture
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/draw_to_texture.html" title="Draw to Texture Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/draw_to_texture.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/draw_to_texture.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/easysprite.md
+++ b/docs/samples/easysprite.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Easy Sprite
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/easysprite.html" title="Easy Sprite Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/easysprite.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/easy_sprite.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/fetch_image.md
+++ b/docs/samples/fetch_image.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Fetch Image
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/fetch_image.html" title="Fetch Image Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/fetch_image.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/fetch_image.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/font_debug.md
+++ b/docs/samples/font_debug.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Font Debug
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/font_debug.html" title="Font Debug Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/font_debug.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/font_debug.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/glitch.md
+++ b/docs/samples/glitch.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Glitch
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/glitch.html" title="Glitch Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/glitch.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/glitch.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/hello_triangle.md
+++ b/docs/samples/hello_triangle.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Hello Triangle
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/hello_triangle.html" title="Hello Triangle Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/hello_triangle.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/hello_triangle.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/hidpi.md
+++ b/docs/samples/hidpi.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# HiDPI
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/hidpi.html" title="HiDPI Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/hidpi.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/hidpi.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/ime.md
+++ b/docs/samples/ime.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# IME Text Input
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/ime.html" title="IME Text Input Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/ime.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/ime.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/imgui.md
+++ b/docs/samples/imgui.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Dear ImGui
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/imgui.html" title="Dear ImGui Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/imgui.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/imgui.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/imgui_texture.md
+++ b/docs/samples/imgui_texture.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Dear ImGui Texture
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/imgui_texture.html" title="Dear ImGui Texture Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/imgui_texture.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/imgui_texture.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/import_spritesheet.md
+++ b/docs/samples/import_spritesheet.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Import Spritesheet
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/import_spritesheet.html" title="Import Spritesheet Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/import_spritesheet.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/import_spritesheet.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/index.md
+++ b/docs/samples/index.md
@@ -4,6 +4,159 @@ Interactive samples demonstrating Cute Framework features. Click any card to pla
 
 <div class="grid cards" markdown>
 
+- **[9-Slice](nine_slice.md)**
+
+    ---
+
+    Interactive sample demonstrating 9-slice features.
+
+    [:octicons-arrow-right-24: Play](nine_slice.md)
+
+
+- **[Basic Camera](basic_camera.md)**
+
+    ---
+
+    Interactive sample demonstrating basic camera features.
+
+    [:octicons-arrow-right-24: Play](basic_camera.md)
+
+
+- **[Basic Indexed Rendering](basicindexedrendering.md)**
+
+    ---
+
+    Interactive sample demonstrating basic indexed rendering features.
+
+    [:octicons-arrow-right-24: Play](basicindexedrendering.md)
+
+
+- **[Basic Instancing](basicinstancing.md)**
+
+    ---
+
+    Interactive sample demonstrating basic instancing features.
+
+    [:octicons-arrow-right-24: Play](basicinstancing.md)
+
+
+- **[Basic Shapes](basicshapes.md)**
+
+    ---
+
+    Interactive sample demonstrating basic shapes features.
+
+    [:octicons-arrow-right-24: Play](basicshapes.md)
+
+
+- **[Basic Sprite](basicsprite.md)**
+
+    ---
+
+    Interactive sample demonstrating basic sprite features.
+
+    [:octicons-arrow-right-24: Play](basicsprite.md)
+
+
+- **[Blend Modes](blend_modes.md)**
+
+    ---
+
+    Interactive sample demonstrating blend modes features.
+
+    [:octicons-arrow-right-24: Play](blend_modes.md)
+
+
+- **[Clay UI](clay.md)**
+
+    ---
+
+    Interactive sample demonstrating clay ui features.
+
+    [:octicons-arrow-right-24: Play](clay.md)
+
+
+- **[Clay UI Animations](clay_ui_animations.md)**
+
+    ---
+
+    Interactive sample demonstrating clay ui animations features.
+
+    [:octicons-arrow-right-24: Play](clay_ui_animations.md)
+
+
+- **[Custom Shapes](custom_shapes.md)**
+
+    ---
+
+    Interactive sample demonstrating custom shapes features.
+
+    [:octicons-arrow-right-24: Play](custom_shapes.md)
+
+
+- **[Custom Sprite](customsprite.md)**
+
+    ---
+
+    Interactive sample demonstrating custom sprite features.
+
+    [:octicons-arrow-right-24: Play](customsprite.md)
+
+
+- **[Dear ImGui](imgui.md)**
+
+    ---
+
+    Interactive sample demonstrating dear imgui features.
+
+    [:octicons-arrow-right-24: Play](imgui.md)
+
+
+- **[Dear ImGui Texture](imgui_texture.md)**
+
+    ---
+
+    Interactive sample demonstrating dear imgui texture features.
+
+    [:octicons-arrow-right-24: Play](imgui_texture.md)
+
+
+- **[Draw Lists](draw_lists.md)**
+
+    ---
+
+    Interactive sample demonstrating draw lists features.
+
+    [:octicons-arrow-right-24: Play](draw_lists.md)
+
+
+- **[Draw to Texture](draw_to_texture.md)**
+
+    ---
+
+    Interactive sample demonstrating draw to texture features.
+
+    [:octicons-arrow-right-24: Play](draw_to_texture.md)
+
+
+- **[Easy Sprite](easysprite.md)**
+
+    ---
+
+    Interactive sample demonstrating easy sprite features.
+
+    [:octicons-arrow-right-24: Play](easysprite.md)
+
+
+- **[Fetch Image](fetch_image.md)**
+
+    ---
+
+    Interactive sample demonstrating fetch image features.
+
+    [:octicons-arrow-right-24: Play](fetch_image.md)
+
+
 - **[Fluid Sim](fluid_sim.md)**
 
     ---
@@ -11,6 +164,177 @@ Interactive samples demonstrating Cute Framework features. Click any card to pla
     Interactive sample demonstrating fluid sim features.
 
     [:octicons-arrow-right-24: Play](fluid_sim.md)
+
+
+- **[Font Debug](font_debug.md)**
+
+    ---
+
+    Interactive sample demonstrating font debug features.
+
+    [:octicons-arrow-right-24: Play](font_debug.md)
+
+
+- **[Glitch](glitch.md)**
+
+    ---
+
+    Interactive sample demonstrating glitch features.
+
+    [:octicons-arrow-right-24: Play](glitch.md)
+
+
+- **[Hello Triangle](hello_triangle.md)**
+
+    ---
+
+    Interactive sample demonstrating hello triangle features.
+
+    [:octicons-arrow-right-24: Play](hello_triangle.md)
+
+
+- **[HiDPI](hidpi.md)**
+
+    ---
+
+    Interactive sample demonstrating hidpi features.
+
+    [:octicons-arrow-right-24: Play](hidpi.md)
+
+
+- **[IME Text Input](ime.md)**
+
+    ---
+
+    Interactive sample demonstrating ime text input features.
+
+    [:octicons-arrow-right-24: Play](ime.md)
+
+
+- **[Import Spritesheet](import_spritesheet.md)**
+
+    ---
+
+    Interactive sample demonstrating import spritesheet features.
+
+    [:octicons-arrow-right-24: Play](import_spritesheet.md)
+
+
+- **[Input Binding](input_binding.md)**
+
+    ---
+
+    Interactive sample demonstrating input binding features.
+
+    [:octicons-arrow-right-24: Play](input_binding.md)
+
+
+- **[Joypad](joypad.md)**
+
+    ---
+
+    Interactive sample demonstrating joypad features.
+
+    [:octicons-arrow-right-24: Play](joypad.md)
+
+
+- **[Mandala](mandala.md)**
+
+    ---
+
+    Interactive sample demonstrating mandala features.
+
+    [:octicons-arrow-right-24: Play](mandala.md)
+
+
+- **[Metaballs](metaballs.md)**
+
+    ---
+
+    Interactive sample demonstrating metaballs features.
+
+    [:octicons-arrow-right-24: Play](metaballs.md)
+
+
+- **[Noise](noise.md)**
+
+    ---
+
+    Interactive sample demonstrating noise features.
+
+    [:octicons-arrow-right-24: Play](noise.md)
+
+
+- **[Outline (Stencil)](outline_stencil.md)**
+
+    ---
+
+    Interactive sample demonstrating outline (stencil) features.
+
+    [:octicons-arrow-right-24: Play](outline_stencil.md)
+
+
+- **[Pivot](pivot.md)**
+
+    ---
+
+    Interactive sample demonstrating pivot features.
+
+    [:octicons-arrow-right-24: Play](pivot.md)
+
+
+- **[Platformer](platformer.md)**
+
+    ---
+
+    Interactive sample demonstrating platformer features.
+
+    [:octicons-arrow-right-24: Play](platformer.md)
+
+
+- **[Polygon](polygon.md)**
+
+    ---
+
+    Interactive sample demonstrating polygon features.
+
+    [:octicons-arrow-right-24: Play](polygon.md)
+
+
+- **[Rainbow Liquid](rainbow_liquid.md)**
+
+    ---
+
+    Interactive sample demonstrating rainbow liquid features.
+
+    [:octicons-arrow-right-24: Play](rainbow_liquid.md)
+
+
+- **[Recolor](recolor.md)**
+
+    ---
+
+    Interactive sample demonstrating recolor features.
+
+    [:octicons-arrow-right-24: Play](recolor.md)
+
+
+- **[Shallow Water](shallow_water.md)**
+
+    ---
+
+    Interactive sample demonstrating shallow water features.
+
+    [:octicons-arrow-right-24: Play](shallow_water.md)
+
+
+- **[Sound Pan](sound_pan.md)**
+
+    ---
+
+    Interactive sample demonstrating sound pan features.
+
+    [:octicons-arrow-right-24: Play](sound_pan.md)
 
 
 - **[Space Shooter](spaceshooter.md)**
@@ -22,6 +346,60 @@ Interactive samples demonstrating Cute Framework features. Click any card to pla
     [:octicons-arrow-right-24: Play](spaceshooter.md)
 
 
+- **[Stencil Pie Chart](stencil_pie_chart.md)**
+
+    ---
+
+    Interactive sample demonstrating stencil pie chart features.
+
+    [:octicons-arrow-right-24: Play](stencil_pie_chart.md)
+
+
+- **[Text Drawing](textdrawing.md)**
+
+    ---
+
+    Interactive sample demonstrating text drawing features.
+
+    [:octicons-arrow-right-24: Play](textdrawing.md)
+
+
+- **[Tile Performance](tile_perf.md)**
+
+    ---
+
+    Interactive sample demonstrating tile performance features.
+
+    [:octicons-arrow-right-24: Play](tile_perf.md)
+
+
+- **[Timestep](timestep.md)**
+
+    ---
+
+    Interactive sample demonstrating timestep features.
+
+    [:octicons-arrow-right-24: Play](timestep.md)
+
+
+- **[Vector Paths](vector_paths.md)**
+
+    ---
+
+    Interactive sample demonstrating vector paths features.
+
+    [:octicons-arrow-right-24: Play](vector_paths.md)
+
+
+- **[Vector Text](vector_text.md)**
+
+    ---
+
+    Interactive sample demonstrating vector text features.
+
+    [:octicons-arrow-right-24: Play](vector_text.md)
+
+
 - **[Waves](waves.md)**
 
     ---
@@ -29,6 +407,15 @@ Interactive samples demonstrating Cute Framework features. Click any card to pla
     Interactive sample demonstrating waves features.
 
     [:octicons-arrow-right-24: Play](waves.md)
+
+
+- **[Window Resizing](windowresizing.md)**
+
+    ---
+
+    Interactive sample demonstrating window resizing features.
+
+    [:octicons-arrow-right-24: Play](windowresizing.md)
 
 </div>
 

--- a/docs/samples/input_binding.md
+++ b/docs/samples/input_binding.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Input Binding
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/input_binding.html" title="Input Binding Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/input_binding.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/input_binding.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/joypad.md
+++ b/docs/samples/joypad.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Joypad
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/joypad.html" title="Joypad Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/joypad.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/joypad.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/mandala.md
+++ b/docs/samples/mandala.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Mandala
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/mandala.html" title="Mandala Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/mandala.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/mandala.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/metaballs.md
+++ b/docs/samples/metaballs.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Metaballs
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/metaballs.html" title="Metaballs Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/metaballs.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/metaballs.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/nine_slice.md
+++ b/docs/samples/nine_slice.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# 9-Slice
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/9_slice.html" title="9-Slice Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/9_slice.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/9_slice.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/noise.md
+++ b/docs/samples/noise.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Noise
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/noise.html" title="Noise Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/noise.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/noise.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/outline_stencil.md
+++ b/docs/samples/outline_stencil.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Outline (Stencil)
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/outline_stencil.html" title="Outline (Stencil) Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/outline_stencil.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/outline_stencil.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/pivot.md
+++ b/docs/samples/pivot.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Pivot
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/pivot.html" title="Pivot Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/pivot.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/pivot.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/platformer.md
+++ b/docs/samples/platformer.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Platformer
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/platformer.html" title="Platformer Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/platformer.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/platformer.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/polygon.md
+++ b/docs/samples/polygon.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Polygon
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/polygon.html" title="Polygon Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/polygon.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/polygon.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/rainbow_liquid.md
+++ b/docs/samples/rainbow_liquid.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Rainbow Liquid
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/rainbow_liquid.html" title="Rainbow Liquid Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/rainbow_liquid.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/rainbow_liquid.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/recolor.md
+++ b/docs/samples/recolor.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Recolor
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/recolor.html" title="Recolor Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/recolor.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/recolor.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/shallow_water.md
+++ b/docs/samples/shallow_water.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Shallow Water
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/shallow_water.html" title="Shallow Water Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/shallow_water.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/shallow_water.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/sound_pan.md
+++ b/docs/samples/sound_pan.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Sound Pan
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/sound_pan.html" title="Sound Pan Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/sound_pan.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/sound_pan.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/stencil_pie_chart.md
+++ b/docs/samples/stencil_pie_chart.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Stencil Pie Chart
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/stencil_pie_chart.html" title="Stencil Pie Chart Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/stencil_pie_chart.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/stencil_pie_chart.c){: .md-button target="_blank" }
+</div>

--- a/docs/samples/textdrawing.md
+++ b/docs/samples/textdrawing.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Text Drawing
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/textdrawing.html" title="Text Drawing Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/textdrawing.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/text_drawing.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/tile_perf.md
+++ b/docs/samples/tile_perf.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Tile Performance
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/tile_perf.html" title="Tile Performance Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/tile_perf.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/tile_perf.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/timestep.md
+++ b/docs/samples/timestep.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Timestep
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/timestep.html" title="Timestep Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/timestep.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/timestep.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/vector_paths.md
+++ b/docs/samples/vector_paths.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Vector Paths
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/vector_paths.html" title="Vector Paths Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/vector_paths.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/vector_paths.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/vector_text.md
+++ b/docs/samples/vector_text.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Vector Text
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/vector_text.html" title="Vector Text Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/vector_text.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/vector_text.cpp){: .md-button target="_blank" }
+</div>

--- a/docs/samples/windowresizing.md
+++ b/docs/samples/windowresizing.md
@@ -1,0 +1,15 @@
+---
+hide:
+  - toc
+---
+
+# Window Resizing
+
+<div class="sample-container">
+  <iframe class="sample-iframe" src="../play/windowresizing.html" title="Window Resizing Sample"></iframe>
+</div>
+
+<div class="sample-controls" markdown>
+  [:material-fullscreen: Fullscreen](../play/windowresizing.html){: .md-button target="_blank" }
+  [:material-code-tags: View Source](https://github.com/RandyGaul/cute_framework/blob/master/samples/window_resizing.cpp){: .md-button target="_blank" }
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,9 +126,52 @@ nav:
   - Samples:
       - samples/index.md
       # Sample pages are generated with tools/generate_sample_pages.rb by reading this file
+      - 9-Slice: samples/nine_slice.md
+      - Basic Camera: samples/basic_camera.md
+      - Basic Indexed Rendering: samples/basicindexedrendering.md
+      - Basic Instancing: samples/basicinstancing.md
+      - Basic Shapes: samples/basicshapes.md
+      - Basic Sprite: samples/basicsprite.md
+      - Blend Modes: samples/blend_modes.md
+      - Clay UI: samples/clay.md
+      - Clay UI Animations: samples/clay_ui_animations.md
+      - Custom Shapes: samples/custom_shapes.md
+      - Custom Sprite: samples/customsprite.md
+      - Dear ImGui: samples/imgui.md
+      - Dear ImGui Texture: samples/imgui_texture.md
+      - Draw Lists: samples/draw_lists.md
+      - Draw to Texture: samples/draw_to_texture.md
+      - Easy Sprite: samples/easysprite.md
+      - Fetch Image: samples/fetch_image.md
       - Fluid Sim: samples/fluid_sim.md
-      - Waves: samples/waves.md
+      - Font Debug: samples/font_debug.md
+      - Glitch: samples/glitch.md
+      - Hello Triangle: samples/hello_triangle.md
+      - HiDPI: samples/hidpi.md
+      - IME Text Input: samples/ime.md
+      - Import Spritesheet: samples/import_spritesheet.md
+      - Input Binding: samples/input_binding.md
+      - Joypad: samples/joypad.md
+      - Mandala: samples/mandala.md
+      - Metaballs: samples/metaballs.md
+      - Noise: samples/noise.md
+      - Outline (Stencil): samples/outline_stencil.md
+      - Pivot: samples/pivot.md
+      - Platformer: samples/platformer.md
+      - Polygon: samples/polygon.md
+      - Rainbow Liquid: samples/rainbow_liquid.md
+      - Recolor: samples/recolor.md
+      - Shallow Water: samples/shallow_water.md
+      - Sound Pan: samples/sound_pan.md
       - Space Shooter: samples/spaceshooter.md
+      - Stencil Pie Chart: samples/stencil_pie_chart.md
+      - Text Drawing: samples/textdrawing.md
+      - Tile Performance: samples/tile_perf.md
+      - Timestep: samples/timestep.md
+      - Vector Paths: samples/vector_paths.md
+      - Vector Text: samples/vector_text.md
+      - Waves: samples/waves.md
+      - Window Resizing: samples/windowresizing.md
   - Made with CF: made_with_cf.md
   - Community / Ask for Help: community_ask_for_help.md
   - API Reference: api_reference.md

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -99,6 +99,11 @@ if (EMSCRIPTEN)
 	target_link_options(waves PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/waves_data@/waves_data")
 	target_link_options(spaceshooter PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/spaceshooter_data@/spaceshooter_data")
 	target_link_options(fluid_sim PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/fluid_sim_data@/fluid_sim_data")
+	target_link_options(shallow_water PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/shallow_water_data@/shallow_water_data")
+	target_link_options(import_spritesheet PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/import_spritesheet_data@/import_spritesheet_data")
+	target_link_options(pivot PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/pivot_data@/pivot_data")
+	target_link_options(9_slice PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/9_slice_data@/9_slice_data")
+	target_link_options(customsprite PRIVATE --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/custom_sprite_data@/custom_sprite_data")
 endif ()
 
 # Copy over some folders for certain samples.

--- a/tools/generate_sample_pages.rb
+++ b/tools/generate_sample_pages.rb
@@ -11,9 +11,25 @@ require 'fileutils'
 require 'pathname'
 require 'yaml'
 
-# Target name mappings for cases where the nav target differs from the file name
+# Target name mappings for cases where the nav target differs from the build target
 # e.g. nine_slice -> 9_slice
 TARGET_MAP = { 'nine_slice' => '9_slice' }.freeze
+
+# Source file basename mappings for cases where the CMake add_sample() build target
+# differs from the source file's basename, e.g. add_sample(basicinstancing basic_instancing.c)
+SOURCE_FILE_MAP = {
+  'basicinstancing' => 'basic_instancing',
+  'basicindexedrendering' => 'basic_indexed_rendering',
+  'easysprite' => 'easy_sprite',
+  'basicserialization' => 'basic_serialization',
+  'textdrawing' => 'text_drawing',
+  'basicsprite' => 'basic_sprite',
+  'basicshapes' => 'basic_shapes',
+  'windowresizing' => 'window_resizing',
+  'basicinput' => 'basic_input',
+  'windowevents' => 'window_events',
+  'customsprite' => 'custom_sprite',
+}.freeze
 
 # Extract only the nav: block from mkdocs.yml so we avoid Python-specific YAML
 # tags (!!python/name:, !!python/object/apply:) present in other sections.
@@ -73,9 +89,9 @@ def parse_samples_from_nav(nav)
 end
 
 def find_source_file(target, samples_src_dir)
-  actual_target = TARGET_MAP.fetch(target, target)
+  source_basename = SOURCE_FILE_MAP.fetch(target, TARGET_MAP.fetch(target, target))
   %w[c cpp].each do |ext|
-    file = "#{actual_target}.#{ext}"
+    file = "#{source_basename}.#{ext}"
     return file if File.exist?(File.join(samples_src_dir, file))
   end
   nil


### PR DESCRIPTION
Now that CF compiles shaders at runtime everywhere (cute_spirv, #525), most samples build and run fine on Emscripten. This adds nav entries for everything that renders correctly and leaves out the ones that don't:

- `compute`/`galaxy`/`hrc` use real GPU compute shaders, which WebGL2/GLES3 doesn't have at all; CF's GLES backend hard-asserts on the compute-storage texture usage bits, aborting the page.
- `scratch.c` is an author scratchpad, not a real sample.
- `basic_serialization.c` never opens a window — nothing to show in an iframe.
- `window.cpp`, `window_events.c`, `basic_input.c` only `printf` to stdout, no draw calls — blank canvas in a browser with no visible console.
- `scissor.c` technically draws (a sliver in one corner), but reads as a black screen and isn't a useful demo.
- `canvas_readback.c`'s clipboard-image copy is a dead end on web: Emscripten's SDL3 port only implements clipboard text, not images, so the sample's headline feature silently no-ops.

Also fixes two bugs surfaced along the way:
- `generate_sample_pages.rb` conflated the CMake build-target name with the source file's basename, silently skipping any sample where they differ (11 of them). Split `TARGET_MAP` (nav target -> build target) from a new `SOURCE_FILE_MAP` (build target -> source basename).
- `samples/CMakeLists.txt` only wired Emscripten's `--preload-file` data embedding for 3 of the ~8 samples that `fs_mount()` a data directory at runtime. The rest silently found no data on web: `customsprite`/`import_spritesheet` hard-crashed, `9_slice`/`pivot`/`shallow_water` showed an in-canvas "unable to load sprite" error dialog instead of the demo. Added the missing `--preload-file` entries for all 5.

All 46 samples verified with a headless-Chromium sweep (console errors + screenshots) plus manual browsing of the live docs site.

https://claude.ai/code/session_014VaSf9BiQUieExNK66UrsR