### PR TITLE
Fix unclosed test function breaking master CI

### DIFF
--- a/test/test_math.c
+++ b/test/test_math.c
@@ -294,6 +294,9 @@ TEST_CASE(test_slice_nonconvex_no_overflow_c) {
 	CF_SliceOutput out = cf_slice(plane, zig, 1e-4f);
 	REQUIRE(out.front.count <= CF_POLY_MAX_VERTS);
 	REQUIRE(out.back.count <= CF_POLY_MAX_VERTS);
+	return true;
+}
+
 TEST_CASE(test_polygon_degenerate_c) {
 	/* Zero-area (collinear) polygon: results must be finite, falling back
 	   to the vertex average. */


### PR DESCRIPTION
test_slice_nonconvex_no_overflow_c (from #547) is missing its `return true; }`, so every later TEST_CASE nests inside it -- GCC rejects nested functions (invalid storage class / unexpected EOF at line 375) and master's Build workflow is red. One-line close, test_math 7/7 locally.