### PR TITLE
Remove dead CMake config and fix Linux link cruft

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(cmake/StandardProjectSettings.cmake)
 include(GNUInstallDirs)
 # These are needed for how we use FetchContent.
 include(FetchContent)
-Set(FETCHCONTENT_QUIET FALSE)
+set(FETCHCONTENT_QUIET FALSE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # Todo - Fix how turning some of these off breaks the build.
@@ -68,10 +68,6 @@ if(MSVC)
 	add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
 	add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 	add_compile_options(/MP)
-endif()
-
-if(CF_FRAMEWORK_WITH_HTTPS MATCHES OFF)
-	add_definitions(-DCF_NO_HTTPS)
 endif()
 
 configure_file(
@@ -300,7 +296,7 @@ endif()
 
 if(LINUX)
 	find_package(OpenGL REQUIRED)
-	set(CF_LINK_LIBS ${CF_LINK_LIBS} ${IOKIT} ${FOUNDATION} ${SECURITY} ${OPENGL_LIBRARIES})
+	set(CF_LINK_LIBS ${CF_LINK_LIBS} ${OPENGL_LIBRARIES})
 endif()
 
 if(CF_FRAMEWORK_STATIC)


### PR DESCRIPTION
\`CF_FRAMEWORK_WITH_HTTPS\` was never declared as a CMake option, so \`if(CF_FRAMEWORK_WITH_HTTPS MATCHES OFF)\` was always false -- and the \`CF_NO_HTTPS\` macro it would define isn't read anywhere in the tree. Removing it since it's inert.

The Linux link-libs line also pulled in \`IOKIT\`/\`FOUNDATION\`/\`SECURITY\`, which are Apple-only \`find_library()\` results that are unset (and expand to nothing) on Linux -- leftover from a copy-paste off the Apple block above it.

First of a small stack of CMake modernization PRs; this one is just the standalone bug fixes.