### PR TITLE
Fix cf_sdlgpu_supports_msaa querying the wrong sample count

### DIFF
--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -19,10 +19,10 @@ static void* cf_fxc_compile(const char* hlsl, size_t hlsl_size, const char* targ
 
 using namespace Cute;
 
-// s_make_texture, cf_sdlgpu_supports_msaa, and the pipeline's multisample_state all cast a
-// CF_SampleCount straight to SDL_GPUSampleCount -- that's only correct because both enums
-// index 1x/2x/4x/8x as 0/1/2/3 in the same order. Catch it at compile time if SDL ever
-// renumbers its enum, rather than silently mis-sampling MSAA targets again.
+// s_make_texture and the pipeline's multisample_state both cast a CF_SampleCount straight to
+// SDL_GPUSampleCount -- that's only correct because both enums index 1x/2x/4x/8x as 0/1/2/3
+// in the same order. Catch it at compile time if SDL ever renumbers its enum, rather than
+// silently mis-sampling MSAA targets again.
 static_assert(
 	(int)CF_SAMPLE_COUNT_1 == (int)SDL_GPU_SAMPLECOUNT_1 &&
 	(int)CF_SAMPLE_COUNT_2 == (int)SDL_GPU_SAMPLECOUNT_2 &&

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -19,6 +19,17 @@ static void* cf_fxc_compile(const char* hlsl, size_t hlsl_size, const char* targ
 
 using namespace Cute;
 
+// s_make_texture, cf_sdlgpu_supports_msaa, and the pipeline's multisample_state all cast a
+// CF_SampleCount straight to SDL_GPUSampleCount -- that's only correct because both enums
+// index 1x/2x/4x/8x as 0/1/2/3 in the same order. Catch it at compile time if SDL ever
+// renumbers its enum, rather than silently mis-sampling MSAA targets again.
+static_assert(
+	(int)CF_SAMPLE_COUNT_1 == (int)SDL_GPU_SAMPLECOUNT_1 &&
+	(int)CF_SAMPLE_COUNT_2 == (int)SDL_GPU_SAMPLECOUNT_2 &&
+	(int)CF_SAMPLE_COUNT_4 == (int)SDL_GPU_SAMPLECOUNT_4 &&
+	(int)CF_SAMPLE_COUNT_8 == (int)SDL_GPU_SAMPLECOUNT_8,
+	"CF_SampleCount must share SDL_GPUSampleCount's index ordering");
+
 struct CF_CanvasInternal
 {
 	int w, h;
@@ -931,7 +942,9 @@ void cf_sdlgpu_attach(SDL_Window* window)
 bool cf_sdlgpu_supports_msaa(int sample_count)
 {
 	SDL_GPUTextureFormat fmt = SDL_GetGPUSwapchainTextureFormat(g_ctx.device, g_ctx.window);
-	return SDL_GPUTextureSupportsSampleCount(g_ctx.device, fmt, (SDL_GPUSampleCount)sample_count);
+	// sample_count is the raw MSAA multiplier (1/2/4/8); SDL_GPUSampleCount is indexed (0/1/2/3).
+	SDL_GPUSampleCount count = (SDL_GPUSampleCount)cf_clamp(sample_count >> 1, 0, 3);
+	return SDL_GPUTextureSupportsSampleCount(g_ctx.device, fmt, count);
 }
 
 void cf_sdlgpu_flush()

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -136,9 +136,10 @@ TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state)
 // SDL_GPUSampleCount instead of converting it to the enum's index (1/2/4/8 -> 0/1/2/3), so
 // cf_app_set_msaa(4) could never succeed on Metal/Vulkan/D3D12 (SDL_GPUSampleCount only goes
 // up to 3) while cf_app_set_msaa(2) accidentally worked (raw value 2 happens to equal the
-// enum index for 4x). Every backend CF targets that supports 2x MSAA is required to support
-// 4x too (Vulkan/D3D12/Metal all guarantee 4x sample-count support on standard color
-// formats), so a backend where 2x succeeds but 4x fails means the query itself is broken.
+// enum index for 4x). This asserts 4x support whenever 2x is reported: red on this exact
+// case pre-fix (2x yes, 4x no) on real Metal hardware, green after. 4x-given-2x isn't a
+// documented guarantee on every backend (Vulkan's spec, for one, only mandates 1x), so this
+// is an empirically-motivated regression check, not a proven cross-backend invariant.
 TEST_CASE(test_app_msaa_4x_supported_when_2x_is)
 {
 	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));

--- a/test/test_app.cpp
+++ b/test/test_app.cpp
@@ -132,6 +132,26 @@ TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state)
 	return true;
 }
 
+// Regression test: cf_sdlgpu_supports_msaa used to cast the raw sample count straight to
+// SDL_GPUSampleCount instead of converting it to the enum's index (1/2/4/8 -> 0/1/2/3), so
+// cf_app_set_msaa(4) could never succeed on Metal/Vulkan/D3D12 (SDL_GPUSampleCount only goes
+// up to 3) while cf_app_set_msaa(2) accidentally worked (raw value 2 happens to equal the
+// enum index for 4x). Every backend CF targets that supports 2x MSAA is required to support
+// 4x too (Vulkan/D3D12/Metal all guarantee 4x sample-count support on standard color
+// formats), so a backend where 2x succeeds but 4x fails means the query itself is broken.
+TEST_CASE(test_app_msaa_4x_supported_when_2x_is)
+{
+	REQUIRE(!is_error(make_app(NULL, 0, 0, 0, 0, CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_AUDIO_BIT, NULL)));
+
+	if (cf_app_set_msaa(2)) {
+		REQUIRE(cf_app_set_msaa(4));
+	}
+
+	destroy_app();
+
+	return true;
+}
+
 TEST_SUITE(test_app)
 {
 	RUN_TEST_CASE(test_app_destroy_safety);
@@ -145,4 +165,5 @@ TEST_SUITE(test_app)
 	RUN_TEST_CASE(test_app_present_mode_vsync_always_supported);
 	RUN_TEST_CASE(test_app_present_mode_off_round_trip);
 	RUN_TEST_CASE(test_app_present_mode_mailbox_failure_does_not_corrupt_state);
+	RUN_TEST_CASE(test_app_msaa_4x_supported_when_2x_is);
 }


### PR DESCRIPTION
`cf_app_set_msaa`'s support query cast the raw MSAA multiplier (1/2/4/8) straight to `SDL_GPUSampleCount`, which is indexed (0/1/2/3), instead of converting it the way `cute_app.cpp:155` already does when applying the count to the canvas. The query and the apply disagreed: requesting 4x MSAA could never report supported (enum value 4 is out of range) on the SDL_GPU backend, while requesting 2x accidentally queried 4x support instead.

Added a `static_assert` pinning the `CF_SampleCount`/`SDL_GPUSampleCount` index alignment that this cast (and two other direct casts in the file) depend on, so a future SDL enum reorder fails to compile instead of silently mis-sampling MSAA targets again.

The new test is a local guard, not a strict CI regression gate: it's conditional on 2x MSAA being supported (varies by backend/driver; the GLES backend doesn't support MSAA at all and reports unsupported unconditionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhGrTdXn8WjeihcmXzaDT8