### PR TITLE
Fix upside-down shadow-cube faces in the point_light sample

### DIFF
--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -1582,7 +1582,7 @@ typedef struct CF_CanvasParams
 	   For a cube face rendered through a right-handed camera (`cf_look_at`/`cf_perspective`,
 	   e.g. via `cute_draw3d.h`), mind the T axis: CF renders top-row-first (row 0 at clip
 	   y = +1), which is the opposite of the row a right-handed face camera's `up` vector
-	   would put there. Rendering as-is stores every face upside down; a samplerCube fetch
+	   would put there. Rendering as-is stores every face upside down; a `samplerCube` fetch
 	   then reads shadows/reflections from the mirrored elevation. Mirror clip-space y in the
 	   face projection to fix it (which reverses triangle winding, so flip cull mode too). See
 	   `samples/point_light.c`'s `face_projection`/`face_state` for the exact fix. */

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -1577,7 +1577,15 @@ typedef struct CF_CanvasParams
 	CF_Texture attach_target;
 
 	/* @member Which face (0-5: +X, -X, +Y, -Y, +Z, -Z), array layer, or 3D slice of
-	   `attach_target` to render into. */
+	   `attach_target` to render into.
+
+	   For a cube face rendered through a right-handed camera (`cf_look_at`/`cf_perspective`,
+	   e.g. via `cute_draw3d.h`), mind the T axis: CF renders top-row-first (row 0 at clip
+	   y = +1), which is the opposite of the row a right-handed face camera's `up` vector
+	   would put there. Rendering as-is stores every face upside down; a samplerCube fetch
+	   then reads shadows/reflections from the mirrored elevation. Mirror clip-space y in the
+	   face projection to fix it (which reverses triangle winding, so flip cull mode too). See
+	   `samples/point_light.c`'s `face_projection`/`face_state` for the exact fix. */
 	int attach_layer;
 
 	/* @member Which mip level of `attach_target` to render into (default 0). The canvas takes the
@@ -2032,9 +2040,9 @@ CF_API void CF_CALL cf_mesh_update_instance_data(CF_Mesh mesh, void* data, int c
 #define CF_CULL_MODE_DEFS \
 	/* @entry No culling at all. */                        \
 	CF_ENUM(CULL_MODE_NONE,  0)                            \
-	/* @entry Cull triangles ordered clockwise. */         \
-	CF_ENUM(CULL_MODE_FRONT, 1)                            \
 	/* @entry Cull triangles ordered counter-clockwise. */ \
+	CF_ENUM(CULL_MODE_FRONT, 1)                            \
+	/* @entry Cull triangles ordered clockwise. */         \
 	CF_ENUM(CULL_MODE_BACK,  2)                            \
 	/* @end */
 

--- a/samples/point_light.c
+++ b/samples/point_light.c
@@ -210,7 +210,7 @@ int main(int argc, char* argv[])
 	// SDL_GPU renders top-row-first (row 0 at ndc y = +1), but a cube face's T axis runs the
 	// other way relative to the right-handed bases above -- rendered as-is every face lands
 	// upside down, and the lit pass reads its shadows from the mirrored elevation. Mirroring
-	// clip-space y lines them up. That reverses triangle winding, hence CULL_MODE_FRONT.
+	// clip-space y lines them up. That reverses triangle winding, hence `CF_CULL_MODE_FRONT`.
 	CF_M4x4 face_projection = cf_mul_m4(cf_m4_scale(cf_v3(1, -1, 1)),
 		cf_perspective(CF_PI * 0.5f, 1.0f, 0.1f, LIGHT_RADIUS));
 	CF_RenderState face_state = cf_render_state_3d_defaults();

--- a/samples/point_light.c
+++ b/samples/point_light.c
@@ -22,8 +22,15 @@
 #include <stdio.h>
 
 #define PILLARS 8
+// The light's reach: far plane of the six face frustums AND the attenuation radius, on
+// purpose. Anything the face passes clip away is past dist 1 in the lit pass, where atten
+// is already 0 -- so the "saw nothing" white it reads back can never show.
 #define LIGHT_RADIUS 14.0f
 #define FACE_SIZE 512
+// How far the lit pass nudges its shadow query off the surface, in units of distance-to-light.
+// A 90 degree face spans 2 units at unit distance, so one texel is 2/FACE_SIZE; two texels of
+// slop covers the diagonal.
+#define SHADOW_NUDGE "(4.0 / " CF_STRINGIZE(FACE_SIZE) ".0)"
 
 static const char* s_dist_vs =
 "layout (location = 0) in vec3 in_pos;\n"
@@ -84,12 +91,22 @@ static const char* s_lit_fs =
 "void main() {\n"
 "    vec3 n = normalize(v_normal);\n"
 "    vec3 to_light = u_light.xyz - v_world;\n"
-"    float dist = length(to_light) / u_light.w;\n"
-"    vec3 l = normalize(to_light);\n"
+"    float r = length(to_light);\n"
+"    vec3 l = to_light / r;\n"
+"    float ndl = max(dot(n, l), 0.0);\n"
+"    // Normal offset. The cube holds ONE distance per texel, so on a slanted surface the\n"
+"    // stored value can be a texel's worth of slope nearer than the pixel being lit: the\n"
+"    // surface shadows itself, in texel-sized rectangles (acne). Lift the query point off\n"
+"    // the surface by about two texels' world size (r * SHADOW_NUDGE), scaled by how edge-on\n"
+"    // the light is. Unlike a depth bias this cannot detach a shadow from its caster -- the ray\n"
+"    // to the lifted point still runs through the same occluder.\n"
+"    vec3 q = v_world + n * (r * " SHADOW_NUDGE " * sqrt(max(1.0 - ndl * ndl, 0.0)));\n"
+"    vec3 from_light = q - u_light.xyz;\n"
 "    // The light's stored view along this direction; farther than it saw means shadow.\n"
-"    float seen = texture(u_shadow, -l).x;\n"
-"    float lit = dist - 0.01 <= seen ? 1.0 : 0.0;\n"
-"    float diffuse = max(dot(n, l), 0.0) * lit;\n"
+"    float seen = texture(u_shadow, from_light).x;\n"
+"    float lit = length(from_light) / u_light.w - 0.001 <= seen ? 1.0 : 0.0;\n"
+"    float diffuse = ndl * lit;\n"
+"    float dist = r / u_light.w;\n"
 "    float atten = clamp(1.0 - dist, 0.0, 1.0);\n"
 "    atten *= atten;\n"
 "    vec3 warm = vec3(1.0, 0.85, 0.6);\n"
@@ -166,9 +183,14 @@ int main(int argc, char* argv[])
 	CF_Shader lit_shd = cf_make_shader_from_source(s_lit_vs, s_lit_fs);
 
 	// The shadow cube: float color faces holding distance-to-light, six canvases attached.
+	// NEAREST is load-bearing, not taste. These texels are distances feeding a binary
+	// compare; blending two of them invents a distance no surface is at, so every occluder
+	// silhouette grows a one-texel halo of wrong shadow that crawls as the light moves.
+	// Filter comparison *results* (PCF) if you want soft edges -- never the distances.
 	CF_TextureParams tp = cf_texture_defaults(FACE_SIZE, FACE_SIZE);
 	tp.texture_type = CF_TEXTURE_TYPE_CUBE;
 	tp.pixel_format = CF_PIXEL_FORMAT_R16G16B16A16_FLOAT;
+	tp.filter = CF_FILTER_NEAREST;
 	tp.usage = CF_TEXTURE_USAGE_COLOR_TARGET_BIT | CF_TEXTURE_USAGE_SAMPLER_BIT;
 	CF_Texture shadow_cube = cf_make_texture(tp);
 	CF_Canvas faces[6];
@@ -185,6 +207,15 @@ int main(int argc, char* argv[])
 	CF_V3 face_dir[6] = { { 1, 0, 0 }, { -1, 0, 0 }, { 0, 1, 0 }, { 0, -1, 0 }, { 0, 0, 1 }, { 0, 0, -1 } };
 	CF_V3 face_up[6]  = { { 0, -1, 0 }, { 0, -1, 0 }, { 0, 0, 1 }, { 0, 0, -1 }, { 0, -1, 0 }, { 0, -1, 0 } };
 
+	// SDL_GPU renders top-row-first (row 0 at ndc y = +1), but a cube face's T axis runs the
+	// other way relative to the right-handed bases above -- rendered as-is every face lands
+	// upside down, and the lit pass reads its shadows from the mirrored elevation. Mirroring
+	// clip-space y lines them up. That reverses triangle winding, hence CULL_MODE_FRONT.
+	CF_M4x4 face_projection = cf_mul_m4(cf_m4_scale(cf_v3(1, -1, 1)),
+		cf_perspective(CF_PI * 0.5f, 1.0f, 0.1f, LIGHT_RADIUS));
+	CF_RenderState face_state = cf_render_state_3d_defaults();
+	face_state.cull_mode = CF_CULL_MODE_FRONT;
+
 	float t = 0;
 	while (cf_app_is_running()) {
 		cf_app_update(NULL);
@@ -197,14 +228,16 @@ int main(int argc, char* argv[])
 
 		// Six face passes: same scene, 90 degree frustums from the light.
 		cf_draw3d_push_shader(dist_shd);
+		cf_draw3d_push_render_state(face_state);
 		for (int i = 0; i < 6; ++i) {
-			cf_draw3d_push_projection(cf_perspective(CF_PI * 0.5f, 1.0f, 0.1f, LIGHT_RADIUS));
+			cf_draw3d_push_projection(face_projection);
 			cf_draw3d_push_view(cf_look_at(light, cf_add_v3(light, face_dir[i]), face_up[i]));
 			s_scene(cube);
 			cf_draw3d_pop_view();
 			cf_draw3d_pop_projection();
 			cf_render_to(faces[i], true);
 		}
+		cf_draw3d_pop_render_state();
 		cf_draw3d_pop_shader();
 
 		// Lit pass under the orbiting main camera.

--- a/test/test_texture_types.cpp
+++ b/test/test_texture_types.cpp
@@ -232,6 +232,106 @@ TEST_CASE(test_render_to_cube_face)
 	return true;
 }
 
+static const char* s_quad_vs =
+"layout (location = 0) in vec3 in_pos;\n"
+"layout (set = 1, binding = 0) uniform uniform_block {\n"
+"    mat4 u_view_projection;\n"
+"};\n"
+"void main() { gl_Position = u_view_projection * vec4(in_pos, 1.0); }\n";
+
+static const char* s_red_fs =
+"layout (location = 0) out vec4 result;\n"
+"void main() { result = vec4(1.0, 0.0, 0.0, 1.0); }\n";
+
+// Pins the cube-face T-axis convention that samples/point_light.c relies on: a face camera
+// built with cf_look_at + a Y-mirrored cf_perspective (see that sample's face_projection
+// comment) must render geometry into the row a samplerCube fetch expects, not the row a
+// plain (unmirrored) right-handed camera would put it in.
+TEST_CASE(test_cube_face_orientation)
+{
+	if (!test_make_app(W, H)) return true; // Headless CI: no display/GPU.
+
+	CF_TextureParams tp = cf_texture_defaults(64, 64);
+	tp.texture_type = CF_TEXTURE_TYPE_CUBE;
+	tp.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT;
+	CF_Texture cube = cf_make_texture(tp);
+	REQUIRE(cube.id);
+
+	CF_CanvasParams cp = cf_canvas_defaults(64, 64);
+	cp.attach_target = cube;
+	cp.attach_layer = 0; // +X face.
+	CF_Canvas face = cf_make_canvas(cp);
+	REQUIRE(face.id);
+	cf_canvas_set_clear_color(face, cf_make_color_rgb_f(1, 1, 1)); // "Saw nothing" background.
+
+	// A small red quad above the eye, off to the +X side -- same face-camera construction as
+	// samples/point_light.c: cf_look_at down +X, up (0,-1,0), and a Y-mirrored 90 degree
+	// cf_perspective.
+	struct { float x, y, z; } verts[6] = {
+		{ 5, 1.5f, -0.5f }, { 5, 2.5f, -0.5f }, { 5, 2.5f,  0.5f },
+		{ 5, 1.5f, -0.5f }, { 5, 2.5f,  0.5f }, { 5, 1.5f,  0.5f },
+	};
+	CF_VertexAttribute attrs[1] = { };
+	attrs[0].name = "in_pos";
+	attrs[0].format = CF_VERTEX_FORMAT_FLOAT3;
+	attrs[0].offset = 0;
+	CF_Mesh quad = cf_make_mesh(sizeof(verts), attrs, 1, sizeof(verts[0]));
+	cf_mesh_update_vertex_data(quad, verts, 6);
+
+	CF_M4x4 projection = cf_mul_m4(cf_m4_scale(cf_v3(1, -1, 1)), cf_perspective(CF_PI * 0.5f, 1.0f, 0.1f, 10.0f));
+	CF_M4x4 view = cf_look_at(cf_v3(0, 0, 0), cf_v3(1, 0, 0), cf_v3(0, -1, 0));
+	CF_M4x4 vp = cf_mul_m4(projection, view);
+
+	CF_Shader quad_shader = cf_make_shader_from_source(s_quad_vs, s_red_fs);
+	REQUIRE(quad_shader.id);
+	CF_Material quad_material = cf_make_material();
+	CF_RenderState rs = cf_render_state_defaults();
+	rs.cull_mode = CF_CULL_MODE_NONE; // Winding depends on the mirror; don't cull either way.
+	cf_material_set_render_state(quad_material, rs);
+	cf_material_set_uniform_vs(quad_material, "u_view_projection", &vp, CF_UNIFORM_TYPE_MAT4, 1);
+
+	cf_app_update(NULL);
+	cf_apply_canvas(face, true);
+	cf_apply_mesh(quad);
+	cf_apply_shader(quad_shader, quad_material);
+	cf_draw_elements();
+	cf_app_draw_onto_screen(false);
+
+	// Sample the cube: a direction above the eye (matching the quad) must be red; a direction
+	// below (matching nothing) must stay the white background. Getting these swapped is
+	// exactly the bug the mirror in samples/point_light.c fixes.
+	CF_Shader cube_shader = cf_make_shader_from_source(s_vs, s_cube_fs);
+	REQUIRE(cube_shader.id);
+	CF_Mesh fullscreen = s_make_fullscreen_quad();
+	CF_Material material = cf_make_material();
+	CF_Canvas out = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(W * H * (int)sizeof(CF_Pixel));
+	cf_material_set_texture_fs(material, "u_cube", cube);
+
+	float dir_up[4] = { 1.0f, 0.4f, 0.0f, 0.0f };
+	cf_material_set_uniform_fs(material, "u_dir", dir_up, CF_UNIFORM_TYPE_FLOAT4, 1);
+	CF_Pixel c = s_draw_and_read(out, fullscreen, cube_shader, material, px);
+	REQUIRE(c.colors.r > 200 && c.colors.g < 60 && c.colors.b < 60);
+
+	float dir_down[4] = { 1.0f, -0.4f, 0.0f, 0.0f };
+	cf_material_set_uniform_fs(material, "u_dir", dir_down, CF_UNIFORM_TYPE_FLOAT4, 1);
+	c = s_draw_and_read(out, fullscreen, cube_shader, material, px);
+	REQUIRE(c.colors.r > 200 && c.colors.g > 200 && c.colors.b > 200);
+
+	cf_free(px);
+	cf_destroy_canvas(out);
+	cf_destroy_material(material);
+	cf_destroy_mesh(fullscreen);
+	cf_destroy_shader(cube_shader);
+	cf_destroy_material(quad_material);
+	cf_destroy_mesh(quad);
+	cf_destroy_shader(quad_shader);
+	cf_destroy_canvas(face);
+	cf_destroy_texture(cube);
+	test_destroy_app();
+	return true;
+}
+
 static const char* s_lod_fs =
 "layout (location = 0) out vec4 result;\n"
 "layout (set = 2, binding = 0) uniform sampler2D u_tex;\n"
@@ -548,6 +648,7 @@ TEST_SUITE(test_texture_types)
 	RUN_TEST_CASE(test_cube_map_sample);
 	RUN_TEST_CASE(test_texture_array_sample);
 	RUN_TEST_CASE(test_render_to_cube_face);
+	RUN_TEST_CASE(test_cube_face_orientation);
 	RUN_TEST_CASE(test_depth_attach);
 	RUN_TEST_CASE(test_attach_mip);
 	RUN_TEST_CASE(test_standalone_sampler);


### PR DESCRIPTION
`samples/point_light.c` borrowed the classic OpenGL/LearnOpenGL point-shadow face table, but CF renders through SDL_GPU's D3D/Metal-style convention (row 0 at clip y = +1), so every one of the six cube faces was stored vertically mirrored relative to what a `samplerCube` fetch reads back. Pillar shadows detached from their bases and popped in and out as the light moved, and faces facing the light read mostly unlit.

The fix mirrors clip-space y in the face projection and flips cull mode for the six face passes -- this can't be done by picking a different `face_up`, since `cf_look_at` only ever emits bases with `cross(s, u) = -f`. A new regression test (`test_cube_face_orientation`) pins the convention using the same face-camera construction; confirmed it fails without the mirror. Two doc-comment bugs found along the way are fixed too: `CF_CULL_MODE_FRONT`/`BACK`'s descriptions were swapped, and `CF_CanvasParams::attach_layer` now documents the T-axis convention.

Two secondary fixes were needed to get a clean image once the orientation was right: the shadow cube now samples `NEAREST` instead of the default `LINEAR` (bilinear blends stored *distances* before a binary compare, inventing distances no surface occupies and growing crawling halos at every silhouette), and the constant `0.01` depth bias is replaced with a normal-offset shadow query, which stays bounded everywhere in this scene instead of diverging at grazing angles like a depth bias would.

Suite passes on `test_texture_types`, `test_draw3d`, `test_shadow_sampling`; the pre-existing `test_draw_tiled` failures in this environment reproduce identically on master and are unrelated.

https://claude.ai/code/session_01C8Xbhf2qPLaAQm2LvJuxWa