### PR TITLE
Fix cf_shader_directory crashing on files with no extension

### DIFF
--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -33,8 +33,10 @@ static void s_shader_directory_recursive(CF_Path path)
 		} else {
 			CF_Stat stat;
 			fs_stat(p, &stat);
-			String ext = p.ext();
-			if (ext == ".vs" || ext == ".fs" || ext == ".shd" || ext == ".c_shd") {
+			// spext_equ rather than comparing p.ext(): cf_path_get_ext returns NULL for a file with
+			// no extension, and String::operator== would strcmp that null pointer.
+			if (spext_equ(p.c_str(), ".vs") || spext_equ(p.c_str(), ".fs") ||
+			    spext_equ(p.c_str(), ".shd") || spext_equ(p.c_str(), ".c_shd")) {
 				// Exclude app->shader_directory for easier lookups.
 				// e.g. app->shader_directory is "/shaders" and contains
 				// "/shaders/my_shader.shd", the user needs to only reference it by:
@@ -135,8 +137,10 @@ static void s_shader_watch_recursive(CF_Path path)
 		} else {
 			CF_Stat stat;
 			fs_stat(p, &stat);
-			String ext = p.ext();
-			if (ext == ".vs" || ext == ".fs" || ext == ".shd" || ext == ".c_shd") {
+			// spext_equ rather than comparing p.ext(): cf_path_get_ext returns NULL for a file with
+			// no extension, and String::operator== would strcmp that null pointer.
+			if (spext_equ(p.c_str(), ".vs") || spext_equ(p.c_str(), ".fs") ||
+			    spext_equ(p.c_str(), ".shd") || spext_equ(p.c_str(), ".c_shd")) {
 				const char* key = sintern(path + dir[i]);
 				CF_ShaderFileInfo& info = app->shader_file_infos.find(key);
 				if (info.stat.last_modified_time < stat.last_modified_time) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CF_TEST_SRCS
 	test_json.cpp
 	test_markups.cpp
 	test_draw_tiled.cpp
+	test_shader_directory.cpp
 	test_math.cpp
 	test_math.c
 	test_ckit.c

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -42,6 +42,7 @@ TEST_SUITE(test_string);
 TEST_SUITE(test_json);
 TEST_SUITE(test_markups);
 TEST_SUITE(test_draw_tiled);
+TEST_SUITE(test_shader_directory);
 TEST_SUITE(test_math);
 extern "C" {
 TEST_SUITE(test_math_c);
@@ -88,6 +89,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_json);
 	RUN_TRACED(test_markups);
 	RUN_TRACED(test_draw_tiled);
+	RUN_TRACED(test_shader_directory);
 	RUN_TRACED(test_math);
 	RUN_TRACED(test_math_c);
 	RUN_TRACED(test_ckit);

--- a/test/test_shader_directory.cpp
+++ b/test/test_shader_directory.cpp
@@ -1,0 +1,49 @@
+/*
+    Cute Framework
+    Copyright (C) 2025 Randy Gaul https://randygaul.github.io/
+
+    This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute.h>
+
+using namespace Cute;
+
+// cf_shader_directory walks the tree and checks each file's extension. cf_path_get_ext returns
+// NULL for a file that has no extension, and comparing that through CF_Path::ext() strcmp'd the
+// null pointer -- so a shader directory containing a plain "README", a "Makefile", or (very
+// easily) a built executable took the whole app down before it drew a frame.
+//
+// A directory with a shader next to an extensionless file is the whole repro.
+TEST_CASE(test_shader_directory_survives_extensionless_files)
+{
+	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, 64, 64, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL))) return true; // Headless CI: no display/GPU.
+
+	// Build the directory under the write directory so the test owns it outright.
+	const char* base = cf_fs_get_base_directory();
+	cf_fs_set_write_directory(base);
+	cf_fs_create_directory("/shader_dir_test");
+
+	const char* shader_src = "vec4 shader(vec4 color, ShaderParams params) { return color; }\n";
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/ok.shd", shader_src)));
+	// No dot anywhere in the name: cf_path_get_ext returns NULL for this one.
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/README", "not a shader\n")));
+
+	// Pre-fix this call segfaults inside s_shader_directory_recursive.
+	cf_shader_directory("/shader_dir_test");
+
+	// The real shader beside it must still have been picked up.
+	CF_Shader shd = cf_make_draw_shader("ok.shd");
+	REQUIRE(shd.id);
+	cf_destroy_shader(shd);
+
+	cf_destroy_app();
+	return true;
+}
+
+TEST_SUITE(test_shader_directory)
+{
+	RUN_TEST_CASE(test_shader_directory_survives_extensionless_files);
+}


### PR DESCRIPTION
cf_path_get_ext returns NULL when a filename has no dot. Both the directory scan and the hot-reload watcher fed that straight into String::operator==, which strcmps it, so a shader directory containing a plain README -- or a Makefile, or a built executable, which is easy to hit when the shader folder sits next to the binary -- segfaulted before the app drew a frame.

Comparing with spext_equ instead sidesteps it: that helper already returns 0 for the no-extension case rather than handing back a null pointer.

Found while pointing cf_shader_directory at a sample's data folder.