### PR TITLE
Fix/ckit_hash

### DIFF
--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -178,7 +178,7 @@ using remove_reference = cf_remove_reference<T>;
 // Not sure where to put this... Here is good I guess.
 CF_INLINE uint64_t cf_fnv1a(const void* data, int size)
 {
-	const char* s = (const char*)data;
+	const unsigned char* s = (const unsigned char*)data;
 	uint64_t h = 14695981039346656037ULL;
 	while (size--) {
 		h = h ^ (uint64_t)(*s++);

--- a/libraries/cute/ckit.h
+++ b/libraries/cute/ckit.h
@@ -1766,11 +1766,10 @@ void ck_map_clear_impl(CK_MapHeader* hdr)
 uint64_t ck_hash_fnv1a(const void* ptr, size_t sz)
 {
 	uint64_t x = 0xcbf29ce484222325ull;
-	const char* buf = (const char*)ptr;
+	const unsigned char* buf = (const unsigned char*)ptr;
 	for (size_t i = 0; i < sz; i++) {
-		x ^= (uint64_t)(unsigned char)buf[i];
+		x ^= (uint64_t)buf[i];
 		x *= 0x100000001b3ull;
-		x ^= x >> 32;
 	}
 	return x;
 }

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -76,6 +76,8 @@ TEST_CASE(test_array_hash)
 	REQUIRE(cf_array_hash(e) == cf_fnv1a(f, sizeof(f)));
 
 	cf_array_free(e);
+
+	return true;
 }
 
 TEST_SUITE(test_array)

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -53,12 +53,17 @@ TEST_CASE(test_array_list_init)
 	REQUIRE(!CF_STRCMP(d[1].c_str(), "b"));
 	REQUIRE(!CF_STRCMP(d[2].c_str(), "c"));
 
-	Array<int> e = {
-		1,
-		2,
-		3,
-		4
-	};
+	return true;
+}
+
+TEST_CASE(test_array_hash)
+{
+	CF_ARRAY(int) e = NULL;
+	cf_array_push(e, 1);
+	cf_array_push(e, 2);
+	cf_array_push(e, 3);
+	cf_array_push(e, 4);
+		
 	int f[] = {
 		1,
 		2,
@@ -66,13 +71,15 @@ TEST_CASE(test_array_list_init)
 		4
 	};
 
-	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * e.count()));
-	REQUIRE(cf_array_hash(e) == cf_fnv1a(f, sizeof(f));
+	// Verify that both ck_hash_fnv1a matches cf_fnv1a.
+	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * cf_array_count(e)));
+	REQUIRE(cf_array_hash(e) == cf_fnv1a(f, sizeof(f)));
 
-	return true;
+	cf_array_free(e);
 }
 
 TEST_SUITE(test_array)
 {
 	RUN_TEST_CASE(test_array_list_init);
+	RUN_TEST_CASE(test_array_hash);
 }

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -53,6 +53,15 @@ TEST_CASE(test_array_list_init)
 	REQUIRE(!CF_STRCMP(d[1].c_str(), "b"));
 	REQUIRE(!CF_STRCMP(d[2].c_str(), "c"));
 
+	Array<int> e = {
+		1,
+		2,
+		3,
+		4
+	};
+
+	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * e.count());
+
 	return true;
 }
 

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -59,8 +59,15 @@ TEST_CASE(test_array_list_init)
 		3,
 		4
 	};
+	int f[] = {
+		1,
+		2,
+		3,
+		4
+	};
 
 	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * e.count()));
+	REQUIRE(cf_array_hash(e) == cf_fnv1a(f, sizeof(f));
 
 	return true;
 }

--- a/test/test_array.cpp
+++ b/test/test_array.cpp
@@ -60,7 +60,7 @@ TEST_CASE(test_array_list_init)
 		4
 	};
 
-	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * e.count());
+	REQUIRE(cf_array_hash(e) == cf_fnv1a(e, sizeof(*e) * e.count()));
 
 	return true;
 }


### PR DESCRIPTION
Removed ck_hash_fnv1a right shift since it's not part of the algorithm (https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) so both ckit and CF both has the same hash result.