### PR TITLE
Guard polygon and segment helpers against degenerate input

### DIFF
--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -2645,6 +2645,7 @@ CF_INLINE CF_Raycast cf_ray_to_halfspace(CF_Ray A, CF_Halfspace B)
  * @param    b          The end point of a line segment.
  * @param    p          The query point.
  * @remarks  See [this article](https://randygaul.github.io/math/collision-detection/2014/07/01/Distance-Point-to-Line-Segment.html) for implementation details.
+ *           If `a == b` the segment is a point and the squared distance from `p` to `a` is returned.
  * @related  CF_V2 CF_Ray
  */
 CF_INLINE float cf_distance_sq(CF_V2 a, CF_V2 b, CF_V2 p)

--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -2535,6 +2535,7 @@ CF_INLINE int cf_collide_aabb(CF_Aabb a, CF_Aabb b) { return cf_overlaps(a, b); 
  */
 CF_INLINE CF_Aabb cf_make_aabb_verts(const CF_V2* verts, int count)
 {
+	if (count <= 0) return cf_make_aabb(cf_v2(0, 0), cf_v2(0, 0));
 	CF_V2 vmin = verts[0];
 	CF_V2 vmax = vmin;
 	for (int i = 0; i < count; ++i) {
@@ -2650,6 +2651,11 @@ CF_INLINE float cf_distance_sq(CF_V2 a, CF_V2 b, CF_V2 p)
 {
 	CF_V2 n = cf_sub(b, a);
 	CF_V2 pa = cf_sub(a, p);
+	float nn = cf_dot(n, n);
+
+	// Degenerate segment where a == b
+	if (nn == 0.0f) return cf_dot(pa, pa);
+
 	float c = cf_dot(n, pa);
 
 	// Closest point is a
@@ -2660,7 +2666,7 @@ CF_INLINE float cf_distance_sq(CF_V2 a, CF_V2 b, CF_V2 p)
 	if (cf_dot(n, bp) > 0.0f) return cf_dot(bp, bp);
 
 	// Closest point is between a and b
-	CF_V2 e = cf_sub(pa, cf_mul_v2_f(n, (c / cf_dot(n, n))));
+	CF_V2 e = cf_sub(pa, cf_mul_v2_f(n, (c / nn)));
 	return cf_dot(e, e);
 }
 

--- a/include/cute_math.h
+++ b/include/cute_math.h
@@ -2531,6 +2531,7 @@ CF_INLINE int cf_collide_aabb(CF_Aabb a, CF_Aabb b) { return cf_overlaps(a, b); 
  * @function cf_make_aabb_verts
  * @category math
  * @brief    Returns a `CF_Aabb` that tightly contains all input verts.
+ * @remarks  If `count <= 0` a zero'd out `CF_Aabb` is returned and `verts` is not read (it may be `NULL`).
  * @related  CF_Aabb cf_make_aabb_verts cf_aabb_verts
  */
 CF_INLINE CF_Aabb cf_make_aabb_verts(const CF_V2* verts, int count)

--- a/src/cute_math.cpp
+++ b/src/cute_math.cpp
@@ -30,6 +30,9 @@ using namespace Cute;
 
 CF_V2 cf_center_of_mass(CF_Poly poly)
 {
+	if (poly.count <= 0) return V2(0,0);
+	if (poly.count == 1) return poly.verts[0];
+	if (poly.count == 2) return (poly.verts[0] + poly.verts[1]) * 0.5f;
 	v2 p0 = poly.verts[0];
 	float area_sum = 0;
 	const float inv3 = 1.0f / 3.0f;
@@ -47,6 +50,13 @@ CF_V2 cf_center_of_mass(CF_Poly poly)
 		// Center of mass is the area-weighted centroid.
 		// Centroid is the average of all vertices.
 		center_of_mass += (p0 + p1 + p2) * (area_of_triangle * inv3);
+	}
+
+	// Degenerate (zero-area) polygon -- fall back to the vertex average.
+	if (area_sum == 0) {
+		v2 average = V2(0,0);
+		for (int i = 0; i < poly.count; ++i) average += poly.verts[i];
+		return average * (1.0f / poly.count);
 	}
 
 	center_of_mass *= 1.0f / area_sum;
@@ -162,6 +172,12 @@ CF_V2 cf_centroid(const CF_V2* cf_verts, int count)
 		float area = 0.5f * cf_cross(e1, e2);
 		area_sum += area;
 		c = c + (p1 + p2 + p3) * area * (1.0f/3.0f);
+	}
+	// Degenerate (zero-area) polygon -- fall back to the vertex average.
+	if (area_sum == 0) {
+		CF_V2 average = cf_v2(0, 0);
+		for (int i = 0; i < count; ++i) average = average + verts[i];
+		return average * (1.0f / count);
 	}
 	return c * (1.0f / area_sum) + p0;
 }

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -120,6 +120,51 @@ TEST_CASE(test_atan2_360_mixed_c) {
 	return true;
 }
 
+TEST_CASE(test_polygon_degenerate_c) {
+	/* Zero-area (collinear) polygon: results must be finite, falling back
+	   to the vertex average. */
+	CF_Poly line;
+	line.count = 3;
+	line.verts[0] = cf_v2(0, 0);
+	line.verts[1] = cf_v2(1, 0);
+	line.verts[2] = cf_v2(2, 0);
+	CF_V2 com = cf_center_of_mass(line);
+	REQUIRE(com.x == com.x && com.y == com.y); /* not NaN */
+	REQUIRE(cf_abs(com.x - 1.0f) < 1e-4f);
+
+	CF_V2 pts[3];
+	pts[0] = cf_v2(0, 0);
+	pts[1] = cf_v2(1, 0);
+	pts[2] = cf_v2(2, 0);
+	CF_V2 cen = cf_centroid(pts, 3);
+	REQUIRE(cen.x == cen.x && cen.y == cen.y); /* not NaN */
+	REQUIRE(cf_abs(cen.x - 1.0f) < 1e-4f);
+
+	/* count == 0 must not divide by zero (nor read verts[0]). */
+	CF_Poly empty;
+	empty.count = 0;
+	CF_V2 z = cf_center_of_mass(empty);
+	REQUIRE(z.x == 0.0f && z.y == 0.0f);
+
+	return true;
+}
+
+TEST_CASE(test_distance_sq_degenerate_c) {
+	/* Zero-length segment: squared distance to the point a == b. */
+	float d = cf_distance_sq(cf_v2(1, 1), cf_v2(1, 1), cf_v2(5, 5));
+	REQUIRE(d == d); /* not NaN */
+	REQUIRE(cf_abs(d - 32.0f) < 1e-4f);
+	return true;
+}
+
+TEST_CASE(test_make_aabb_verts_empty_c) {
+	/* count == 0 must not read verts[0]. */
+	CF_Aabb bb = cf_make_aabb_verts(NULL, 0);
+	REQUIRE(bb.min.x == 0.0f && bb.min.y == 0.0f);
+	REQUIRE(bb.max.x == 0.0f && bb.max.y == 0.0f);
+	return true;
+}
+
 TEST_SUITE(test_math_c) {
 	RUN_TEST_CASE(test_make_translation_v2_c);
 	RUN_TEST_CASE(test_make_translation_floats_c);
@@ -129,4 +174,7 @@ TEST_SUITE(test_math_c) {
 	RUN_TEST_CASE(test_atan2_360_v2_c);
 	RUN_TEST_CASE(test_atan2_360_sincos_c);
 	RUN_TEST_CASE(test_atan2_360_mixed_c);
+	RUN_TEST_CASE(test_polygon_degenerate_c);
+	RUN_TEST_CASE(test_distance_sq_degenerate_c);
+	RUN_TEST_CASE(test_make_aabb_verts_empty_c);
 }

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -146,6 +146,20 @@ TEST_CASE(test_polygon_degenerate_c) {
 	CF_V2 z = cf_center_of_mass(empty);
 	REQUIRE(z.x == 0.0f && z.y == 0.0f);
 
+	/* count == 1 and count == 2: the point and the segment midpoint. */
+	CF_Poly point;
+	point.count = 1;
+	point.verts[0] = cf_v2(3, 4);
+	CF_V2 one = cf_center_of_mass(point);
+	REQUIRE(one.x == 3.0f && one.y == 4.0f);
+
+	CF_Poly seg;
+	seg.count = 2;
+	seg.verts[0] = cf_v2(0, 0);
+	seg.verts[1] = cf_v2(2, 6);
+	CF_V2 mid = cf_center_of_mass(seg);
+	REQUIRE(mid.x == 1.0f && mid.y == 3.0f);
+
 	return true;
 }
 


### PR DESCRIPTION
Degenerate inputs — zero-area polygons from collinear points, empty vertex lists, zero-length segments — made these helpers return NaN or read out of bounds, and the NaN then propagates silently into transforms and culling. `cf_center_of_mass` read `verts[0]` unguarded and divided by a zero area sum; `cf_centroid` guarded counts 0/1/2 but not the collinear case; `cf_distance_sq` divided 0/0 when a == b; `cf_make_aabb_verts` read `verts[0]` before checking count. All now return finite fallbacks (vertex average, distance-to-point, zero AABB). No behavior change for valid input — the guards are exact-condition early-outs that only trigger where the old code produced NaN/inf or an OOB read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUK7V6S9X2oevn3ysgYHBk