### PR TITLE
Per canvas clear

### DIFF
--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -2355,6 +2355,8 @@ CF_INLINE void destroy_canvas(CF_Canvas canvas) { cf_destroy_canvas(canvas); }
 CF_INLINE CF_Texture canvas_get_target(CF_Canvas canvas) { return cf_canvas_get_target(canvas); }
 CF_INLINE CF_Texture canvas_get_depth_stencil_target(CF_Canvas canvas) { return cf_canvas_get_depth_stencil_target(canvas); }
 CF_INLINE void clear_canvas(CF_Canvas canvas) { cf_clear_canvas(canvas); }
+CF_INLINE void canvas_set_clear_color(CF_Canvas canvas, CF_Color color) { cf_canvas_set_clear_color(canvas, color); }
+CF_INLINE void canvas_set_clear_depth_stencil(CF_Canvas canvas, float depth, uint32_t stencil) { cf_canvas_set_clear_depth_stencil(canvas, depth, stencil); }
 CF_INLINE CF_Readback canvas_readback(CF_Canvas canvas) { return cf_canvas_readback(canvas); }
 CF_INLINE bool readback_ready(CF_Readback readback) { return cf_readback_ready(readback); }
 CF_INLINE int readback_data(CF_Readback readback, void* data, int size) { return cf_readback_data(readback, data, size); }

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -1252,6 +1252,40 @@ CF_API CF_Texture CF_CALL cf_canvas_get_depth_stencil_target(CF_Canvas canvas);
  */
 CF_API void CF_CALL cf_clear_canvas(CF_Canvas canvas);
 
+/**
+ * @function cf_canvas_set_clear_color
+ * @category graphics
+ * @brief    Gives one canvas its own clear color, instead of the global `cf_clear_color`.
+ * @param    canvas  The canvas.
+ * @param    color   The color this canvas clears to from now on.
+ * @remarks  `cf_clear_color` sets a single global value that every clear reads, so a multi-pass
+ *           renderer wanting different clears per pass has to set the global before each pass and
+ *           put it back afterwards -- and forgetting the restore leaves the main screen clearing to
+ *           whatever the last pass wanted. This sets the value on the canvas once:
+ *
+ *           ```c
+ *           cf_canvas_set_clear_color(gbuffer, cf_color_black());
+ *           cf_canvas_set_clear_color(composite, cf_color_invisible());
+ *           ```
+ *
+ *           A canvas with no override set clears to the global, so existing code behaves exactly as
+ *           before. There is no way to go back to inheriting once set -- set the value you want.
+ * @related  CF_Canvas cf_clear_color cf_canvas_set_clear_depth_stencil cf_clear_canvas cf_apply_canvas
+ */
+CF_API void CF_CALL cf_canvas_set_clear_color(CF_Canvas canvas, CF_Color color);
+
+/**
+ * @function cf_canvas_set_clear_depth_stencil
+ * @category graphics
+ * @brief    Gives one canvas its own clear depth and stencil, instead of the global `cf_clear_depth_stencil`.
+ * @param    canvas   The canvas.
+ * @param    depth    The depth value this canvas clears to. 1.0 pairs with `CF_COMPARE_FUNCTION_LESS_THAN`.
+ * @param    stencil  The stencil value this canvas clears to.
+ * @remarks  See `cf_canvas_set_clear_color`. A canvas with no override clears to the global values.
+ * @related  CF_Canvas cf_clear_depth_stencil cf_canvas_set_clear_color cf_clear_canvas cf_render_state_3d_defaults
+ */
+CF_API void CF_CALL cf_canvas_set_clear_depth_stencil(CF_Canvas canvas, float depth, uint32_t stencil);
+
 //--------------------------------------------------------------------------------------------------
 // Readback.
 

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -911,6 +911,8 @@ CF_DISPATCH_SHIM(CF_Texture, canvas_get_target, (CF_Canvas canvas_handle), canva
 CF_DISPATCH_SHIM(CF_Texture, canvas_get_depth_stencil_target, (CF_Canvas canvas_handle), canvas_handle)
 CF_DISPATCH_SHIM_VOID(canvas_get_size, (CF_Canvas canvas_handle, int* w, int* h), canvas_handle, w, h)
 CF_DISPATCH_SHIM_VOID(clear_canvas, (CF_Canvas canvas_handle), canvas_handle)
+CF_DISPATCH_SHIM_VOID(canvas_set_clear_color, (CF_Canvas canvas_handle, CF_Color color), canvas_handle, color)
+CF_DISPATCH_SHIM_VOID(canvas_set_clear_depth_stencil, (CF_Canvas canvas_handle, float depth, uint32_t stencil), canvas_handle, depth, stencil)
 CF_DISPATCH_SHIM(CF_Readback, canvas_readback, (CF_Canvas canvas), canvas)
 CF_DISPATCH_SHIM(bool, readback_ready, (CF_Readback readback), readback)
 CF_DISPATCH_SHIM(int, readback_data, (CF_Readback readback, void* data, int size), readback, data, size)

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -176,6 +176,13 @@ struct CF_GL_Canvas
 	bool has_depth;
 	bool has_stencil;
 
+	// Per-canvas clear overrides; unset means fall back to the globals.
+	bool has_clear_color;
+	CF_Color clear_color;
+	bool has_clear_depth_stencil;
+	float clear_depth;
+	uint32_t clear_stencil;
+
 	CF_Texture cf_color;
 };
 
@@ -1114,13 +1121,14 @@ CF_Texture cf_gles_canvas_get_depth_stencil_target(CF_Canvas)
 static inline void s_clear_canvas(const CF_GL_Canvas* canvas)
 {
 	GLbitfield bits = GL_COLOR_BUFFER_BIT;
-	glClearColor(app->clear_color.r, app->clear_color.g, app->clear_color.b, app->clear_color.a);
+	CF_Color cc = canvas->has_clear_color ? canvas->clear_color : app->clear_color;
+	glClearColor(cc.r, cc.g, cc.b, cc.a);
 	if (s_canvas_has_depth(canvas)) {
-		glClearDepthf(app->clear_depth);
+		glClearDepthf(canvas->has_clear_depth_stencil ? canvas->clear_depth : app->clear_depth);
 		bits |= GL_DEPTH_BUFFER_BIT;
 	}
 	if (s_canvas_has_stencil(canvas)) {
-		glClearStencil((GLint)app->clear_stencil);
+		glClearStencil((GLint)(canvas->has_clear_depth_stencil ? canvas->clear_stencil : app->clear_stencil));
 		bits |= GL_STENCIL_BUFFER_BIT;
 	}
 	g_ctx.current_state.scissor_enabled = false;
@@ -2037,4 +2045,21 @@ void cf_gles_destroy_readback(CF_Readback readback)
 	if (!rb) return;
 	CF_FREE(rb->data);
 	CF_FREE(rb);
+}
+
+void cf_gles_canvas_set_clear_color(CF_Canvas canvas_handle, CF_Color color)
+{
+	CF_GL_Canvas* canvas = (CF_GL_Canvas*)(uintptr_t)canvas_handle.id;
+	if (!canvas) return;
+	canvas->has_clear_color = true;
+	canvas->clear_color = color;
+}
+
+void cf_gles_canvas_set_clear_depth_stencil(CF_Canvas canvas_handle, float depth, uint32_t stencil)
+{
+	CF_GL_Canvas* canvas = (CF_GL_Canvas*)(uintptr_t)canvas_handle.id;
+	if (!canvas) return;
+	canvas->has_clear_depth_stencil = true;
+	canvas->clear_depth = depth;
+	canvas->clear_stencil = stencil;
 }

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -33,10 +33,23 @@ struct CF_CanvasInternal
 
 	bool clear;
 
+	// Per-canvas clear overrides. Unset means "use the global cf_clear_color /
+	// cf_clear_depth_stencil", so existing code is unaffected.
+	bool has_clear_color;
+	CF_Color clear_color;
+	bool has_clear_depth_stencil;
+	float clear_depth;
+	uint32_t clear_stencil;
+
 	// These get set by cf_apply_* functions.
 	struct CF_MeshInternal* mesh;
 	SDL_GPURenderPass* pass;
 };
+
+// Per-canvas clear values, falling back to the globals when the canvas has no override.
+static CF_Color s_clear_color(const CF_CanvasInternal* c) { return (c && c->has_clear_color) ? c->clear_color : app->clear_color; }
+static float s_clear_depth(const CF_CanvasInternal* c) { return (c && c->has_clear_depth_stencil) ? c->clear_depth : app->clear_depth; }
+static uint32_t s_clear_stencil(const CF_CanvasInternal* c) { return (c && c->has_clear_depth_stencil) ? c->clear_stencil : app->clear_stencil; }
 
 struct CF_TextureInternal
 {
@@ -1196,20 +1209,20 @@ void cf_sdlgpu_clear_canvas(CF_Canvas canvas_handle)
 
 	SDL_GPUColorTargetInfo color_info = {
 		.texture = canvas->texture,
-		.clear_color = { app->clear_color.r, app->clear_color.g, app->clear_color.b, app->clear_color.a },
+		.clear_color = { s_clear_color(canvas).r, s_clear_color(canvas).g, s_clear_color(canvas).b, s_clear_color(canvas).a },
 		.load_op = SDL_GPU_LOADOP_CLEAR,
 		.store_op = SDL_GPU_STOREOP_STORE,
 		.cycle = true,
 	};
 	SDL_GPUDepthStencilTargetInfo depth_stencil_info = {
 		.texture = canvas->depth_stencil,
-		.clear_depth = 1.0f,
+		.clear_depth = s_clear_depth(canvas),
 		.load_op = SDL_GPU_LOADOP_CLEAR,
 		.store_op = SDL_GPU_STOREOP_STORE,
 		.stencil_load_op = SDL_GPU_LOADOP_CLEAR,
 		.stencil_store_op = SDL_GPU_STOREOP_STORE,
 		.cycle = true,
-		.clear_stencil = 0,
+		.clear_stencil = (Uint8)s_clear_stencil(canvas),
 	};
 	SDL_GPURenderPass* renderPass = SDL_BeginGPURenderPass(cmd, &color_info, 1, canvas->depth_stencil ? &depth_stencil_info : NULL);
 	SDL_EndGPURenderPass(renderPass);
@@ -1808,7 +1821,8 @@ void cf_sdlgpu_apply_shader(CF_Shader shader_handle, CF_Material material_handle
 		SDL_GPUColorTargetInfo pass_color_info;
 		CF_MEMSET(&pass_color_info, 0, sizeof(pass_color_info));
 		pass_color_info.texture = g_ctx.canvas->texture;
-		pass_color_info.clear_color = { app->clear_color.r, app->clear_color.g, app->clear_color.b, app->clear_color.a };
+		CF_Color cc = s_clear_color(g_ctx.canvas);
+		pass_color_info.clear_color = { cc.r, cc.g, cc.b, cc.a };
 		pass_color_info.load_op = g_ctx.canvas->clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_LOAD;
 		pass_color_info.cycle = g_ctx.canvas->clear ? true : false;
 		if (g_ctx.canvas->sample_count == CF_SAMPLE_COUNT_1) {
@@ -1824,8 +1838,8 @@ void cf_sdlgpu_apply_shader(CF_Shader shader_handle, CF_Material material_handle
 		SDL_GPUDepthStencilTargetInfo* depth_stencil_ptr = NULL;
 		if (g_ctx.canvas->depth_stencil) {
 			pass_depth_stencil_info.texture = g_ctx.canvas->depth_stencil;
-			pass_depth_stencil_info.clear_depth = app->clear_depth;
-			pass_depth_stencil_info.clear_stencil = app->clear_stencil;
+			pass_depth_stencil_info.clear_depth = s_clear_depth(g_ctx.canvas);
+			pass_depth_stencil_info.clear_stencil = (Uint8)s_clear_stencil(g_ctx.canvas);
 			pass_depth_stencil_info.load_op = g_ctx.canvas->clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_LOAD;
 			pass_depth_stencil_info.store_op = SDL_GPU_STOREOP_STORE;
 			pass_depth_stencil_info.stencil_load_op = g_ctx.canvas->clear ? SDL_GPU_LOADOP_CLEAR : SDL_GPU_LOADOP_LOAD;
@@ -2374,3 +2388,20 @@ void cf_sdlgpu_dispatch_compute(CF_ComputeShader shader, CF_Material material_ha
 }
 
 #endif
+
+void cf_sdlgpu_canvas_set_clear_color(CF_Canvas canvas_handle, CF_Color color)
+{
+	CF_CanvasInternal* canvas = (CF_CanvasInternal*)canvas_handle.id;
+	if (!canvas) return;
+	canvas->has_clear_color = true;
+	canvas->clear_color = color;
+}
+
+void cf_sdlgpu_canvas_set_clear_depth_stencil(CF_Canvas canvas_handle, float depth, uint32_t stencil)
+{
+	CF_CanvasInternal* canvas = (CF_CanvasInternal*)canvas_handle.id;
+	if (!canvas) return;
+	canvas->has_clear_depth_stencil = true;
+	canvas->clear_depth = depth;
+	canvas->clear_stencil = stencil;
+}

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -2387,8 +2387,6 @@ void cf_sdlgpu_dispatch_compute(CF_ComputeShader shader, CF_Material material_ha
 	SDL_EndGPUComputePass(pass);
 }
 
-#endif
-
 void cf_sdlgpu_canvas_set_clear_color(CF_Canvas canvas_handle, CF_Color color)
 {
 	CF_CanvasInternal* canvas = (CF_CanvasInternal*)canvas_handle.id;
@@ -2405,3 +2403,5 @@ void cf_sdlgpu_canvas_set_clear_depth_stencil(CF_Canvas canvas_handle, float dep
 	canvas->clear_depth = depth;
 	canvas->clear_stencil = stencil;
 }
+
+#endif

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -1323,8 +1323,16 @@ bool cf_sdlgpu_readback_ready(CF_Readback readback)
 	CF_ReadbackInternal* rb = (CF_ReadbackInternal*)readback.id;
 	if (!rb) return false;
 	if (rb->ready) return true;
-	rb->ready = SDL_QueryGPUFence(g_ctx.device, rb->fence);
-	return rb->ready;
+	if (!SDL_QueryGPUFence(g_ctx.device, rb->fence)) return false;
+	// A signaled fence only guarantees the GPU-side copy finished. On D3D12, a download
+	// whose row pitch needs realigning to the 256-byte copy alignment is unpacked into
+	// the transfer buffer lazily, on the next *wait* that observes the fence -- a query
+	// never does this. Without the wait below, cf_readback_data can read stale transfer
+	// buffer contents even though the fence already reports done. This call returns
+	// immediately, since the fence is already known signaled.
+	SDL_WaitForGPUFences(g_ctx.device, true, &rb->fence, 1);
+	rb->ready = true;
+	return true;
 }
 
 int cf_sdlgpu_readback_data(CF_Readback readback, void* data, int size)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(CF_TEST_SRCS
 	test_markups.cpp
 	test_draw_tiled.cpp
 	test_shader_directory.cpp
+	test_canvas_clear.cpp
 	test_math.cpp
 	test_math.c
 	test_ckit.c

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -43,6 +43,7 @@ TEST_SUITE(test_json);
 TEST_SUITE(test_markups);
 TEST_SUITE(test_draw_tiled);
 TEST_SUITE(test_shader_directory);
+TEST_SUITE(test_canvas_clear);
 TEST_SUITE(test_math);
 extern "C" {
 TEST_SUITE(test_math_c);
@@ -90,6 +91,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_markups);
 	RUN_TRACED(test_draw_tiled);
 	RUN_TRACED(test_shader_directory);
+	RUN_TRACED(test_canvas_clear);
 	RUN_TRACED(test_math);
 	RUN_TRACED(test_math_c);
 	RUN_TRACED(test_ckit);

--- a/test/test_canvas_clear.cpp
+++ b/test/test_canvas_clear.cpp
@@ -1,0 +1,163 @@
+/*
+    Cute Framework
+    Copyright (C) 2025 Randy Gaul https://randygaul.github.io/
+
+    This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute.h>
+#include <stdlib.h>
+
+using namespace Cute;
+
+#define W 32
+#define H 32
+
+static int s_app_options()
+{
+	int options = CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT;
+	const char* gles = getenv("CF_TEST_GLES");
+	if (gles && *gles == '1') options |= CF_APP_OPTIONS_GFX_OPENGL_BIT | CF_APP_OPTIONS_GFX_DEBUG_BIT;
+	return options;
+}
+
+static bool s_near(int a, int b) { int d = a - b; return (d < 0 ? -d : d) < 24; }
+
+static CF_Pixel s_clear_and_read(CF_Canvas canvas, CF_Pixel* px)
+{
+	cf_app_update(NULL);
+	cf_clear_canvas(canvas);
+	cf_app_draw_onto_screen(false);
+
+	CF_Readback rb = cf_canvas_readback(canvas);
+	while (!cf_readback_ready(rb)) {}
+	cf_readback_data(rb, px, W * H * (int)sizeof(CF_Pixel));
+	cf_destroy_readback(rb);
+	return px[(H / 2) * W + (W / 2)];
+}
+
+// cf_clear_color is a single global that every clear reads, so a multi-pass renderer wanting
+// different clears per pass has to set it before each pass and restore it afterwards. Two
+// canvases must be able to hold their own clear colors at the same time.
+TEST_CASE(test_per_canvas_clear_color)
+{
+	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, s_app_options(), NULL))) return true; // Headless CI: no display/GPU.
+
+	CF_Canvas red_canvas = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Canvas blue_canvas = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Canvas inherits = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(W * H * (int)sizeof(CF_Pixel));
+
+	// The global stays green the whole way through; neither override touches it.
+	cf_clear_color(0, 1.0f, 0, 1.0f);
+	cf_canvas_set_clear_color(red_canvas, cf_make_color_rgb_f(1.0f, 0, 0));
+	cf_canvas_set_clear_color(blue_canvas, cf_make_color_rgb_f(0, 0, 1.0f));
+
+	CF_Pixel r = s_clear_and_read(red_canvas, px);
+	REQUIRE(s_near(r.colors.r, 255) && s_near(r.colors.b, 0));
+
+	CF_Pixel b = s_clear_and_read(blue_canvas, px);
+	REQUIRE(s_near(b.colors.b, 255) && s_near(b.colors.r, 0));
+
+	// A canvas with no override still follows the global, so existing code is unaffected.
+	CF_Pixel g = s_clear_and_read(inherits, px);
+	REQUIRE(s_near(g.colors.g, 255) && s_near(g.colors.r, 0) && s_near(g.colors.b, 0));
+
+	// And setting overrides did not disturb the global for anyone else.
+	CF_Pixel g2 = s_clear_and_read(inherits, px);
+	REQUIRE(s_near(g2.colors.g, 255));
+
+	cf_free(px);
+	cf_destroy_canvas(red_canvas);
+	cf_destroy_canvas(blue_canvas);
+	cf_destroy_canvas(inherits);
+	cf_destroy_app();
+	return true;
+}
+
+// cf_clear_canvas hardcoded clear_depth to 1.0 and clear_stencil to 0 on the SDL_GPU backend,
+// ignoring cf_clear_depth_stencil entirely -- while the cf_apply_canvas path honored it, so the
+// two disagreed. Clearing depth to 0 with a LESS_THAN test must reject everything drawn after.
+TEST_CASE(test_canvas_clear_depth_is_honored)
+{
+	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, s_app_options(), NULL))) return true; // Headless CI: no display/GPU.
+
+	const char* vs =
+		"layout (location = 0) in vec2 in_pos;\n"
+		"void main() { gl_Position = vec4(in_pos, 0.5, 1); }\n"; // Fixed mid-range depth.
+	const char* fs =
+		"layout(location = 0) out vec4 result;\n"
+		"void main() { result = vec4(1, 0, 0, 1); }\n";
+
+	struct Vertex { float x, y; };
+	Vertex verts[4] = { { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, 1 } };
+	uint16_t indices[6] = { 0, 1, 2, 0, 2, 3 };
+	CF_VertexAttribute attrs[1] = { };
+	attrs[0].name = "in_pos";
+	attrs[0].format = CF_VERTEX_FORMAT_FLOAT2;
+	attrs[0].offset = 0;
+	CF_Mesh mesh = cf_make_mesh(sizeof(verts), attrs, 1, sizeof(Vertex));
+	cf_mesh_update_vertex_data(mesh, verts, 4);
+	cf_mesh_set_index_buffer(mesh, sizeof(indices), 16);
+	cf_mesh_update_index_data(mesh, indices, 6);
+
+	CF_Shader shader = cf_make_shader_from_source(vs, fs);
+	REQUIRE(shader.id);
+
+	CF_CanvasParams params = cf_canvas_defaults(W, H);
+	params.depth_stencil_enable = true;
+	CF_Canvas canvas = cf_make_canvas(params);
+
+	CF_Material material = cf_make_material();
+	CF_RenderState rs = cf_render_state_defaults();
+	rs.depth_write_enabled = true;
+	rs.depth_compare = CF_COMPARE_FUNCTION_LESS_THAN;
+	cf_material_set_render_state(material, rs);
+
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(W * H * (int)sizeof(CF_Pixel));
+	cf_clear_color(0, 0, 0, 1.0f);
+
+	// Depth cleared to 0: the quad at 0.5 fails LESS_THAN and must not appear.
+	cf_canvas_set_clear_depth_stencil(canvas, 0.0f, 0);
+	cf_app_update(NULL);
+	cf_apply_canvas(canvas, true);
+	cf_apply_mesh(mesh);
+	cf_apply_shader(shader, material);
+	cf_draw_elements();
+	cf_app_draw_onto_screen(false);
+	CF_Readback rb = cf_canvas_readback(canvas);
+	while (!cf_readback_ready(rb)) {}
+	cf_readback_data(rb, px, W * H * (int)sizeof(CF_Pixel));
+	cf_destroy_readback(rb);
+	REQUIRE(s_near(px[(H / 2) * W + (W / 2)].colors.r, 0)); // Rejected.
+
+	// Depth cleared to 1: the same quad now passes.
+	cf_canvas_set_clear_depth_stencil(canvas, 1.0f, 0);
+	cf_app_update(NULL);
+	cf_apply_canvas(canvas, true);
+	cf_apply_mesh(mesh);
+	cf_apply_shader(shader, material);
+	cf_draw_elements();
+	cf_app_draw_onto_screen(false);
+	rb = cf_canvas_readback(canvas);
+	while (!cf_readback_ready(rb)) {}
+	cf_readback_data(rb, px, W * H * (int)sizeof(CF_Pixel));
+	cf_destroy_readback(rb);
+	REQUIRE(s_near(px[(H / 2) * W + (W / 2)].colors.r, 255)); // Drawn.
+
+	cf_free(px);
+	cf_destroy_canvas(canvas);
+	cf_destroy_material(material);
+	cf_destroy_shader(shader);
+	cf_destroy_mesh(mesh);
+	cf_destroy_app();
+	return true;
+}
+
+TEST_SUITE(test_canvas_clear)
+{
+	RUN_TEST_CASE(test_per_canvas_clear_color);
+	RUN_TEST_CASE(test_canvas_clear_depth_is_honored);
+}

--- a/test/test_canvas_clear.cpp
+++ b/test/test_canvas_clear.cpp
@@ -25,6 +25,14 @@ static int s_app_options()
 
 static bool s_near(int a, int b) { int d = a - b; return (d < 0 ? -d : d) < 24; }
 
+// A failed REQUIRE below returns out of the test case early, so destroying the app must
+// happen via RAII rather than a final statement -- otherwise the leaked app (and its
+// file system init) breaks cf_make_app in whichever test case runs next.
+struct AppDestroyGuard
+{
+	~AppDestroyGuard() { cf_destroy_app(); }
+};
+
 static CF_Pixel s_clear_and_read(CF_Canvas canvas, CF_Pixel* px)
 {
 	cf_app_update(NULL);
@@ -35,6 +43,17 @@ static CF_Pixel s_clear_and_read(CF_Canvas canvas, CF_Pixel* px)
 	while (!cf_readback_ready(rb)) {}
 	cf_readback_data(rb, px, W * H * (int)sizeof(CF_Pixel));
 	cf_destroy_readback(rb);
+
+	if (getenv("CF_TEST_DUMP")) {
+		// Debug aid: a stride/pitch bug shows up as row 0 reading correctly while row 1
+		// (and beyond) start mid-garbage; a wrong-clear bug reads uniformly wrong instead.
+		printf(
+			"backend=%s row0=%08x %08x row1=%08x %08x center=%08x\n",
+			cf_backend_type_to_string(cf_query_backend()),
+			px[0].val, px[1].val, px[W].val, px[W + 1].val, px[(H / 2) * W + (W / 2)].val
+		);
+	}
+
 	return px[(H / 2) * W + (W / 2)];
 }
 
@@ -44,6 +63,7 @@ static CF_Pixel s_clear_and_read(CF_Canvas canvas, CF_Pixel* px)
 TEST_CASE(test_per_canvas_clear_color)
 {
 	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, s_app_options(), NULL))) return true; // Headless CI: no display/GPU.
+	AppDestroyGuard app_guard;
 
 	CF_Canvas red_canvas = cf_make_canvas(cf_canvas_defaults(W, H));
 	CF_Canvas blue_canvas = cf_make_canvas(cf_canvas_defaults(W, H));
@@ -73,7 +93,6 @@ TEST_CASE(test_per_canvas_clear_color)
 	cf_destroy_canvas(red_canvas);
 	cf_destroy_canvas(blue_canvas);
 	cf_destroy_canvas(inherits);
-	cf_destroy_app();
 	return true;
 }
 
@@ -83,6 +102,7 @@ TEST_CASE(test_per_canvas_clear_color)
 TEST_CASE(test_canvas_clear_depth_is_honored)
 {
 	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, s_app_options(), NULL))) return true; // Headless CI: no display/GPU.
+	AppDestroyGuard app_guard;
 
 	const char* vs =
 		"layout (location = 0) in vec2 in_pos;\n"
@@ -152,7 +172,6 @@ TEST_CASE(test_canvas_clear_depth_is_honored)
 	cf_destroy_material(material);
 	cf_destroy_shader(shader);
 	cf_destroy_mesh(mesh);
-	cf_destroy_app();
 	return true;
 }
 

--- a/test/test_canvas_clear.cpp
+++ b/test/test_canvas_clear.cpp
@@ -1,8 +1,8 @@
 /*
-    Cute Framework
-    Copyright (C) 2025 Randy Gaul https://randygaul.github.io/
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
 
-    This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
 */
 
 #include "test_harness.h"


### PR DESCRIPTION
**`cf_clear_color`** sets one global that every clear reads. A multi-pass renderer
wanting a different clear per pass -- transparent for the colour buffer, opaque
far for a depth-carrying g-buffer, transparent again for the composite -- has to
set the global before each pass and put it back at the end of the frame. Forget
the restore and the main screen inherits whatever the last pass wanted, which
presents as the whole game going transparent and points nowhere near the cause.
`cf_clear_canvas` takes no colour argument and `CF_CanvasParams` has no clear field,
so there was no way to say it locally.

The clear values now live on the canvas, and a canvas without an override reads
the globals exactly as before, so nothing existing changes behavior. There is
deliberately no way back to inheriting once set: "sometimes local, sometimes
global" is the ambiguity worth avoiding.

This also settles a disagreement between the two clear paths on SDL_GPU.
`cf_clear_canvas` hardcoded clear_depth to 1.0 and `clear_stencil` to 0, ignoring
`cf_clear_depth_stencil`, while the `cf_apply_canvas` path honored it -- and GLES
honored it in both. All three now agree.