### PR TITLE
3D shippability shore-up: D3D12 depth-cube warning, cm_interleave, Shipping 3D docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 4.2)
 project(cute_framework
-	DESCRIPTION "The cutest framework out there for creating 2D games in C++!"
+	DESCRIPTION "The cutest framework out there for creating 2D and 3D games in C++!"
 	HOMEPAGE_URL "https://github.com/RandyGaul/cute_framework"
 	LANGUAGES C CXX
 	VERSION 1.1.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <img alt="Discord" src="https://img.shields.io/discord/432009046833233930?label=discord">
 </p>
 
-[Cute Framework](https://randygaul.github.io/cute_framework/) (CF) is the *cutest* framework available for making 2D games in C++. It provides a portable foundational layer for building 2D games in C/C++ without baggage, gnarly dependencies, or cryptic APIs. CF runs almost anywhere, including Windows, MacOS, iOS, Android, Linux, Browsers, and more!
+[Cute Framework](https://randygaul.github.io/cute_framework/) (CF) is the *cutest* framework available for making 2D and 3D games in C++. It provides a portable foundational layer for building games in C/C++ without baggage, gnarly dependencies, or cryptic APIs. CF runs almost anywhere, including Windows, MacOS, iOS, Android, Linux, Browsers, and more!
 
 <p align="center"><img src="assets/block_man.gif"></p>
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,4 @@
-Cute Framework (CF for short) is the *cutest* framework available for making 2D games in C++. CF provides a portable foundational layer for building 2D games in C/C++ without baggage, gnarly dependencies, or cryptic APIs. CF runs almost anywhere, including Windows, MacOS, iOS, Android, Linux, and more!
+Cute Framework (CF for short) is the *cutest* framework available for making 2D and 3D games in C++. CF provides a portable foundational layer for building games in C/C++ without baggage, gnarly dependencies, or cryptic APIs. CF runs almost anywhere, including Windows, MacOS, iOS, Android, Linux, and more!
 
 > [!NOTE]
 > Cute Framework documentation covers the C API, however, the vast majority of CF also has associated C++ wrapper APIs that sit along-side the C API in each header.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@
   ![Cute Framework Logo](assets/CF_Logo_Hifi.svg){ width="256" }
 </figure>
 
-> The _cutest_ framework available for making 2D games in C/C++
+> The _cutest_ framework available for making 2D and 3D games in C/C++
 
-- Foundational layer for almost any 2D game
+- Foundational layer for almost any 2D or 3D game
 - 100% free and open source
 - Works nearly everwhere (Desktops, Mobile, Web, and more...)
 

--- a/docs/topics/drawing_3d.md
+++ b/docs/topics/drawing_3d.md
@@ -209,3 +209,7 @@ Each common 3D need has a sample showing the pattern, because each one is a patt
 ## Below This Layer
 
 The draw3d layer sits on the same [low level graphics API](low_level_graphics.md) everything else uses, and that layer grew the full 3D access inventory alongside it: multiple render targets with [per-target blend states](low_level_graphics.md#multiple-render-targets), cube/3D/array textures with per-layer and per-mip upload, depth-texture sampling and comparison samplers (`sampler2DShadow`), rendering into individual cube faces, array layers, or mip levels (`CF_CanvasParams.attach_target` / `attach_layer` / `attach_mip`), [storage buffers](low_level_graphics.md#storage-buffers-and-pull-instancing) for skinning palettes and GPU-driven data, [indirect draws](low_level_graphics.md#indirect-draws) fed by compute, standalone [samplers](low_level_graphics.md#standalone-samplers), and sized `vec4`/`mat4` arrays in uniform blocks. When the draw3d layer doesn't fit, drop down -- both layers speak the same meshes, shaders, materials, and canvases.
+
+## Toward a Release
+
+Headed for shipping? [Shipping 3D](shipping_3d.md) consolidates every per-backend caveat and pre-flight recipe -- compressed textures with mips, draw-list frustum culling, the web tier's capability list, the anti-aliasing options -- into one checklist.

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -31,6 +31,7 @@ After completing the above fundamental reading it's recommended to then select t
 * [Random Numbers](./random_numbers.md)
 * [A Tour of CF's Renderer](./renderer.md)
 * [Shader Compilation](./shader_compilation.md)
+* [Shipping 3D](./shipping_3d.md)
 * [Strings](./strings.md)
 * [Virtual File System](./virtual_file_system.md)
 * [HTTPS](./web.md)

--- a/docs/topics/shipping_3d.md
+++ b/docs/topics/shipping_3d.md
@@ -1,0 +1,108 @@
+# Shipping 3D
+
+Everything on this page is documented somewhere -- a header remark here, a sample comment there. This page is the consolidation: every per-backend caveat and pre-release recipe in one place, so each one costs you a checklist line instead of a debugging session. Read [3D Drawing](drawing_3d.md) first; this page assumes you're past "it renders" and headed for "it ships."
+
+## The Backend Caveat Checklist
+
+CF renders through SDL_GPU (Vulkan, Metal, D3D12, D3D11) plus its own GLES3 backend for web. The API is one surface, but the floors differ. `cf_query_backend()` tells you where you landed at runtime.
+
+### Windows (D3D12 -- SDL_GPU's default driver there)
+
+- **Depth cube faces don't render.** SDL_GPU's D3D12 driver creates only 2D depth views, so rendering into one face of a depth-format cube texture silently produces nothing. CF prints a loud warning when such a canvas is created. Use one of the portable patterns instead: six 2D depth canvases, a 2D depth atlas, or a color-encoded distance cube -- the `point_light` sample ships the last of these and it works on every backend.
+- D3D11 is available behind `CF_APP_OPTIONS_GFX_D3D11_BIT` but is legacy-support only; don't target it fresh.
+
+### macOS / iOS (Metal)
+
+- No D24S8 depth format. `cf_canvas_defaults` negotiates to D32 float + S8 automatically -- only relevant if you construct depth `CF_TextureParams` by hand.
+
+### Web (GLES3 / WebGL2)
+
+The web tier trades capability for reach. If browsers are a release target, design these out from day one rather than discovering them at port time:
+
+| Missing on web | Ship instead |
+| --- | --- |
+| Compute shaders, compute-writable storage buffers | CPU-side preparation, or gate the feature per backend |
+| Indirect draws (hard assert) | Ordinary submissions; baked draw lists cover most GPU-driven wins |
+| MSAA (none at all) | Post AA -- see the anti-aliasing stance below |
+| BCn compressed textures | PNG/JPG fallbacks -- see the texture recipe below |
+| Per-target blend states | `blends[0]` applies to all MRT targets |
+| Depth clamp (`enable_depth_clip` ignored) | Pull the shadow near plane back instead |
+| GPU debug labels | No-ops; harmless to leave in |
+| Async readback | Same API, but it stalls the pipeline -- keep it out of the frame loop |
+
+Read-only storage buffers *do* work on web -- emulated through texture fetches, transparently -- limited to 4 per stage, each an anonymous block with a single runtime `vec4[]` tail. The storage-buffer skinning pattern ships on web unchanged (`model3d --gles` exercises exactly this).
+
+### Everywhere
+
+- **MSAA and MRT are mutually exclusive** -- a multi-target canvas requires `CF_SAMPLE_COUNT_1`.
+- **MSAA targets can't be sampled directly.** The resolve happens automatically at pass end; `cf_canvas_get_target` hands you the resolved texture, which is the one you sample.
+- **No wireframe fill mode.** Rasterizer fill is always solid. Debug wireframes are what the 3D stroke shapes are for (`cf_draw3d_box_wire` and friends -- anti-aliased, batched, no state to manage), or build a `CF_PRIMITIVE_TYPE_LINELIST` mesh.
+- **Front faces wind counter-clockwise, not configurable.** Imported meshes wound clockwise need their index order flipped at import (or `CF_CULL_MODE_FRONT` as a blunt instrument).
+- **No base-vertex in range draws.** `cf_draw3d_mesh_range` / `cf_draw_elements_range` take absolute indices -- geometry arenas write their indices absolute into the shared buffer. This is what keeps ranges portable to web.
+- **Sampling a depth texture needs one of two things:** `compare_enable` on its `CF_TextureParams` (hardware-compare shadow sampling via `sampler2DShadow`), or a standalone `CF_Sampler` bound alongside it (raw depth reads, e.g. PCSS blocker search). A depth texture with neither gets no sampler at all.
+- **A canvas depth target isn't sampleable by default.** `cf_canvas_defaults` gives the depth attachment `DEPTH_STENCIL_TARGET_BIT` only -- OR in `CF_TEXTURE_USAGE_SAMPLER_BIT` yourself before sampling it in a later pass (the `draw3d` sample's shadow canvas shows the full setup).
+- **No GPU timing.** SDL_GPU exposes no timestamp or occlusion queries yet, so neither does CF. Profile with `cf_push_gpu_label`/`cf_pop_gpu_label` regions under RenderDoc, Nsight, or PIX; watch batching with `cf_draw3d_stats`; and use `cf_gpu_sync` for coarse CPU-side bracketing when desperate.
+
+## The Anti-Aliasing Stance
+
+CF takes no AA position for you, but the pieces line up like this:
+
+- **3D strokes self-anti-alias.** The signed-distance ribbon shader gives smooth edges at any zoom with no MSAA involved -- debug and stylized line work is covered for free.
+- **MSAA covers desktop forward rendering** -- single target, `sample_count` on the canvas, automatic resolve. It stops at the MRT boundary and doesn't exist on web.
+- **Everything else is post AA in user shaders.** FXAA is an afternoon; TAA is a weekend plus motion vectors (`cf_draw3d_set_uniform_m4` with last frame's view-projection is the input it needs). Deferred pipelines and web builds end up here, which is the same place most shipped engines ended up.
+
+## Recipe: Shipping Textures
+
+The `model3d` sample decodes PNGs at load and samples them mipless, which is honest for a sample and wrong for a shipping game -- unmipped textures shimmer at 3D viewing distances and burn bandwidth.
+
+**Native targets: convert offline to DDS.** glTF embeds PNG/JPEG; a shipping build converts those to block-compressed DDS in the asset pipeline (BC7 for color, BC5 for normal maps, BC4 for single-channel masks -- any standard tool: NVTT, Compressonator, ktx/toktx piped through DDS). Then:
+
+```cpp
+CF_Texture tex = cf_make_texture_from_dds("/assets/fox_albedo.dds");
+```
+
+One call uploads the compressed pixels and the full mip chain exactly as authored -- no decode, no runtime mip generation. Use the sRGB BC variants for color textures and linear for data textures, and `cf_texture_supports_format` if you want to probe before committing.
+
+**Web fallback: keep the PNGs, generate mips.** There's no BC on WebGL2, so ship the originals there -- but never mipless:
+
+```cpp
+CF_TextureParams tp = cf_texture_defaults(w, h);
+tp.allocate_mipmaps = true;   // mip_count 0 = full chain
+tp.filter = CF_FILTER_LINEAR;
+CF_Texture tex = cf_make_texture(tp);
+cf_texture_update(tex, pixels, size);
+cf_generate_mipmaps(tex);
+```
+
+Anisotropic filtering (`max_anisotropy` on `CF_TextureParams`) is the difference between smeared and readable ground textures at grazing angles; it's cheap on everything modern.
+
+## Recipe: Culling Baked Draw Lists
+
+A baked `CF_DrawList` replays as one instanced draw -- which also makes it all-or-nothing: there is no per-instance culling inside a bake. The pattern is to make the *list* the culling granularity:
+
+```cpp
+// At load: record one list per spatial chunk, each with its bounds.
+struct Chunk { CF_DrawList list; CF_Aabb3 bounds; };
+
+// Per frame: extract the frustum once, replay only what it sees.
+CF_M4x4 view_projection = cf_mul(projection, view);
+CF_Frustum frustum = cf_frustum_from_m4(view_projection);
+for (int i = 0; i < chunk_count; ++i) {
+	if (cf_frustum_test_aabb3(frustum, chunks[i].bounds)) {
+		cf_draw_list(chunks[i].list);
+	}
+}
+```
+
+Chunks of a few hundred to a few thousand instances keep the draw count trivial while letting the frustum do real work -- the `fireflies` sample culls its forest chunks with exactly this pair. Size chunks so a typical view rejects most of them; a single worldwide list rejects nothing.
+
+When frustum granularity isn't enough -- dense cities, per-instance occlusion -- the escape hatch composes: meshes with their own instance buffers, a compute pass that culls into a storage buffer, and `cf_draw_elements_indirect` consuming the result, all with zero readback. SDL_GPU backends only; on web, chunked lists are the answer.
+
+## Pre-Flight, Compressed
+
+- [ ] Windows/D3D12 run tested -- especially anything shadow-cube shaped
+- [ ] Web build tested early if browsers are a target (compute/indirect/MSAA/BC gaps designed out, not ported out)
+- [ ] Textures block-compressed with mips on native; mipped PNG fallback on web; anisotropy on
+- [ ] MSAA only on single-target canvases, or post AA
+- [ ] Draw lists chunked for frustum culling
+- [ ] `cf_draw3d_stats` near zero avoidable splits; `cf_push_gpu_label` regions in place for GPU captures

--- a/libraries/cute/cute_model.h
+++ b/libraries/cute/cute_model.h
@@ -27,6 +27,8 @@
 		hierarchy with rest-pose transforms, skins with inverse-bind matrices,
 		keyframe animation clips, and embedded images -- everything needed to feed
 		a GPU skinning pipeline, with zero opinions about how you render.
+		cm_interleave packs the separate streams into your vertex struct, ready
+		for one GPU vertex-buffer upload.
 
 		The runtime half samples clips and composes matrix palettes:
 
@@ -352,6 +354,44 @@ void cm_blend(const CM_Model* model, const CM_Transform* a, const CM_Transform* 
 // the animation has no weights channel for the node, so prefill with the mesh's default
 // weights (CM_Mesh::weights) or zeros. Apply as: vertex += sum(weights[i] * delta[i]).
 void cm_animate_weights(const CM_Model* model, const CM_Animation* animation, float time, int node, float* weights, int weight_count);
+
+//--------------------------------------------------------------------------------------------------
+// Interleaving. The loader hands back separate tightly-packed streams; GPUs want one
+// interleaved vertex buffer. This is that glue -- declare your vertex struct, list which
+// stream lands at which byte offset, and get ready-to-upload vertices (pair each entry
+// with a matching CF_VertexAttribute when feeding Cute Framework's cf_make_mesh).
+
+// Which loader stream a CM_VertexAttribute copies, and the bytes it writes per vertex:
+//   POSITION  3 floats            (never missing)
+//   NORMAL    3 floats            (never missing; generated smooth when the file has none)
+//   TANGENT   4 floats, xyz + w handedness; (1,0,0,1) when missing
+//   UV, UV1   2 floats; (0,0) when missing
+//   COLOR     4 floats; opaque white when missing
+//   JOINTS    4 uint16_t; all zero when missing (matches WEIGHTS' rigid default)
+//   WEIGHTS   4 floats; (1,0,0,0) when missing, so unskinned vertices follow bone 0
+typedef enum CM_Stream
+{
+	CM_STREAM_POSITION,
+	CM_STREAM_NORMAL,
+	CM_STREAM_TANGENT,
+	CM_STREAM_UV,
+	CM_STREAM_UV1,
+	CM_STREAM_COLOR,
+	CM_STREAM_JOINTS,
+	CM_STREAM_WEIGHTS,
+} CM_Stream;
+
+typedef struct CM_VertexAttribute
+{
+	CM_Stream stream; // Which loader stream to copy.
+	int offset;       // Byte offset of this attribute within one output vertex.
+} CM_VertexAttribute;
+
+// Interleaves a primitive's streams into caller-allocated `out`, which must hold
+// prim->vertex_count * stride bytes. Streams the primitive lacks write the defaults
+// listed on CM_Stream, so one attribute list serves skinned and unskinned meshes alike.
+// Keep the loader's indices (CM_Primitive::indices) for the index buffer.
+void cm_interleave(const CM_Primitive* prim, const CM_VertexAttribute* attributes, int attribute_count, int stride, void* out);
 
 #endif // CUTE_MODEL_H
 
@@ -1855,6 +1895,43 @@ void cm_skin_palette(const CM_Model* model, int skin_index, const float* world, 
 	const CM_Skin* skin = model->skins + skin_index;
 	for (int i = 0; i < skin->joint_count; ++i) {
 		cm_mat4_mul(world + (size_t)skin->joints[i] * 16, skin->inverse_binds + (size_t)i * 16, palette + (size_t)i * 16);
+	}
+}
+
+void cm_interleave(const CM_Primitive* prim, const CM_VertexAttribute* attributes, int attribute_count, int stride, void* out)
+{
+	static const float cm_default_tangent[4] = { 1, 0, 0, 1 };
+	static const float cm_default_uv[2] = { 0, 0 };
+	static const float cm_default_color[4] = { 1, 1, 1, 1 };
+	static const uint16_t cm_default_joints[4] = { 0, 0, 0, 0 };
+	static const float cm_default_weights[4] = { 1, 0, 0, 0 };
+	for (int v = 0; v < prim->vertex_count; ++v) {
+		char* vert = (char*)out + (size_t)v * (size_t)stride;
+		for (int a = 0; a < attribute_count; ++a) {
+			void* dst = vert + attributes[a].offset;
+			switch (attributes[a].stream) {
+			case CM_STREAM_POSITION: memcpy(dst, prim->positions + (size_t)v * 3, sizeof(float) * 3); break;
+			case CM_STREAM_NORMAL:   memcpy(dst, prim->normals + (size_t)v * 3, sizeof(float) * 3); break;
+			case CM_STREAM_TANGENT:
+				memcpy(dst, prim->tangents ? prim->tangents + (size_t)v * 4 : cm_default_tangent, sizeof(float) * 4);
+				break;
+			case CM_STREAM_UV:
+				memcpy(dst, prim->uvs ? prim->uvs + (size_t)v * 2 : cm_default_uv, sizeof(float) * 2);
+				break;
+			case CM_STREAM_UV1:
+				memcpy(dst, prim->uvs1 ? prim->uvs1 + (size_t)v * 2 : cm_default_uv, sizeof(float) * 2);
+				break;
+			case CM_STREAM_COLOR:
+				memcpy(dst, prim->colors ? prim->colors + (size_t)v * 4 : cm_default_color, sizeof(float) * 4);
+				break;
+			case CM_STREAM_JOINTS:
+				memcpy(dst, prim->joints ? prim->joints + (size_t)v * 4 : cm_default_joints, sizeof(uint16_t) * 4);
+				break;
+			case CM_STREAM_WEIGHTS:
+				memcpy(dst, prim->weights ? prim->weights + (size_t)v * 4 : cm_default_weights, sizeof(float) * 4);
+				break;
+			}
+		}
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: Cute Framework
 site_url: https://RandyGaul.github.io/cute_framework/
 site_author: Randy Gaul
 site_description: >-
-  The cutest framework available for making 2D games in C/C++
+  The cutest framework available for making 2D and 3D games in C/C++
 
 # Repository information
 repo_url: https://github.com/RandyGaul/cute_framework
@@ -98,6 +98,7 @@ nav:
       - File I/O: topics/file_io.md
       - Drawing: topics/drawing.md
       - 3D Drawing: topics/drawing_3d.md
+      - Shipping 3D: topics/shipping_3d.md
       - Debug/Tools UI: topics/dear_imgui.md
       - Allocators: topics/allocator.md
       - Android Builds: topics/android.md

--- a/samples/model3d.c
+++ b/samples/model3d.c
@@ -97,24 +97,23 @@ static const char* s_fs =
 "    result = vec4(albedo * (0.28 + 0.22 * hemi + 0.6 * key), 1.0);\n"
 "}\n";
 
-// Interleaves the loader's separate streams into one indexed draw3d mesh. The loader hands
-// over ready-to-use u32 indices, so keep them: vertex_count interleaved vertices instead of
+// Interleaves the loader's separate streams into one indexed draw3d mesh via cm_interleave:
+// one CM_VertexAttribute per CF_VertexAttribute, same offsets. The loader hands over
+// ready-to-use u32 indices, so keep them: vertex_count interleaved vertices instead of
 // index_count de-indexed ones (3-4x less vertex memory on typical meshes), and joints ride
 // as USHORT4 into a uvec4 shader input with no widening.
 static CF_Mesh s_make_mesh(const CM_Primitive* prim, int* out_count)
 {
 	int n = prim->vertex_count;
 	Vertex* verts = (Vertex*)cf_alloc(sizeof(Vertex) * (size_t)n);
-	for (int v = 0; v < n; ++v) {
-		Vertex* out = verts + v;
-		out->pos = cf_v3(prim->positions[v * 3], prim->positions[v * 3 + 1], prim->positions[v * 3 + 2]);
-		out->n = cf_v3(prim->normals[v * 3], prim->normals[v * 3 + 1], prim->normals[v * 3 + 2]);
-		out->uv = prim->uvs ? cf_v2(prim->uvs[v * 2], prim->uvs[v * 2 + 1]) : cf_v2(0, 0);
-		for (int k = 0; k < 4; ++k) {
-			out->joints[k] = prim->joints ? prim->joints[v * 4 + k] : 0;
-			out->weights[k] = prim->weights ? prim->weights[v * 4 + k] : (k == 0 ? 1.0f : 0.0f);
-		}
-	}
+	CM_VertexAttribute streams[5] = {
+		{ CM_STREAM_POSITION, CF_OFFSET_OF(Vertex, pos) },
+		{ CM_STREAM_NORMAL,   CF_OFFSET_OF(Vertex, n) },
+		{ CM_STREAM_UV,       CF_OFFSET_OF(Vertex, uv) },
+		{ CM_STREAM_JOINTS,   CF_OFFSET_OF(Vertex, joints) },
+		{ CM_STREAM_WEIGHTS,  CF_OFFSET_OF(Vertex, weights) },
+	};
+	cm_interleave(prim, streams, 5, (int)sizeof(Vertex), verts);
 	CF_VertexAttribute attrs[5] = { 0 };
 	attrs[0].name = "in_pos";     attrs[0].format = CF_VERTEX_FORMAT_FLOAT3;  attrs[0].offset = CF_OFFSET_OF(Vertex, pos);
 	attrs[1].name = "in_normal";  attrs[1].format = CF_VERTEX_FORMAT_FLOAT3;  attrs[1].offset = CF_OFFSET_OF(Vertex, n);

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -1347,6 +1347,15 @@ CF_Canvas cf_sdlgpu_make_canvas(CF_CanvasParams params)
 			// A depth-format attach becomes the canvas's DEPTH target: a depth-only pass with
 			// no color side at all -- the shadow-cube case (render each face of a depth cube,
 			// then sample it with samplerCubeShadow).
+			if (attach->type == CF_TEXTURE_TYPE_CUBE && s_query_backend() == CF_BACKEND_TYPE_D3D12) {
+				// SDL_GPU's D3D12 driver creates only 2D depth views, so these passes silently
+				// render nothing there -- and D3D12 is SDL_GPU's default driver on Windows.
+				fprintf(stderr,
+					"WARNING -- Rendering into a depth CUBE face is not supported on SDL_GPU's D3D12 driver;\n"
+					"           this pass will silently produce nothing. Use six 2D depth canvases (or a 2D\n"
+					"           depth atlas) instead of a depth cube, or run on Vulkan/Metal/GLES. See the\n"
+					"           `attach_target` docs in cute_graphics.h and the Shipping 3D topic page.\n");
+			}
 			canvas->attached = true; // Owns nothing: color side absent, depth side borrowed.
 			canvas->attached_depth = true;
 			canvas->attach_layer = params.attach_layer;

--- a/test/test_model.cpp
+++ b/test/test_model.cpp
@@ -265,6 +265,56 @@ TEST_CASE(test_model_gltf_external)
 	return true;
 }
 
+// cm_interleave: real streams land at their offsets, missing streams (this quad has no
+// joints/weights) write their documented defaults, so one attribute list serves skinned
+// and unskinned meshes alike.
+TEST_CASE(test_model_interleave)
+{
+	CM_LoadParams params = { 0 };
+	params.read_fn = s_read;
+	CM_Model* model = cm_load_ex(s_gltf, (int)CF_STRLEN(s_gltf), params);
+	REQUIRE(model);
+	CM_Primitive* prim = model->meshes[0].primitives;
+
+	typedef struct Vertex
+	{
+		float pos[3];
+		float n[3];
+		float t[4];
+		float uv[2];
+		float color[4];
+		uint16_t joints[4];
+		float weights[4];
+	} Vertex;
+	CM_VertexAttribute streams[7] = {
+		{ CM_STREAM_POSITION, CF_OFFSET_OF(Vertex, pos) },
+		{ CM_STREAM_NORMAL,   CF_OFFSET_OF(Vertex, n) },
+		{ CM_STREAM_TANGENT,  CF_OFFSET_OF(Vertex, t) },
+		{ CM_STREAM_UV,       CF_OFFSET_OF(Vertex, uv) },
+		{ CM_STREAM_COLOR,    CF_OFFSET_OF(Vertex, color) },
+		{ CM_STREAM_JOINTS,   CF_OFFSET_OF(Vertex, joints) },
+		{ CM_STREAM_WEIGHTS,  CF_OFFSET_OF(Vertex, weights) },
+	};
+	Vertex verts[4];
+	cm_interleave(prim, streams, 7, (int)sizeof(Vertex), verts);
+
+	// Vertex 1 of the unit quad: position (1,0,0), uv (1,0), COLOR_0 green.
+	REQUIRE(verts[1].pos[0] == 1.0f && verts[1].pos[1] == 0 && verts[1].pos[2] == 0);
+	REQUIRE(cf_abs(verts[1].uv[0] - 1.0f) < 0.001f && cf_abs(verts[1].uv[1]) < 0.001f);
+	REQUIRE(verts[1].color[0] < 0.01f && cf_abs(verts[1].color[1] - 1.0f) < 0.01f);
+
+	// Generated streams interleave like authored ones: +z normal, +x tangent.
+	REQUIRE(cf_abs(verts[0].n[2] - 1.0f) < 0.001f);
+	REQUIRE(cf_abs(verts[0].t[0] - 1.0f) < 0.001f && cf_abs(verts[0].t[3] - 1.0f) < 0.001f);
+
+	// Missing joints/weights write the rigid defaults: all bone 0, weights (1,0,0,0).
+	REQUIRE(verts[2].joints[0] == 0 && verts[2].joints[3] == 0);
+	REQUIRE(verts[2].weights[0] == 1.0f && verts[2].weights[1] == 0);
+
+	cm_free(model);
+	return true;
+}
+
 // Hostile-input regressions, all found by tools/cute_model_fuzz.c. Every case here
 // crashed or read out of bounds before the hardening pass; they must now be rejected
 // cleanly (NULL + an error string), never accepted with a dangling index.
@@ -337,5 +387,6 @@ TEST_CASE(test_model_malformed_rejected)
 TEST_SUITE(test_model)
 {
 	RUN_TEST_CASE(test_model_gltf_external);
+	RUN_TEST_CASE(test_model_interleave);
 	RUN_TEST_CASE(test_model_malformed_rejected);
 }


### PR DESCRIPTION
Follow-up to the 3D API shippability review. Three pieces:

**D3D12 depth-cube guard** -- SDL_GPU's D3D12 driver creates only 2D depth views, so rendering into a depth cube face silently produces nothing, and D3D12 is the default driver on Windows. Canvas creation now prints a loud warning pointing at the portable patterns (six 2D depth canvases, a depth atlas, or the `point_light` sample's color-encoded distance cube).

**`cm_interleave`** -- the streams-to-vertex-buffer glue everyone was hand-rolling. One `CM_VertexAttribute { stream, offset }` per output attribute, documented defaults for missing streams (rigid-skinning weights, opaque white color, identity-ish tangent) so one attribute list serves skinned and unskinned meshes. `model3d` now uses it; `test_model_interleave` pins real, generated, and defaulted streams.

**Shipping 3D docs page** -- consolidates every per-backend caveat (D3D12 depth cubes, the web tier's capability list, MSAA/MRT exclusivity, depth-sampling requirements, no GPU timing) and the pre-flight recipes: BCn textures with mips via DDS + mipped-PNG web fallback, chunked draw-list frustum culling, and the AA stance. Wired into the nav and linked from 3D Drawing. Also updates the 2D-only positioning in the README, docs front page, getting started, mkdocs description, and CMake description to '2D and 3D'.

Verified: `test_model` (3/3, incl. new case) and `test_draw3d` (22/22) pass; `model3d` renders correctly through the new interleave path (screenshot harness).