### PR TITLE
Fix inverted back-face culling on the GLES backend

### DIFF
--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -1577,6 +1577,11 @@ void cf_gles_apply_shader(CF_Shader shader_handle, CF_Material material_handle)
 	} else {
 		glEnable(GL_CULL_FACE);
 		glCullFace(s_wrap(render_state.cull_mode));
+		// The GLSL ES transpiler emits `gl_Position.y = -gl_Position.y` so canvases come out with
+		// row 0 at the top, matching the other backends. That negation mirrors every triangle, so
+		// geometry CF considers front-facing reaches the rasterizer wound clockwise -- leaving GL
+		// at its GL_CCW default would cull exactly the wrong faces and turn solids inside out.
+		glFrontFace(GL_CW);
 	}
 
 	// Depth.


### PR DESCRIPTION
The GLSL ES transpiler emits `gl_Position.y = -gl_Position.y` so canvases come out with row 0 at the top, matching the other backends. That negation mirrors every triangle, so geometry CF treats as front-facing reaches the rasterizer wound clockwise — but the backend sets `glCullFace` and never `glFrontFace`, leaving GL at its `GL_CCW` default. Culling then removes exactly the faces it should keep.

The effect is that any 3D drawn on the web with `CF_CULL_MODE_BACK` comes out inside out: closed solids show their interiors, and single-sided geometry disappears entirely. 2D never surfaced it because `cf_render_state_defaults` uses `CF_CULL_MODE_NONE`.

Found while running a 3D sample under WebGL2, where the boxes rendered hollow and the ground vanished. Verified against both backends — the suite passes normally and with `CF_TEST_GLES=1`, and the sample renders identically on desktop and web afterwards.