### PR TITLE
Add hot reload for two-file cf_make_shader shaders

### DIFF
--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -842,6 +842,27 @@ CF_API void CF_CALL cf_shader_on_error(void (*on_error_fn)(const char* error_mes
 CF_API CF_Shader CF_CALL cf_make_shader(const char* vertex_path, const char* fragment_path);
 
 /**
+ * @function cf_shader_reload_from_files
+ * @category graphics
+ * @brief    Recompiles a shader made by `cf_make_shader` from its original vertex and fragment files.
+ * @param    shader  The shader to reload.
+ * @return   Returns true if the shader was rebuilt, false if it did not come from `cf_make_shader`
+ *           or if the rebuild failed.
+ * @remarks  On failure the existing shader keeps working and the reason is available from
+ *           `cf_shader_compile_error`, so a typo saved mid-edit does not blank the screen.
+ *
+ *           Unlike `cf_shader_reload`, which returns a fresh handle for draw shaders, this swaps the
+ *           shader's contents in place -- every copy of the handle stays valid, including ones
+ *           already handed to a `CF_Material`.
+ *
+ *           Shaders under `cf_shader_directory` reload automatically when their files change, so
+ *           this is only needed when driving reloads by hand from `cf_shader_on_changed` (which
+ *           turns the automatic path off).
+ * @related  cf_make_shader cf_shader_reload cf_compute_shader_reload cf_shader_directory cf_shader_on_changed cf_shader_compile_error
+ */
+CF_API bool CF_CALL cf_shader_reload_from_files(CF_Shader* shader);
+
+/**
  * @function cf_make_shader_from_source
  * @category graphics
  * @brief    Creates a shader from strings containing glsl source code.

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -23,6 +23,11 @@ using namespace Cute;
 
 static Map<const char*> s_compute_shader_paths;
 
+// Source paths for shaders made by cf_make_shader, so they can hot-reload like draw and compute
+// shaders already do. Draw and compute shaders each need only one path, hence the separate map.
+struct CF_GraphicsShaderPaths { const char* vertex_path; const char* fragment_path; };
+static Map<CF_GraphicsShaderPaths> s_graphics_shader_paths;
+
 static void s_shader_directory_recursive(CF_Path path)
 {
 	Array<CF_Path> dir = CF_Directory::enumerate(app->shader_directory + path);
@@ -102,6 +107,29 @@ static void s_shader_auto_reload(const char* changed_key)
 					cf_destroy_shader_internal(fresh_blit);
 				}
 			}
+		}
+	}
+
+	// Two-file graphics shaders. The stored paths are whatever the user passed to cf_make_shader,
+	// which is a full VFS path, while `changed_key` is relative to the shader directory -- so
+	// resolve the key to its full path and compare interned pointers.
+	{
+		const char* changed_full = NULL;
+		CF_ShaderFileInfo* info = app->shader_file_infos.try_find(sintern(changed_key));
+		if (info) changed_full = info->path;
+
+		Array<uint64_t> gs_ids;
+		int gn = s_graphics_shader_paths.count();
+		for (int i = 0; i < gn; ++i) {
+			CF_GraphicsShaderPaths p = s_graphics_shader_paths.items()[i];
+			bool hit = (changed_full && (p.vertex_path == changed_full || p.fragment_path == changed_full)) ||
+			           matches(p.vertex_path) || matches(p.fragment_path);
+			if (hit) gs_ids.add(s_graphics_shader_paths.keys()[i]);
+		}
+		// cf_make_shader mutates s_graphics_shader_paths, so reload only after collecting.
+		for (int i = 0; i < gs_ids.count(); ++i) {
+			CF_Shader old = { gs_ids[i] };
+			cf_shader_reload_from_files(&old);
 		}
 	}
 
@@ -454,6 +482,7 @@ void cf_unload_internal_shaders()
 void cf_destroy_shader(CF_Shader shader_handle)
 {
 	s_draw->shader_paths.remove(shader_handle.id);
+	s_graphics_shader_paths.remove(shader_handle.id);
 
 	// Draw shaders automatically have blit shaders generated, so clean that up as well,
 	// if it exists. See `cf_make_draw_shader`.
@@ -791,15 +820,50 @@ void cf_clear_depth_stencil(float depth, uint32_t stencil)
 
 CF_Shader cf_make_shader(const char* vertex_path, const char* fragment_path)
 {
-	// Make sure each file can be found.
 	char* vs = fs_read_entire_file_to_memory_and_nul_terminate(vertex_path);
 	char* fs = fs_read_entire_file_to_memory_and_nul_terminate(fragment_path);
-	CF_ASSERT(vs);
-	CF_ASSERT(fs);
+
+	// Report a missing file the same way a compile error is reported, rather than asserting.
+	// Hot reload fires on filesystem timestamps and will happily catch a file mid-write, and the
+	// whole point of reloading is that a bad edit leaves the old shader running instead of
+	// taking the app down.
+	if (!vs || !fs) {
+		s_shader_compile_error = String("Unable to read shader file: ") + (vs ? fragment_path : vertex_path);
+		fprintf(stderr, "%s\n", s_shader_compile_error.c_str());
+		if (s_shader_error_fn) s_shader_error_fn(s_shader_compile_error.c_str(), s_shader_error_udata);
+		if (vs) CF_FREE(vs);
+		if (fs) CF_FREE(fs);
+		CF_Shader result = { 0 };
+		return result;
+	}
+
 	CF_Shader shader = cf_make_shader_from_source(vs, fs);
 	CF_FREE(vs);
 	CF_FREE(fs);
+
+	if (shader.id) {
+		CF_GraphicsShaderPaths paths;
+		paths.vertex_path = sintern(vertex_path);
+		paths.fragment_path = sintern(fragment_path);
+		s_graphics_shader_paths.add(shader.id, paths);
+	}
 	return shader;
+}
+
+bool cf_shader_reload_from_files(CF_Shader* shader)
+{
+	if (!shader) return false;
+	CF_GraphicsShaderPaths* paths = s_graphics_shader_paths.try_find(shader->id);
+	if (!paths) return false;
+
+	CF_Shader fresh = cf_make_shader(paths->vertex_path, paths->fragment_path);
+	if (!fresh.id) return false; // Compile or read error; the caller's shader keeps working.
+
+	// Swap guts rather than handles, so every copy of this handle -- including ones already
+	// handed to a CF_Material -- keeps working.
+	cf_shader_swap_contents(*shader, fresh);
+	cf_destroy_shader(fresh);
+	return true;
 }
 
 CF_Shader cf_make_shader_from_source(const char* vertex_src, const char* fragment_src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CF_TEST_SRCS
 	test_json.cpp
 	test_markups.cpp
 	test_draw_tiled.cpp
+	test_shader_reload.cpp
 	test_math.cpp
 	test_math.c
 	test_ckit.c

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -42,6 +42,7 @@ TEST_SUITE(test_string);
 TEST_SUITE(test_json);
 TEST_SUITE(test_markups);
 TEST_SUITE(test_draw_tiled);
+TEST_SUITE(test_shader_reload);
 TEST_SUITE(test_math);
 extern "C" {
 TEST_SUITE(test_math_c);
@@ -88,6 +89,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_json);
 	RUN_TRACED(test_markups);
 	RUN_TRACED(test_draw_tiled);
+	RUN_TRACED(test_shader_reload);
 	RUN_TRACED(test_math);
 	RUN_TRACED(test_math_c);
 	RUN_TRACED(test_ckit);

--- a/test/test_shader_reload.cpp
+++ b/test/test_shader_reload.cpp
@@ -1,0 +1,135 @@
+/*
+    Cute Framework
+    Copyright (C) 2025 Randy Gaul https://randygaul.github.io/
+
+    This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+// Reload coverage for the two-file cf_make_shader path. Draw and compute shaders could already
+// reload; the low-level path -- the only one a custom 3d vertex stage can use -- could not.
+
+#include "test_harness.h"
+
+#include <cute.h>
+
+using namespace Cute;
+
+#define W 64
+#define H 64
+
+static const char* s_vs =
+"layout (location = 0) in vec2 in_pos;\n"
+"void main() { gl_Position = vec4(in_pos, 0, 1); }\n";
+
+// Parameterized so the test can rewrite the file and check the change took effect.
+static const char* s_fs_fmt =
+"layout(location = 0) out vec4 result;\n"
+"void main() { result = vec4(%s); }\n";
+
+static CF_Mesh s_make_fullscreen_quad()
+{
+	struct Vertex { float x, y; };
+	Vertex verts[4] = { { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, 1 } };
+	uint16_t indices[6] = { 0, 1, 2, 0, 2, 3 };
+	CF_VertexAttribute attrs[1] = { };
+	attrs[0].name = "in_pos";
+	attrs[0].format = CF_VERTEX_FORMAT_FLOAT2;
+	attrs[0].offset = 0;
+	CF_Mesh mesh = cf_make_mesh(sizeof(verts), attrs, 1, sizeof(Vertex));
+	cf_mesh_update_vertex_data(mesh, verts, 4);
+	cf_mesh_set_index_buffer(mesh, sizeof(indices), 16);
+	cf_mesh_update_index_data(mesh, indices, 6);
+	return mesh;
+}
+
+static CF_Pixel s_render_probe(CF_Mesh mesh, CF_Shader shader, CF_Material material, CF_Canvas canvas, CF_Pixel* px)
+{
+	cf_app_update(NULL);
+	cf_apply_canvas(canvas, true);
+	cf_apply_mesh(mesh);
+	cf_apply_shader(shader, material);
+	cf_draw_elements();
+	cf_app_draw_onto_screen(false);
+
+	CF_Readback rb = cf_canvas_readback(canvas);
+	while (!cf_readback_ready(rb)) {}
+	cf_readback_data(rb, px, W * H * (int)sizeof(CF_Pixel));
+	cf_destroy_readback(rb);
+	return px[(H / 2) * W + (W / 2)];
+}
+
+TEST_CASE(test_two_file_shader_reload)
+{
+	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL))) return true; // Headless CI: no display/GPU.
+
+	const char* base = cf_fs_get_base_directory();
+	cf_fs_set_write_directory(base);
+	cf_fs_create_directory("/shader_reload_test");
+
+	char fs_src[256];
+	snprintf(fs_src, sizeof(fs_src), s_fs_fmt, "1.0, 0.0, 0.0, 1.0"); // Red.
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_reload_test/t.vs", s_vs)));
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_reload_test/t.fs", fs_src)));
+
+	CF_Shader shader = cf_make_shader("/shader_reload_test/t.vs", "/shader_reload_test/t.fs");
+	REQUIRE(shader.id);
+
+	CF_Mesh mesh = s_make_fullscreen_quad();
+	CF_Material material = cf_make_material();
+	CF_Canvas canvas = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(W * H * (int)sizeof(CF_Pixel));
+
+	CF_Pixel before = s_render_probe(mesh, shader, material, canvas, px);
+	REQUIRE(before.colors.r > 200 && before.colors.g < 60);
+
+	// Rewrite the fragment file and reload through the same handle.
+	snprintf(fs_src, sizeof(fs_src), s_fs_fmt, "0.0, 1.0, 0.0, 1.0"); // Green.
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_reload_test/t.fs", fs_src)));
+
+	uint64_t id_before = shader.id;
+	REQUIRE(cf_shader_reload_from_files(&shader));
+	REQUIRE(shader.id == id_before); // Contents swap in place; the handle stays valid.
+
+	CF_Pixel after = s_render_probe(mesh, shader, material, canvas, px);
+	REQUIRE(after.colors.g > 200 && after.colors.r < 60);
+
+	// A shader that does not come from cf_make_shader cannot be reloaded this way.
+	CF_Shader from_source = cf_make_shader_from_source(s_vs, fs_src);
+	REQUIRE(from_source.id);
+	REQUIRE(!cf_shader_reload_from_files(&from_source));
+	cf_destroy_shader(from_source);
+
+	// A broken edit must leave the working shader alone rather than blanking the screen.
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_reload_test/t.fs", "this is not glsl\n")));
+	REQUIRE(!cf_shader_reload_from_files(&shader));
+	CF_Pixel after_bad = s_render_probe(mesh, shader, material, canvas, px);
+	REQUIRE(after_bad.colors.g > 200 && after_bad.colors.r < 60); // Still green.
+
+	cf_free(px);
+	cf_destroy_canvas(canvas);
+	cf_destroy_material(material);
+	cf_destroy_mesh(mesh);
+	cf_destroy_shader(shader);
+	cf_destroy_app();
+	return true;
+}
+
+// cf_make_shader used to CF_ASSERT on a missing file, which meant hot reload catching a file
+// mid-write took the app down instead of keeping the last good shader.
+TEST_CASE(test_make_shader_missing_file_is_not_fatal)
+{
+	if (cf_is_error(cf_make_app(NULL, 0, 0, 0, W, H, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL))) return true; // Headless CI: no display/GPU.
+
+	CF_Shader shader = cf_make_shader("/definitely_not_here.vs", "/definitely_not_here.fs");
+	REQUIRE(shader.id == 0);
+	REQUIRE(cf_shader_compile_error() != NULL); // And it says why.
+
+	cf_destroy_app();
+	return true;
+}
+
+TEST_SUITE(test_shader_reload)
+{
+	RUN_TEST_CASE(test_two_file_shader_reload);
+	RUN_TEST_CASE(test_make_shader_missing_file_is_not_fatal);
+}


### PR DESCRIPTION
Draw shaders and compute shaders already reload when their source changes. The two-file cf_make_shader path did not -- and that is the one kind a custom 3d vertex stage is forced to use, since draw shaders have no hook for the vertex stage. Anyone doing low-level rendering had to wire up destroy/recreate/swap by hand, including holding on to the old shader so a typo saved mid-edit did not blank the screen.

The reason it was left out is that cf_make_shader read its two files, used them, and dropped the paths on the floor; there was nothing to reload from. It now keeps them, and s_shader_auto_reload grows a third pass. Stored paths are full VFS paths while the watcher's key is relative to the shader directory, so the key is resolved through shader_file_infos and compared by interned pointer.

cf_make_shader also no longer asserts when a file is missing. Reload fires off filesystem timestamps and will catch a file mid-write; the entire safety contract of the reload path is that a failed rebuild leaves the old shader running, which an assert makes impossible. It now reports through cf_shader_compile_error like a compile failure and returns a null handle.

cf_shader_reload_from_files swaps the shader's guts in place rather than returning a new handle the way cf_shader_reload does for draw shaders, so copies already handed to a CF_Material keep working.

The test drives a real reload end to end -- render red, rewrite the fragment file, reload, render green -- and checks that a deliberately broken edit leaves the last good shader intact.