### PR TITLE
Fix unresolved doc references in the 3d headers

### DIFF
--- a/docs/topics/low_level_graphics.md
+++ b/docs/topics/low_level_graphics.md
@@ -248,7 +248,7 @@ cf_dispatch_compute(compute_shader, material, dispatch);
 
 ## Storage Buffers and Pull Instancing
 
-[`CF_StorageBuffer`](../graphics/cf_storagebuffer.md) is raw GPU memory for data too large or too dynamic for uniforms: skinning palettes, particle pools, anything a compute shader writes. Create one with `cf_make_storage_buffer` (`cf_storage_buffer_defaults(size)` marks it `graphics_readable`), fill it with `cf_update_storage_buffer`, and bind after `cf_apply_shader`:
+[`CF_StorageBuffer`](../graphics/struct/cf_storagebuffer.md) is raw GPU memory for data too large or too dynamic for uniforms: skinning palettes, particle pools, anything a compute shader writes. Create one with `cf_make_storage_buffer` (`cf_storage_buffer_defaults(size)` marks it `graphics_readable`), fill it with `cf_update_storage_buffer`, and bind after `cf_apply_shader`:
 
 ```c
 cf_apply_shader(shader, material);
@@ -277,7 +277,7 @@ On GLES3/web, read-only storage buffers are emulated through texture fetches tra
 
 ## Standalone Samplers
 
-Textures bake their filter/wrap state at creation, which is the right default. When the same texture needs to be sampled two ways -- pixel-art NEAREST in world, LINEAR in a scaled UI, or a shadow map with and without hardware comparison -- make a [`CF_Sampler`](../graphics/cf_sampler.md) and bind the pair:
+Textures bake their filter/wrap state at creation, which is the right default. When the same texture needs to be sampled two ways -- pixel-art NEAREST in world, LINEAR in a scaled UI, or a shadow map with and without hardware comparison -- make a [`CF_Sampler`](../graphics/struct/cf_sampler.md) and bind the pair:
 
 ```c
 CF_SamplerParams sp = cf_sampler_defaults();

--- a/docs/topics/multithreading.md
+++ b/docs/topics/multithreading.md
@@ -74,7 +74,7 @@ A common use of semaphores is to implement a thread pool (see below). CF actuall
 
 ## Thread Pool
 
-The thread pool is a great tool for games. For a CPU with N cores the thread pool is initialized with N-1 threads (N-1 to account for the main thread as well). The threads are initially asleep. The thread pool can then be loaded up with _tasks_ (each represented by a function pointer and `void*` pair [`CF_TaskFn`])(../multithreading/cf_taskfn.md)).
+The thread pool is a great tool for games. For a CPU with N cores the thread pool is initialized with N-1 threads (N-1 to account for the main thread as well). The threads are initially asleep. The thread pool can then be loaded up with _tasks_ (each represented by a function pointer and `void*` pair [`CF_TaskFn`](../multithreading/function/cf_taskfn.md)).
 
 After loading up the threadpool with tasks they can be kicked off. Once kicked, threads will wake and grab tasks from the pool and perform them until all tasks are complete, and the threads go back to sleep. The pool can be kicked off in two styles: _blocking_ and _non-blocking_.
 

--- a/include/cute_draw3d.h
+++ b/include/cute_draw3d.h
@@ -793,7 +793,7 @@ CF_API void CF_CALL cf_draw3d_billboard(const CF_Sprite* sprite, CF_V3 position)
  * @category draw3d
  * @brief    Pushes a color for subsequent 3d shape drawing.
  * @param    c  The color.
- * @remarks  Applies to all `cf_draw3d_` shape functions (lines, circles, solids). Defaults to white.
+ * @remarks  Applies to all `cf_draw3d_*` shape functions (lines, circles, solids). Defaults to white.
  * @related  cf_draw3d_pop_color cf_draw3d_peek_color cf_draw3d_line cf_draw3d_cube
  */
 CF_API void CF_CALL cf_draw3d_push_color(CF_Color c);

--- a/include/cute_math3d.h
+++ b/include/cute_math3d.h
@@ -133,10 +133,12 @@ typedef struct CF_M4x4
 } CF_M4x4;
 // @end
 
-// cf_v3 is documented in the CF_V3 struct's remarks rather than as its own documented symbol: the
-// docs parser lowercases titles into filenames, so a `cf_v3` page would collide with `CF_V3`'s.
-// cute_math.h leaves cf_v2 undocumented for the same reason. Note that tools/docs_parser.c scans
-// every token in the file, so a doc tag written in an ordinary comment aborts the docs build.
+/**
+ * @function cf_v3
+ * @category math
+ * @brief    Constructs a `CF_V3` from `x`, `y` and `z`, or splats a single value to all three components.
+ * @related  CF_V3 cf_v4 cf_dot cf_cross
+ */
 #define cf_v3(...)
 #undef cf_v3
 // Implemented this way (rather than as a function) to force-inline the initializer even in
@@ -154,7 +156,12 @@ typedef struct CF_M4x4
 #	define cf_v3(...) CF_EXPAND(_CF_V3_SELECT(__VA_ARGS__, _CF_V3_3, _CF_V3_E2, _CF_V3_1)(__VA_ARGS__))
 #endif
 
-// See the note on cf_v3 above -- documented in the CF_V4 struct to avoid a page-name collision.
+/**
+ * @function cf_v4
+ * @category math
+ * @brief    Constructs a `CF_V4` from `x`, `y`, `z` and `w`, or splats a single value to all four components.
+ * @related  CF_V4 cf_v3 cf_v4_from_v3 cf_xyz
+ */
 #define cf_v4(...)
 #undef cf_v4
 #define _CF_V4_SELECT(_1, _2, _3, _4, NAME, ...) NAME
@@ -190,7 +197,19 @@ CF_INLINE CF_V4 cf_v4_from_v3(CF_V3 a, float w) { return cf_v4(a.x, a.y, a.z, w)
  */
 CF_INLINE CF_V3 cf_xyz(CF_V4 a) { return cf_v3(a.x, a.y, a.z); }
 
-// Documented in the CF_Quat struct -- see the note on cf_v3 above about page-name collisions.
+/**
+ * @function cf_quat
+ * @category math
+ * @brief    Constructs a `CF_Quat` component-wise.
+ * @param    x  The x component of the vector part.
+ * @param    y  The y component of the vector part.
+ * @param    z  The z component of the vector part.
+ * @param    w  The scalar part.
+ * @return   Returns the quaternion `{ x, y, z, w }`.
+ * @remarks  The components are not normalized for you. To construct a rotation, prefer
+ *           `cf_quat_from_axis_angle`.
+ * @related  CF_Quat cf_quat_identity cf_quat_from_axis_angle cf_quat_norm
+ */
 CF_INLINE CF_Quat cf_quat(float x, float y, float z, float w) { CF_Quat q; q.x = x; q.y = y; q.z = z; q.w = w; return q; }
 
 //--------------------------------------------------------------------------------------------------
@@ -983,7 +1002,7 @@ extern "C" {
  * @struct   CF_Ray3
  * @category math
  * @brief    A 3d ray: a directional line segment from `p` along unit direction `d` for distance `t`.
- * @related  CF_Ray3 CF_Raycast3 cf_ray3 cf_ray3_to_aabb3 cf_ray3_to_sphere cf_ray3_to_plane3 cf_draw3d_unproject
+ * @related  CF_Ray3 CF_Raycast3 cf_make_ray3 cf_ray3_to_aabb3 cf_ray3_to_sphere cf_ray3_to_plane3 cf_draw3d_unproject
  */
 typedef struct CF_Ray3
 {
@@ -1055,7 +1074,7 @@ typedef struct CF_Sphere
  * @brief    A 3d plane in normal-distance form: points x on the plane satisfy `dot(n, x) == d`.
  * @remarks  The 3d analog of `CF_Halfspace`. The halfspace `dot(n, x) >= d` is the "inside" for
  *           frustum planes.
- * @related  CF_Plane3 cf_plane3 cf_plane3_at cf_distance_plane3 cf_project_plane3 cf_ray3_to_plane3 CF_Frustum
+ * @related  CF_Plane3 cf_make_plane3 cf_plane3_at cf_distance_plane3 cf_project_plane3 cf_ray3_to_plane3 CF_Frustum
  */
 typedef struct CF_Plane3
 {
@@ -1086,8 +1105,7 @@ typedef struct CF_Frustum
  * @function cf_make_ray3
  * @category math
  * @brief    Returns a ray from `p` toward `q`, spanning exactly the distance between them.
- * @remarks  Named like `cf_make_sphere`/`cf_make_aabb3` -- and distinctly from the
- *           `CF_Ray3` type, which shares a docs page slug case-insensitively.
+ * @remarks  Named like `cf_make_sphere`/`cf_make_aabb3`, the other 3d shape constructors.
  * @related  CF_Ray3 cf_ray3_to_aabb3 cf_ray3_to_sphere cf_ray3_to_plane3
  */
 CF_INLINE CF_Ray3 cf_make_ray3(CF_V3 p, CF_V3 q)
@@ -1129,8 +1147,7 @@ CF_INLINE CF_Sphere cf_make_sphere(CF_V3 p, float r) { CF_Sphere s; s.p = p; s.r
  * @function cf_make_plane3
  * @category math
  * @brief    Returns a plane with normal `n` (normalized for you) at distance `d` along `n`.
- * @remarks  Named `cf_make_*` like `cf_make_sphere` -- and distinctly from the `CF_Plane3` type,
- *           which shares a docs page slug case-insensitively.
+ * @remarks  Named `cf_make_*` like `cf_make_sphere`, the other 3d shape constructors.
  * @related  CF_Plane3 cf_plane3_at cf_distance_plane3
  */
 CF_INLINE CF_Plane3 cf_make_plane3(CF_V3 n, float d)
@@ -1145,7 +1162,7 @@ CF_INLINE CF_Plane3 cf_make_plane3(CF_V3 n, float d)
  * @function cf_plane3_at
  * @category math
  * @brief    Returns the plane with normal `n` (normalized for you) passing through point `p`.
- * @related  CF_Plane3 cf_plane3 cf_distance_plane3
+ * @related  CF_Plane3 cf_make_plane3 cf_distance_plane3
  */
 CF_INLINE CF_Plane3 cf_plane3_at(CF_V3 n, CF_V3 p)
 {

--- a/tools/docs_warnings_baseline.txt
+++ b/tools/docs_warnings_baseline.txt
@@ -36,7 +36,6 @@ cute_graphics.h: cf_apply_shader has an unresolved @related entry to `cf_create_
 cute_graphics.h: cf_clear_color has an unresolved @related entry to `cf_clear_screen`.
 cute_graphics.h: cf_clear_depth_stencil has an unresolved @related entry to `cf_clear_screen`.
 cute_graphics.h: cf_draw_elements has an unresolved @related entry to `cf_create_mesh`.
-cute_graphics.h: cf_query_pixel_format has an unresolved @related entry to `cf_texture_supports_format`.
 cute_graphics.h: cf_vertex_format_string has an unresolved @related entry to `cf_mesh_set_attributes`.
 cute_haptics.h: cf_haptic_open has an unresolved @related entry to `CF_Joypad`.
 cute_https.h: cf_https_response has an unresolved @related entry to `CF_Https`.


### PR DESCRIPTION
Since #549 merged, the Documentation workflow fails on master: the 3d headers reference symbols the docs parser can't resolve. The collision notes in cute_math3d.h predate the kind-qualified page paths from #544 -- a macro and a struct can now share a name case-insensitively (`cf_v2`/`CF_V2` already do), so `cf_v3`, `cf_v4`, and `cf_quat` get real doc blocks instead of workaround comments. The `cf_ray3`/`cf_plane3` @related entries predate the `cf_make_ray3`/`cf_make_plane3` rename, and `cf_draw3d_` was a wildcard the parser mistook for a symbol.

Fixing the warnings unmasked a second master breakage further down the same job: two docs/topics pages still link generated API pages at their pre-#544 flat paths, which the mkdocs broken-link check flags. Fixed in the second commit.

Baseline regenerated, which also drops one entry stale since `cf_texture_supports_format` was documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhrxqgfYE2bwuuwR3UiADA