### PR TITLE
3D API review fixes: math helpers, cf_make_model glue, canvas defaults, fireflies baked lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set(CF_SRCS
 	src/cute_draw.cpp
 	src/cute_draw3d.cpp
 	src/cute_image.cpp
+	src/cute_model.cpp
 	src/cute_graphics.cpp
 	src/cute_graphics_sdlgpu.cpp
 	src/cute_graphics_gles.cpp

--- a/docs/samples/model3d.md
+++ b/docs/samples/model3d.md
@@ -1,8 +1,11 @@
 # Model 3D
 
-Loads a glTF fox with [cute_model.h](https://github.com/RandyGaul/cute_framework/blob/master/libraries/cute/cute_model.h)
-and runs a pack of five of them through GPU skinning -- each fox on its own animation clip
-and phase, yet the whole pack lands in a handful of instanced draws.
+Loads a glTF fox with `cf_make_model` -- one call covering the VFS read, the
+[cute_model.h](https://github.com/RandyGaul/cute_framework/blob/master/libraries/cute/cute_model.h)
+parse, and external URI resolution -- decodes its embedded texture with
+`cf_make_texture_from_model_image`, and runs a pack of five foxes through GPU skinning:
+each fox on its own animation clip and phase, yet the whole pack lands in a handful of
+instanced draws.
 
 The trick is the storage-buffer skinning pattern:
 

--- a/docs/topics/drawing_3d.md
+++ b/docs/topics/drawing_3d.md
@@ -173,7 +173,7 @@ cf_draw3d_push_shader(lit_shd);     cf_draw_list(city);  cf_draw3d_pop_shader();
 
 Drawing a list under a pass shader also **fuses**: adjacent baked groups that differ only by frozen uniforms or textures the bound shader never declares collapse into a single draw -- a ten-material scene is one draw in a depth pass, because the depth shader reads none of the material state. `cf_draw3d_stats` counts draw-list draws, so the receipts show it.
 
-And the same closure rule covers uniforms: a name set only *outside* the recording stays live -- set `u_time` each frame and a baked level animates; a name set *inside* the recording freezes with it.
+And the same closure rule covers uniforms: a name set only *outside* the recording stays live -- set `u_time` each frame and a baked level animates; a name set *inside* the recording freezes with it. One rule to respect: ambient capture is by **name at record time** -- only names live when the recording's submissions were made participate, so set every per-frame uniform once *before* recording (bake at startup, before any uniform exists, and the replays bind no uniforms at all; the `fireflies` sample bakes on its first frame for exactly this reason).
 
 Two things to know:
 
@@ -216,8 +216,8 @@ Each common 3D need has a sample showing the pattern, because each one is a patt
 | `obj_loading` | A ~90 line OBJ parser into `cf_make_mesh`; model formats are user space, and this is the whole cost |
 | `shapes3d` | The shape catalog moving: gizmos, grids, arcs, tapered lines, solids -- zero setup |
 | `point_light` | Omnidirectional shadows: six face passes into one cube texture via `attach_target`, distance compare in the lit pass |
-| `model3d` | glTF loading via cute_model.h and the storage-buffer skinning pattern: a five-fox pack on independent animation clips in three instanced draws |
-| `fireflies` | The integration sample -- a first-person block forest with cascaded EVSM shadows, HDR bloom through render-to-mip canvases, frustum culling via cute_math3d.h, and a full gameplay loop |
+| `model3d` | glTF loading via `cf_make_model` (VFS-wired cute_model.h) and the storage-buffer skinning pattern: a five-fox pack on independent animation clips in three instanced draws |
+| `fireflies` | The integration sample -- a first-person block forest with cascaded EVSM shadows, HDR bloom through render-to-mip canvases, and a full gameplay loop; the world bakes into per-chunk draw lists that are frustum-culled and replayed once per pass |
 
 ## 3D Math
 

--- a/docs/topics/hidpi.md
+++ b/docs/topics/hidpi.md
@@ -47,7 +47,7 @@ float scale = fminf(window_w / 320.0f, window_h / 180.0f);
 cf_draw_canvas(canvas, cf_v2(0, 0), cf_v2(320 * scale, 180 * scale));
 ```
 
-Unlike the app's canvas, a canvas you make yourself never resizes behind your back, and the upscale is a deliberate stylistic choice rather than accidental blur. See [Canvas Modes](../samples/canvas_modes.md) for a live comparison of all of these setups, and [Window Resizing](../samples/window_resizing.md) for letterbox/crop/stretch scaling variants.
+Unlike the app's canvas, a canvas you make yourself never resizes behind your back, and the upscale is a deliberate stylistic choice rather than accidental blur. See [Canvas Modes](../samples/canvas_modes.md) for a live comparison of all of these setups, and [Window Resizing](../samples/windowresizing.md) for letterbox/crop/stretch scaling variants.
 
 ## Opting out entirely
 

--- a/docs/topics/shipping_3d.md
+++ b/docs/topics/shipping_3d.md
@@ -53,7 +53,7 @@ CF takes no AA position for you, but the pieces line up like this:
 
 ## Recipe: Shipping Textures
 
-The `model3d` sample decodes PNGs at load and samples them mipless, which is honest for a sample and wrong for a shipping game -- unmipped textures shimmer at 3D viewing distances and burn bandwidth.
+`cf_make_texture_from_model_image` decodes a model's embedded PNG/JPEG at load and generates a full mip chain -- the right development default, and fine to ship for small games. Past that, runtime decode burns load time and uncompressed pixels burn memory and bandwidth.
 
 **Native targets: convert offline to DDS.** glTF embeds PNG/JPEG; a shipping build converts those to block-compressed DDS in the asset pipeline (BC7 for color, BC5 for normal maps, BC4 for single-channel masks -- any standard tool: NVTT, Compressonator, ktx/toktx piped through DDS). Then:
 
@@ -69,6 +69,7 @@ One call uploads the compressed pixels and the full mip chain exactly as authore
 CF_TextureParams tp = cf_texture_defaults(w, h);
 tp.allocate_mipmaps = true;   // mip_count 0 = full chain
 tp.filter = CF_FILTER_LINEAR;
+tp.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT; // cf_generate_mipmaps downsamples via GPU blits.
 CF_Texture tex = cf_make_texture(tp);
 cf_texture_update(tex, pixels, size);
 cf_generate_mipmaps(tex);

--- a/include/cute.h
+++ b/include/cute.h
@@ -52,6 +52,7 @@
 #include "cute_math.h"
 #include "cute_math3d.h"
 #include "cute_draw3d.h"
+#include "cute_model.h"
 #include "cute_networking.h"
 #include "cute_noise.h"
 #include "cute_custom_sprite.h"

--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -94,6 +94,7 @@
 #endif
 
 #define CK_API CF_API
+#define CM_API CF_API
 
 #ifdef CF_WINDOWS
 #	define CF_CALL __cdecl

--- a/include/cute_draw3d.h
+++ b/include/cute_draw3d.h
@@ -125,7 +125,12 @@
 //     - A uniform or texture set inside the recording records frozen; a name that was only
 //       ambient binds the live `cf_draw3d_set_uniform`/`set_texture` value at
 //       `cf_draw_list` time, record-time value as fallback. Set `u_time` each frame and a
-//       baked level animates; set nothing and it renders exactly as recorded.
+//       baked level animates; set nothing and it renders exactly as recorded. Ambient
+//       capture is by NAME at record time: only names live when the recording's
+//       submissions were made participate, so set every per-frame uniform once BEFORE
+//       recording -- a level baked at startup, before any uniform exists, replays with no
+//       uniforms bound at all (the fireflies sample bakes on its first frame for exactly
+//       this reason).
 //
 // This is what makes multi-pass rendering one-recording cheap: record a scene shaderless,
 // then push the shadow shader and draw the list, push the lit shader and draw it again --
@@ -483,7 +488,8 @@ CF_API CF_RenderState CF_CALL cf_draw3d_peek_render_state(void);
 // submission; changing a uniform between two submissions of the same mesh splits their coalescing
 // group, which is the lever for material variety within one shader. Draw-list recordings apply
 // closure semantics per name: set inside the recording = frozen; merely ambient = the draw list
-// binds the live value at `cf_draw_list` time (see the DRAW LISTS section above).
+// binds the live value at `cf_draw_list` time. A name participates only if it was live at record
+// time, so set per-frame uniforms once before recording (see the DRAW LISTS section above).
 
 /**
  * @function cf_draw3d_set_uniform

--- a/include/cute_graphics.h
+++ b/include/cute_graphics.h
@@ -953,6 +953,10 @@ CF_API CF_Texture CF_CALL cf_make_texture_from_dds_mem(const void* data, int siz
  * @param    texture    The texture to generate mipmaps for.
  * @remarks  This is useful when the base level has been updated manually (e.g., for dynamic or render target textures)
  *           and you want to downsample to fill in the full mip chain.
+ *
+ *           The downsampling runs as GPU blits, so on the SDL_GPU backends the texture must carry
+ *           `CF_TEXTURE_USAGE_COLOR_TARGET_BIT` in addition to its sampler usage -- OR it into
+ *           `cf_texture_defaults`'s usage before `cf_make_texture`.
  * @related  CF_TextureParams CF_Texture cf_make_texture cf_destroy_texture cf_texture_update cf_texture_update_mip cf_generate_mipmaps
  */
 CF_API void CF_CALL cf_generate_mipmaps(CF_Texture texture);
@@ -1614,6 +1618,10 @@ typedef struct CF_CanvasParams
  * @function cf_canvas_defaults
  * @category graphics
  * @brief    Returns a good set of default values for a `CF_CanvasParams` to call `cf_make_canvas`.
+ * @remarks  Formats and usages (including the negotiated depth format) fill in regardless of size,
+ *           so `cf_canvas_defaults(0, 0)` is the right starting point for attach-mode canvases
+ *           (`attach_target`), which take their size from the attached texture and mip. Standalone
+ *           canvases need a real size -- `cf_make_canvas` rejects zero-sized targets.
  * @related  CF_CanvasParams cf_canvas_defaults cf_make_canvas cf_destroy_canvas cf_apply_canvas cf_clear_color
  */
 CF_API CF_CanvasParams CF_CALL cf_canvas_defaults(int w, int h);

--- a/include/cute_math3d.h
+++ b/include/cute_math3d.h
@@ -253,6 +253,43 @@ CF_INLINE CF_V3 cf_abs_v3(CF_V3 a) { return cf_v3(a.x < 0 ? -a.x : a.x, a.y < 0 
 CF_INLINE CF_V3 cf_lerp_v3(CF_V3 a, CF_V3 b, float t) { return cf_add_v3(a, cf_mul_v3_f(cf_sub_v3(b, a), t)); }
 CF_INLINE CF_V4 cf_lerp_v4(CF_V4 a, CF_V4 b, float t) { return cf_add_v4(a, cf_mul_v4_f(cf_sub_v4(b, a), t)); }
 
+/**
+ * @function cf_reflect_v3
+ * @category math
+ * @brief    Reflects a vector off a plane given the plane's normal.
+ * @param    a  The vector to reflect.
+ * @param    n  The plane's normal. Should be unit length.
+ * @remarks  The 3d analog of `cf_reflect` -- bounces, ricochets, mirrored cameras. The C++ API
+ *           overloads `cf_reflect` directly.
+ * @related  CF_V3 cf_slide_v3 cf_project_v3 cf_dot
+ */
+CF_INLINE CF_V3 cf_reflect_v3(CF_V3 a, CF_V3 n) { return cf_sub_v3(a, cf_mul_v3_f(n, 2.0f * cf_dot_v3(a, n))); }
+
+/**
+ * @function cf_project_v3
+ * @category math
+ * @brief    Projects vector `a` onto vector `b`.
+ * @param    a  The vector to project.
+ * @param    b  The vector to project onto. Need not be unit length.
+ * @return   Returns the component of `a` parallel to `b`, or zero when `b` is zero.
+ * @remarks  `cf_slide_v3` returns the complementary perpendicular component. For projecting a
+ *           point onto a plane see `cf_project_plane3`.
+ * @related  CF_V3 cf_slide_v3 cf_reflect_v3 cf_project_plane3 cf_dot
+ */
+CF_INLINE CF_V3 cf_project_v3(CF_V3 a, CF_V3 b) { float d = cf_dot_v3(b, b); return d != 0 ? cf_mul_v3_f(b, cf_dot_v3(a, b) / d) : cf_v3(0.0f); }
+
+/**
+ * @function cf_slide_v3
+ * @category math
+ * @brief    Removes from `a` its component along a surface normal, leaving motion along the surface.
+ * @param    a  The vector to slide, typically a velocity or movement delta.
+ * @param    n  The surface normal. Should be unit length.
+ * @remarks  The move-and-slide primitive: hit a wall, slide the remaining motion along it.
+ *           Equivalent to `a - n * dot(a, n)`.
+ * @related  CF_V3 cf_reflect_v3 cf_project_v3 cf_dot
+ */
+CF_INLINE CF_V3 cf_slide_v3(CF_V3 a, CF_V3 n) { return cf_sub_v3(a, cf_mul_v3_f(n, cf_dot_v3(a, n))); }
+
 #ifdef __cplusplus
 } // extern "C"
 CF_INLINE CF_V3 cf_min(CF_V3 a, CF_V3 b) { return cf_min_v3(a, b); }
@@ -278,6 +315,9 @@ CF_INLINE CF_V3 cf_safe_norm(CF_V3 a) { return cf_safe_norm_v3(a); }
 CF_INLINE CF_V4 cf_safe_norm(CF_V4 a) { return cf_safe_norm_v4(a); }
 CF_INLINE CF_V3 cf_lerp(CF_V3 a, CF_V3 b, float t) { return cf_lerp_v3(a, b, t); }
 CF_INLINE CF_V4 cf_lerp(CF_V4 a, CF_V4 b, float t) { return cf_lerp_v4(a, b, t); }
+CF_INLINE CF_V3 cf_reflect(CF_V3 a, CF_V3 n) { return cf_reflect_v3(a, n); }
+CF_INLINE CF_V3 cf_project(CF_V3 a, CF_V3 b) { return cf_project_v3(a, b); }
+CF_INLINE CF_V3 cf_slide(CF_V3 a, CF_V3 n) { return cf_slide_v3(a, n); }
 CF_INLINE CF_V3 cf_mul(CF_V3 a, CF_V3 b) { return cf_mul_v3(a, b); }
 CF_INLINE CF_V3 cf_mul(CF_V3 a, float b) { return cf_mul_v3_f(a, b); }
 CF_INLINE CF_V4 cf_mul(CF_V4 a, CF_V4 b) { return cf_mul_v4(a, b); }
@@ -334,6 +374,29 @@ extern "C" {
 #define cf_cross(a, b) _Generic((a), CF_CROSS_CASES((b)), CF_V3: cf_cross_v3, default: cf_cross_v2)((a), (b))
 #endif
 
+/**
+ * @function cf_orthonormal_basis
+ * @category math
+ * @brief    Builds two unit vectors perpendicular to `n` and to each other.
+ * @param    n      The third axis of the basis. Should be unit length.
+ * @param    x_out  Written with the first perpendicular axis.
+ * @param    y_out  Written with the second perpendicular axis.
+ * @remarks  `(x, y, n)` form a right-handed orthonormal basis: `cross(x, y) == n`. Branchless
+ *           and stable for every unit `n` (the Duff et al. method). The tangents are arbitrary
+ *           but deterministic -- right for sampling disks and cones around a normal, spawning
+ *           particles off a surface, or framing a camera ribbon; wrong for mesh tangent spaces,
+ *           which must come from UVs.
+ * @related  CF_V3 cf_cross cf_quat_from_basis cf_quat_from_to
+ */
+CF_INLINE void cf_orthonormal_basis(CF_V3 n, CF_V3* x_out, CF_V3* y_out)
+{
+	float sign = n.z >= 0 ? 1.0f : -1.0f;
+	float a = -1.0f / (sign + n.z);
+	float b = n.x * n.y * a;
+	*x_out = cf_v3(1.0f + sign * n.x * n.x * a, sign * b, -sign * n.x);
+	*y_out = cf_v3(b, sign + n.y * n.y * a, -n.y);
+}
+
 //--------------------------------------------------------------------------------------------------
 // Quaternions.
 
@@ -383,6 +446,50 @@ CF_INLINE CF_Quat cf_quat_norm(CF_Quat q)
  */
 CF_INLINE CF_Quat cf_quat_conjugate(CF_Quat q) { return cf_quat(-q.x, -q.y, -q.z, q.w); }
 
+/**
+ * @function cf_quat_inverse
+ * @category math
+ * @brief    Returns the inverse rotation.
+ * @remarks  Works for non-unit quaternions by dividing the conjugate by the squared length. A
+ *           unit quaternion's inverse IS its conjugate -- prefer `cf_quat_conjugate` when you
+ *           know the quaternion is normalized.
+ * @related  CF_Quat cf_quat_conjugate cf_quat_norm
+ */
+CF_INLINE CF_Quat cf_quat_inverse(CF_Quat q)
+{
+	float d = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+	if (d == 0.0f) return cf_quat_identity();
+	d = 1.0f / d;
+	return cf_quat(-q.x * d, -q.y * d, -q.z * d, q.w * d);
+}
+
+/**
+ * @function cf_quat_to_axis_angle
+ * @category math
+ * @brief    Extracts the rotation axis and angle from a unit quaternion.
+ * @param    q          The rotation. Should be unit length.
+ * @param    axis_out   Written with the unit rotation axis. May be NULL.
+ * @param    angle_out  Written with the angle in radians, in [0, 2pi]. May be NULL.
+ * @remarks  The inverse of `cf_quat_from_axis_angle`. A rotation at (or vanishingly near) the
+ *           identity has no meaningful axis, so `(1, 0, 0)` with angle 0 is returned. Note a
+ *           quaternion with negative `w` reports its angle as greater than pi -- the same
+ *           rotation, measured the long way around; negate the quaternion first if you want
+ *           the short form.
+ * @related  CF_Quat cf_quat_from_axis_angle cf_quat_norm
+ */
+CF_INLINE void cf_quat_to_axis_angle(CF_Quat q, CF_V3* axis_out, float* angle_out)
+{
+	float s2 = q.x * q.x + q.y * q.y + q.z * q.z;
+	if (s2 < 1e-12f) {
+		if (axis_out) *axis_out = cf_v3(1.0f, 0, 0);
+		if (angle_out) *angle_out = 0;
+		return;
+	}
+	float s = CF_SQRTF(s2);
+	if (axis_out) *axis_out = cf_v3(q.x / s, q.y / s, q.z / s);
+	if (angle_out) *angle_out = 2.0f * CF_ATAN2F(s, q.w);
+}
+
 CF_INLINE CF_Quat cf_mul_q(CF_Quat a, CF_Quat b)
 {
 	return cf_quat(
@@ -423,6 +530,26 @@ CF_INLINE CF_Quat cf_quat_slerp(CF_Quat a, CF_Quat b, float t)
 	float wa = CF_SINF((1.0f - t) * theta) / st;
 	float wb = CF_SINF(t * theta) / st;
 	return cf_quat(a.x * wa + b.x * wb, a.y * wa + b.y * wb, a.z * wa + b.z * wb, a.w * wa + b.w * wb);
+}
+
+/**
+ * @function cf_quat_nlerp
+ * @category math
+ * @brief    Normalized linear interpolation between two rotations -- slerp's cheap cousin.
+ * @param    a  The rotation at `t == 0`.
+ * @param    b  The rotation at `t == 1`.
+ * @param    t  The interpolant, from 0 to 1.
+ * @return   Returns a unit quaternion along the shortest arc from `a` to `b`.
+ * @remarks  Same endpoints and same arc as `cf_quat_slerp`, but the angular velocity is not
+ *           constant across `t`. For small differences -- animation keyframes, per-frame
+ *           smoothing -- the deviation is invisible and this is measurably cheaper.
+ * @related  CF_Quat cf_quat_slerp cf_quat_norm cf_lerp
+ */
+CF_INLINE CF_Quat cf_quat_nlerp(CF_Quat a, CF_Quat b, float t)
+{
+	float d = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+	if (d < 0) b = cf_quat(-b.x, -b.y, -b.z, -b.w);
+	return cf_quat_norm(cf_quat(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t, a.z + (b.z - a.z) * t, a.w + (b.w - a.w) * t));
 }
 
 /**
@@ -594,10 +721,10 @@ CF_INLINE CF_Quat cf_quat_from_m4(CF_M4x4 m)
  * @param    scale        Written with the per-axis scale. May be NULL.
  * @remarks  Assumes `m` is a translate-rotate-scale composition with no shear (skew silently
  *           folds into the rotation). A mirrored transform reports a negative x scale, since a
- *           flip cannot live in the quaternion. The inverse of building one with
- *           `cf_m4_translate * cf_quat_to_m4 * cf_m4_scale` -- useful for pulling a bone's pose
- *           out of a world matrix, or blending between authored transforms.
- * @related  CF_M4x4 CF_Quat cf_quat_from_m4 cf_quat_to_m4 cf_m4_translate cf_m4_scale
+ *           flip cannot live in the quaternion. The inverse of `cf_m4_from_trs` -- useful for
+ *           pulling a bone's pose out of a world matrix, or blending between authored
+ *           transforms.
+ * @related  CF_M4x4 CF_Quat cf_m4_from_trs cf_quat_from_m4 cf_quat_to_m4 cf_m4_translate cf_m4_scale
  */
 CF_INLINE void cf_m4_decompose(CF_M4x4 m, CF_V3* translation, CF_Quat* rotation, CF_V3* scale)
 {
@@ -688,6 +815,28 @@ CF_INLINE CF_M4x4 cf_quat_to_m4(CF_Quat q)
 	m.elements[8] = 2.0f * (xz + wy);
 	m.elements[9] = 2.0f * (yz - wx);
 	m.elements[10] = 1.0f - 2.0f * (xx + yy);
+	return m;
+}
+
+/**
+ * @function cf_m4_from_trs
+ * @category math
+ * @brief    Composes translation, rotation, and scale into a transform matrix.
+ * @param    translation  The translation.
+ * @param    rotation     The rotation. Should be unit length.
+ * @param    scale        The per-axis scale.
+ * @return   Returns the matrix `cf_m4_translate(t) * cf_quat_to_m4(r) * cf_m4_scale(s)`.
+ * @remarks  The inverse of `cf_m4_decompose`, computed directly with no matrix multiplies --
+ *           the usual way to build an object's or bone's world matrix from its pose.
+ * @related  CF_M4x4 CF_Quat cf_m4_decompose cf_quat_to_m4 cf_m4_translate cf_m4_scale
+ */
+CF_INLINE CF_M4x4 cf_m4_from_trs(CF_V3 translation, CF_Quat rotation, CF_V3 scale)
+{
+	CF_M4x4 m = cf_quat_to_m4(rotation);
+	m.elements[0] *= scale.x; m.elements[1] *= scale.x; m.elements[2] *= scale.x;
+	m.elements[4] *= scale.y; m.elements[5] *= scale.y; m.elements[6] *= scale.y;
+	m.elements[8] *= scale.z; m.elements[9] *= scale.z; m.elements[10] *= scale.z;
+	m.elements[12] = translation.x; m.elements[13] = translation.y; m.elements[14] = translation.z;
 	return m;
 }
 
@@ -1530,14 +1679,21 @@ CF_INLINE v3 safe_norm(v3 a) { return cf_safe_norm_v3(a); }
 CF_INLINE v4 safe_norm(v4 a) { return cf_safe_norm_v4(a); }
 CF_INLINE v3 lerp(v3 a, v3 b, float t) { return cf_lerp_v3(a, b, t); }
 CF_INLINE v4 lerp(v4 a, v4 b, float t) { return cf_lerp_v4(a, b, t); }
+CF_INLINE v3 reflect(v3 a, v3 n) { return cf_reflect_v3(a, n); }
+CF_INLINE v3 project(v3 a, v3 b) { return cf_project_v3(a, b); }
+CF_INLINE v3 slide(v3 a, v3 n) { return cf_slide_v3(a, n); }
+CF_INLINE void orthonormal_basis(v3 n, v3* x_out, v3* y_out) { cf_orthonormal_basis(n, x_out, y_out); }
 CF_INLINE v4 v4_from_v3(v3 a, float w) { return cf_v4_from_v3(a, w); }
 CF_INLINE v3 xyz(v4 a) { return cf_xyz(a); }
 
 CF_INLINE quat quat_identity() { return cf_quat_identity(); }
 CF_INLINE quat quat_from_axis_angle(v3 axis, float radians) { return cf_quat_from_axis_angle(axis, radians); }
+CF_INLINE void quat_to_axis_angle(quat q, v3* axis_out, float* angle_out) { cf_quat_to_axis_angle(q, axis_out, angle_out); }
 CF_INLINE quat norm(quat q) { return cf_quat_norm(q); }
 CF_INLINE quat conjugate(quat q) { return cf_quat_conjugate(q); }
+CF_INLINE quat inverse(quat q) { return cf_quat_inverse(q); }
 CF_INLINE quat slerp(quat a, quat b, float t) { return cf_quat_slerp(a, b, t); }
+CF_INLINE quat nlerp(quat a, quat b, float t) { return cf_quat_nlerp(a, b, t); }
 CF_INLINE quat quat_from_to(v3 from, v3 to) { return cf_quat_from_to(from, to); }
 CF_INLINE quat quat_from_basis(v3 x, v3 y, v3 z) { return cf_quat_from_basis(x, y, z); }
 CF_INLINE quat quat_from_m4(m4 m) { return cf_quat_from_m4(m); }
@@ -1553,6 +1709,7 @@ CF_INLINE m4 m4_rotate_z(float radians) { return cf_m4_rotate_z(radians); }
 CF_INLINE m4 transpose(m4 a) { return cf_m4_transpose(a); }
 CF_INLINE m4 invert(m4 a) { return cf_m4_invert(a); }
 CF_INLINE m4 normal_matrix(m4 model) { return cf_m4_normal_matrix(model); }
+CF_INLINE m4 m4_from_trs(v3 translation, quat rotation, v3 scale) { return cf_m4_from_trs(translation, rotation, scale); }
 CF_INLINE void m4_decompose(m4 m, v3* translation, quat* rotation, v3* scale) { cf_m4_decompose(m, translation, rotation, scale); }
 CF_INLINE v3 transform_point(m4 m, v3 p) { return cf_m4_transform_point(m, p); }
 CF_INLINE v3 transform_dir(m4 m, v3 d) { return cf_m4_transform_dir(m, d); }

--- a/include/cute_model.h
+++ b/include/cute_model.h
@@ -1,0 +1,118 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#ifndef CF_MODEL_H
+#define CF_MODEL_H
+
+#include "cute_defines.h"
+#include "cute_graphics.h"
+
+//--------------------------------------------------------------------------------------------------
+// C API
+//
+// Virtual-file-system glue for cute_model.h, CF's glTF 2.0 / GLB loader. The loader itself lives
+// in libraries/cute/cute_model.h and does no file IO of its own; these functions wire it to CF's
+// VFS (external .bin buffers and image files referenced by a .gltf resolve relative to the model's
+// virtual directory) and to CF's image decoders and texture creation.
+//
+// The model's data and animation runtime are the CM_* API: meshes and vertex streams, the node
+// hierarchy, skins, animation clip sampling (cm_animate/cm_blend/cm_skin_palette), interleaving
+// via cm_interleave, and so on. To use them, include the loader's header in the translation units
+// that touch model data:
+//
+//     #include <cute/ckit.h>
+//     #include <cute/cute_model.h>
+//
+// Do NOT define CUTE_MODEL_IMPLEMENTATION -- CF's library already compiles the implementation for
+// you (just like CKIT_IMPLEMENTATION). See the model3d sample for the complete flow from
+// cf_make_model to a skinned, animated, instanced draw.
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+typedef struct CM_Model CM_Model;
+
+/**
+ * @function cf_make_model
+ * @category model
+ * @brief    Loads a GLB or .gltf model from the virtual file system.
+ * @param    virtual_path  A virtual path to the model file (see the Virtual File System topic).
+ * @return   Returns the loaded model, or `NULL` on failure -- call `cf_model_error` for the reason.
+ * @remarks  External references inside a .gltf (a `.bin` buffer, image files) resolve through the
+ *           VFS relative to the model's directory, so a model mounted with its sidecar files simply
+ *           works. The returned `CM_Model` owns all of its arrays; free the whole thing with
+ *           `cf_destroy_model`. The model's data and animation API (`cm_animate`,
+ *           `cm_skin_palette`, `cm_interleave`, ...) lives in `libraries/cute/cute_model.h` -- see
+ *           the includes note at the top of this header.
+ * @related  cf_destroy_model cf_model_error cf_make_texture_from_model_image
+ */
+CF_API CM_Model* CF_CALL cf_make_model(const char* virtual_path);
+
+/**
+ * @function cf_destroy_model
+ * @category model
+ * @brief    Frees a model and everything it owns.
+ * @param    model  The model from `cf_make_model`. `NULL` is allowed.
+ * @related  cf_make_model cf_model_error
+ */
+CF_API void CF_CALL cf_destroy_model(CM_Model* model);
+
+/**
+ * @function cf_model_error
+ * @category model
+ * @brief    Returns a human-readable reason for the last `cf_make_model` failure.
+ * @remarks  Static storage, valid until the next load. Only meaningful after `cf_make_model`
+ *           returns `NULL`.
+ * @related  cf_make_model
+ */
+CF_API const char* CF_CALL cf_model_error(void);
+
+/**
+ * @function cf_make_texture_from_model_image
+ * @category model
+ * @brief    Decodes one of a model's embedded images into a ready-to-sample `CF_Texture`.
+ * @param    model        The model from `cf_make_model`.
+ * @param    image_index  An index into the model's images, e.g. a `CM_TextureRef`'s `image` member.
+ * @return   Returns a linear-filtered texture with a full mip chain generated.
+ * @remarks  Embedded glTF images are PNG or JPEG bytes; both decode here. An `image_index` of -1
+ *           (the loader's "slot unused" sentinel), an out-of-range index, or an undecodable image
+ *           all return a 1x1 white texture, so feeding a material slot straight through always
+ *           yields something drawable:
+ *
+ *           ```c
+ *           CF_Texture albedo = cf_make_texture_from_model_image(model, model->materials[0].base_color_texture.image);
+ *           ```
+ *
+ *           Destroy the result with `cf_destroy_texture`. For block-compressed shipping textures
+ *           see `cf_make_texture_from_dds` and the Shipping 3D topic.
+ * @related  cf_make_model CF_Texture cf_make_texture_from_dds cf_destroy_texture
+ */
+CF_API CF_Texture CF_CALL cf_make_texture_from_model_image(const CM_Model* model, int image_index);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+//--------------------------------------------------------------------------------------------------
+// C++ API
+
+#ifdef CF_CPP
+
+namespace Cute
+{
+
+CF_INLINE CM_Model* make_model(const char* virtual_path) { return cf_make_model(virtual_path); }
+CF_INLINE void destroy_model(CM_Model* model) { cf_destroy_model(model); }
+CF_INLINE const char* model_error() { return cf_model_error(); }
+CF_INLINE CF_Texture make_texture_from_model_image(const CM_Model* model, int image_index) { return cf_make_texture_from_model_image(model, image_index); }
+
+}
+
+#endif // CF_CPP
+
+#endif // CF_MODEL_H

--- a/libraries/cute/cute_model.h
+++ b/libraries/cute/cute_model.h
@@ -91,7 +91,19 @@
 #	error "cute_model.h requires cute/ckit.h to be included beforehand."
 #endif
 
+// Linkage attribute for the public functions, exactly like ckit's CK_API: defaults to
+// nothing, overridable for shared-library builds (Cute Framework wires it to CF_API).
+#ifndef CM_API
+#define CM_API
+#endif
+
 #include <stdint.h>
+
+// C linkage, so the implementation may live in a C++ TU (Cute Framework compiles it in
+// src/cute_model.cpp) while C consumers link the same symbols.
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //--------------------------------------------------------------------------------------------------
 // Data types.
@@ -304,22 +316,22 @@ typedef struct CM_LoadParams
 // Loads a GLB or .gltf model from memory. Returns NULL on failure -- call cm_error()
 // for a human-readable reason. The returned model owns all of its arrays; free the
 // whole thing with cm_free.
-CM_Model* cm_load(const void* data, int size);
+CM_API CM_Model* cm_load(const void* data, int size);
 
 // cm_load with external-file resolution (see CM_LoadParams).
-CM_Model* cm_load_ex(const void* data, int size, CM_LoadParams params);
+CM_API CM_Model* cm_load_ex(const void* data, int size, CM_LoadParams params);
 
 // The reason the last cm_load returned NULL. Static storage, valid until the next call.
-const char* cm_error(void);
+CM_API const char* cm_error(void);
 
-void cm_free(CM_Model* model);
+CM_API void cm_free(CM_Model* model);
 
 // Finds an animation by (case-sensitive) name, or NULL.
-CM_Animation* cm_find_animation(const CM_Model* model, const char* name);
+CM_API CM_Animation* cm_find_animation(const CM_Model* model, const char* name);
 
 // Finds a node by (case-sensitive) name -- attach props to bones, look up authored
 // markers, etc. Returns the node index, or -1.
-int cm_find_node(const CM_Model* model, const char* name);
+CM_API int cm_find_node(const CM_Model* model, const char* name);
 
 //--------------------------------------------------------------------------------------------------
 // Runtime. All output arrays are caller-allocated:
@@ -328,32 +340,32 @@ int cm_find_node(const CM_Model* model, const char* name);
 //   palette -- skin->joint_count mat4s, column-major.
 
 // Fills `locals` with every node's rest-pose transform.
-void cm_rest_pose(const CM_Model* model, CM_Transform* locals);
+CM_API void cm_rest_pose(const CM_Model* model, CM_Transform* locals);
 
 // Samples `animation` at `time` (seconds, clamped to the clip; loop with fmodf yourself)
 // on top of `locals`: only animated paths are overwritten, so un-animated nodes keep
 // whatever `locals` already holds (typically the rest pose). Call multiple times with
 // different clips to layer partial animations.
-void cm_animate(const CM_Model* model, const CM_Animation* animation, float time, CM_Transform* locals);
+CM_API void cm_animate(const CM_Model* model, const CM_Animation* animation, float time, CM_Transform* locals);
 
 // Composes local transforms down the hierarchy into world-space matrices.
-void cm_world_transforms(const CM_Model* model, const CM_Transform* locals, float* world);
+CM_API void cm_world_transforms(const CM_Model* model, const CM_Transform* locals, float* world);
 
 // Writes skin_index's matrix palette: palette[j] = world[joint j] * inverse_bind[j].
 // Upload straight into a mat4 array uniform; the vertex shader does the weighted blend.
 // Per the glTF spec the skinned mesh's node transform is NOT included -- render the
 // mesh under any model transform you like.
-void cm_skin_palette(const CM_Model* model, int skin_index, const float* world, float* palette);
+CM_API void cm_skin_palette(const CM_Model* model, int skin_index, const float* world, float* palette);
 
 // Blends two whole poses: out = lerp(a, b, t) per node, with shortest-path slerp for
 // rotations. Sample two clips into separate local arrays and blend for crossfades.
-void cm_blend(const CM_Model* model, const CM_Transform* a, const CM_Transform* b, float t, CM_Transform* out);
+CM_API void cm_blend(const CM_Model* model, const CM_Transform* a, const CM_Transform* b, float t, CM_Transform* out);
 
 // Samples `animation`'s morph-weight channels targeting `node` into weights (up to
 // weight_count entries, matching the mesh's target_count). Entries stay untouched when
 // the animation has no weights channel for the node, so prefill with the mesh's default
 // weights (CM_Mesh::weights) or zeros. Apply as: vertex += sum(weights[i] * delta[i]).
-void cm_animate_weights(const CM_Model* model, const CM_Animation* animation, float time, int node, float* weights, int weight_count);
+CM_API void cm_animate_weights(const CM_Model* model, const CM_Animation* animation, float time, int node, float* weights, int weight_count);
 
 //--------------------------------------------------------------------------------------------------
 // Interleaving. The loader hands back separate tightly-packed streams; GPUs want one
@@ -391,7 +403,11 @@ typedef struct CM_VertexAttribute
 // prim->vertex_count * stride bytes. Streams the primitive lacks write the defaults
 // listed on CM_Stream, so one attribute list serves skinned and unskinned meshes alike.
 // Keep the loader's indices (CM_Primitive::indices) for the index buffer.
-void cm_interleave(const CM_Primitive* prim, const CM_VertexAttribute* attributes, int attribute_count, int stride, void* out);
+CM_API void cm_interleave(const CM_Primitive* prim, const CM_VertexAttribute* attributes, int attribute_count, int stride, void* out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CUTE_MODEL_H
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ not_in_nav: |
   /list/**
   /map/**
   /math/**
+  /model/**
   /multithreading/**
   /net/**
   /noise/**

--- a/samples/fireflies.c
+++ b/samples/fireflies.c
@@ -107,7 +107,12 @@ static float s_terrain_height(float x, float z)
 }
 
 //--------------------------------------------------------------------------------------------------
-// The world: static blocks baked into chunks at startup, culled per frame by chunk AABB.
+// The world: static blocks baked into chunks at startup. Each chunk records its blocks into
+// a CF_DrawList ONCE (see s_bake_chunks), so every pass -- both shadow cascades and the lit
+// pass -- replays a visible chunk as a single instanced draw instead of re-submitting its
+// blocks. The chunk is also the culling granularity: frustum-test (or shadow-sphere-test)
+// the bounds, then cf_draw_list the survivors. This is the pattern from the Shipping 3D
+// topic's "Culling Baked Draw Lists" recipe.
 
 typedef struct Block
 {
@@ -123,6 +128,7 @@ typedef struct Chunk
 	Block blocks[MAX_BLOCKS_PER_CHUNK];
 	int count;
 	CF_Aabb3 bounds;
+	CF_DrawList list; // The chunk's blocks, baked. Replays as one instanced draw per pass.
 } Chunk;
 
 typedef struct World
@@ -388,7 +394,6 @@ static void s_auto_seek(Input* in, CF_V3 player, float yaw, CF_V3 target, float 
 	float diff = want - yaw;
 	while (diff > CF_PI) diff -= CF_TAU;
 	while (diff < -CF_PI) diff += CF_TAU;
-	in->look_dx = cf_clamp(-diff * 3.0f, -2.4f, 2.4f) / 0.02f * dt * -1.0f;
 	// The look_dx sign convention: yaw -= look_dx * 0.02, so negative diff steers correctly.
 	in->look_dx = -diff * 2.0f / 0.02f * dt;
 	if (cf_abs(diff) < 0.6f) in->move_z = 1.0f;
@@ -450,7 +455,13 @@ static void s_gather_input(Input* in, CF_V3 player, float yaw, float dt)
 // exponentially-warped depth and its square into a color target. Those moments CAN be
 // blurred like any image, and the receiver tests against a Chebyshev bound -- no depth
 // bias anywhere, no acne by construction, and softness comes from an honest gaussian.
-#define EVSM_C "40.0"
+// One numeric constant serves both languages: C code uses EVSM_C directly, GLSL strings
+// paste EVSM_C_STR -- they cannot drift apart. (Plain 40.0, no f suffix: the token must
+// read as a literal in GLSL too.)
+#define EVSM_C 40.0
+#define EVSM_STR_(x) #x
+#define EVSM_STR(x) EVSM_STR_(x)
+#define EVSM_C_STR EVSM_STR(EVSM_C)
 
 static const char* s_moment_vs =
 "layout (location = 0) in vec3 in_pos;\n"
@@ -474,7 +485,7 @@ static const char* s_moment_fs =
 "layout (location = 0) out vec4 result;\n"
 "void main() {\n"
 "	float z = v_zw.x / v_zw.y;\n"        // [0, 1] under CF's clip conventions (ortho: w = 1).
-"	float e = exp(" EVSM_C " * z);\n"
+"	float e = exp(" EVSM_C_STR " * z);\n"
 "	result = vec4(e, e * e, 0.0, 1.0);\n"
 "}\n";
 
@@ -559,7 +570,7 @@ static const char* s_block_fs =
 "	if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) return 1.0;\n"
 "	// EVSM: Chebyshev upper bound over pre-blurred exponentially-warped moments.\n"
 "	vec2 m = texture(u_shadow, vec3(uv, layer)).rg;\n"
-"	float e = exp(" EVSM_C " * ndc.z);\n"
+"	float e = exp(" EVSM_C_STR " * ndc.z);\n"
 "	if (e <= m.x) return 1.0;\n"
 "	float variance = max(m.y - m.x * m.x, 0.00005 * e * e);\n"
 "	float d = e - m.x;\n"
@@ -734,7 +745,7 @@ static CF_Mesh s_make_cube_mesh(void)
 
 static CF_Mesh s_make_fullscreen_mesh(void)
 {
-	float verts[12] = { -1, -1, 3, -1, -1, 3, 0, 0, 0, 0, 0, 0 }; // One big triangle.
+	float verts[6] = { -1, -1, 3, -1, -1, 3 }; // One big triangle.
 	CF_VertexAttribute attrs[1] = { 0 };
 	attrs[0].name = "in_pos";
 	attrs[0].format = CF_VERTEX_FORMAT_FLOAT2;
@@ -763,6 +774,37 @@ static void s_submit_block_ex(CF_Mesh cube, CF_V3 center, CF_V3 scale, CF_Color 
 static void s_submit_block(CF_Mesh cube, const Block* b)
 {
 	s_submit_block_ex(cube, b->center, b->scale, b->color, b->emissive, b->sway);
+}
+
+// Record each chunk's blocks into a draw list, once. The recordings are shaderless and
+// set no uniforms of their own, so both stay FREE VARIABLES (closure semantics): each
+// pass pushes its own shader before cf_draw_list, and the per-frame ambient uniforms
+// (u_time, the sun, the fog) bind live at replay -- one bake serves the moment passes and
+// the lit pass alike, and the leaves keep swaying. Two rules of the recording contract
+// shape the call site:
+//
+//   - Ambient capture is by NAME: a uniform participates as a free variable only if it
+//     was live when the recording's submissions were made. So the bake runs on the first
+//     frame, after every u_* the block shader reads has been set -- bake at startup and
+//     the replays would bind no uniforms at all.
+//   - Render state is NOT a free variable -- a baked submission replays the state
+//     captured at record time -- so the one state every pass agrees on goes inside the
+//     recording: culling off, which the moment pass needs for thin leaf boxes and which
+//     costs the lit pass nothing visible (the blocks are closed).
+static void s_bake_chunks(CF_Mesh cube)
+{
+	CF_RenderState rs = cf_render_state_3d_defaults();
+	rs.cull_mode = CF_CULL_MODE_NONE;
+	for (int i = 0; i < CHUNKS * CHUNKS; ++i) {
+		Chunk* c = &g_world.chunks[i];
+		if (!c->count) continue;
+		c->list = cf_make_draw_list();
+		cf_draw_list_begin(c->list);
+		cf_draw3d_push_render_state(rs);
+		for (int k = 0; k < c->count; ++k) s_submit_block(cube, &c->blocks[k]);
+		cf_draw3d_pop_render_state();
+		cf_draw_list_end();
+	}
 }
 
 // True when a sphere at `p` touches any world block -- the lantern's "would it clip a
@@ -980,7 +1022,10 @@ static int s_shot_count;
 // readbacks stall. Assemble with: ffmpeg -framerate 30 -i fireflies_rec_%05d.png out.mp4
 static float g_record_until;
 static int s_rec_count;
-static void s_record_frame(void)
+
+// Reads the app canvas back and saves it as a png. The spin on cf_readback_ready is fine
+// for this offline harness -- a game loop would poll it across frames instead.
+static void s_save_canvas_png(const char* path, bool verbose)
 {
 	CF_Canvas canvas = cf_app_get_canvas();
 	int w = 0, h = 0;
@@ -995,34 +1040,24 @@ static void s_record_frame(void)
 		img.w = w;
 		img.h = h;
 		img.pix = px;
-		char path[256];
-		snprintf(path, sizeof(path), "/fireflies_rec_%05d.png", s_rec_count++);
 		cf_image_save_png(path, &img);
+		if (verbose) printf("saved %s (%dx%d)\n", path, w, h);
 	}
 	cf_free(px);
 }
 
+static void s_record_frame(void)
+{
+	char path[256];
+	snprintf(path, sizeof(path), "/fireflies_rec_%05d.png", s_rec_count++);
+	s_save_canvas_png(path, false);
+}
+
 static void s_screenshot(void)
 {
-	CF_Canvas canvas = cf_app_get_canvas();
-	int w = 0, h = 0;
-	cf_canvas_get_size(canvas, &w, &h);
-	CF_Pixel* px = (CF_Pixel*)cf_alloc((size_t)w * h * sizeof(CF_Pixel));
-	CF_Readback rb = cf_canvas_readback(canvas);
-	if (rb.id) {
-		while (!cf_readback_ready(rb)) {}
-		cf_readback_data(rb, px, w * h * (int)sizeof(CF_Pixel));
-		cf_destroy_readback(rb);
-		CF_Image img;
-		img.w = w;
-		img.h = h;
-		img.pix = px;
-		char path[256];
-		snprintf(path, sizeof(path), "/fireflies_shot_%02d.png", s_shot_count++);
-		cf_image_save_png(path, &img);
-		printf("saved %s (%dx%d)\n", path, w, h);
-	}
-	cf_free(px);
+	char path[256];
+	snprintf(path, sizeof(path), "/fireflies_shot_%02d.png", s_shot_count++);
+	s_save_canvas_png(path, true);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1147,6 +1182,7 @@ int main(int argc, char* argv[])
 	g_game.stage = STAGE_COLLECT; // You start with the lantern in hand.
 
 	CF_Mesh cube = s_make_cube_mesh();
+	bool world_baked = false; // Chunks bake on the first frame -- see s_bake_chunks' remarks.
 	CF_Shader block_shd = cf_make_shader_from_source(s_block_vs, s_block_fs);
 	CF_Shader sky_shd = cf_make_shader_from_source(s_sky_vs, s_sky_fs);
 	CF_Shader moment_shd = cf_make_shader_from_source(s_moment_vs, s_moment_fs);
@@ -1166,11 +1202,11 @@ int main(int argc, char* argv[])
 		sp.filter = CF_FILTER_LINEAR;
 		shadow_tex = cf_make_texture(sp);
 		shadow_scratch = cf_make_texture(sp);
-		float e = expf(40.0f); // Matches EVSM_C: an empty texel reads as "farthest possible".
+		float e = expf((float)EVSM_C); // An empty texel reads as "farthest possible".
 		for (int i = 0; i < 2; ++i) {
-			// Sized defaults so depth_stencil_target params are filled; the attach branch
-			// ignores the color target entirely and sizes depth to the attach mip.
-			CF_CanvasParams cp = cf_canvas_defaults(SHADOW_RES, SHADOW_RES);
+			// Attach-mode canvases size themselves (and their depth) from the attached
+			// texture and mip, so zero-size defaults are all they need.
+			CF_CanvasParams cp = cf_canvas_defaults(0, 0);
 			cp.attach_target = shadow_tex;
 			cp.attach_layer = i;
 			cp.depth_stencil_enable = true; // The moment pass still depth-tests its own boxes.
@@ -1329,50 +1365,10 @@ int main(int argc, char* argv[])
 			shadow_vp[i] = cf_mul_m4(lproj, lview);
 		}
 
-		// Pass 1 + 2: render the world's shadow moments into each cascade. Same submissions,
-		// moment shader pushed, light matrix as the camera -- multi-pass exactly as the
-		// draw3d header prescribes. No depth bias anywhere: EVSM doesn't need one.
-		CF_RenderState shadow_rs = cf_render_state_3d_defaults();
-		shadow_rs.cull_mode = CF_CULL_MODE_NONE; // Leaf boxes are thin; keep their backs.
-		for (int cascade = 0; cascade < 2; ++cascade) {
-			cf_draw3d_push_projection(shadow_vp[cascade]);
-			cf_draw3d_push_view(cf_m4_identity());
-			cf_draw3d_push_shader(moment_shd);
-			cf_draw3d_push_render_state(shadow_rs);
-			CF_V3 cc = cf_add_v3(player, cf_mul_v3_f(flat_fwd, cascade_r[cascade] * 0.55f));
-			CF_Sphere cull = cf_make_sphere(cc, cascade_r[cascade] * 1.75f);
-			for (int i = 0; i < CHUNKS * CHUNKS; ++i) {
-				Chunk* c = &g_world.chunks[i];
-				if (!c->count) continue;
-				if (!cf_sphere_to_aabb3(cull, c->bounds)) continue;
-				for (int k = 0; k < c->count; ++k) s_submit_block(cube, &c->blocks[k]);
-			}
-			cf_draw3d_pop_render_state();
-			cf_draw3d_pop_shader();
-			cf_draw3d_pop_view();
-			cf_draw3d_pop_projection();
-			cf_render_to(shadow_canvas[cascade], true);
-
-			// Separable gaussian over the cascade's moments: horizontal into the scratch
-			// layer, vertical back into the moment map. This blur is what a comparison
-			// sampler could never allow -- and why the acne is gone.
-			for (int dir = 0; dir < 2; ++dir) {
-				CF_V4 dir_layer = dir == 0
-					? cf_v4(1.0f / SHADOW_RES, 0, (float)cascade, 0)
-					: cf_v4(0, 1.0f / SHADOW_RES, (float)cascade, 0);
-				cf_apply_canvas(dir == 0 ? shadow_blur_h[cascade] : shadow_blur_v[cascade], true);
-				cf_apply_mesh(post.fullscreen);
-				cf_material_set_texture_fs(shadow_blur_mat, "u_src", dir == 0 ? shadow_tex : shadow_scratch);
-				cf_material_set_uniform_fs(shadow_blur_mat, "u_dir_layer", &dir_layer, CF_UNIFORM_TYPE_FLOAT4, 1);
-				cf_apply_shader(shadow_blur_shd, shadow_blur_mat);
-				cf_draw_elements();
-			}
-		}
-
-		// Pass 3: the scene, in HDR.
-		cf_draw3d_push_projection(proj);
-		cf_draw3d_push_view(view);
-
+		// The frame's shading state, set once up front. Uniforms and textures are captured
+		// per submission, so setting them before ANY pass serves them all -- and their names
+		// being live is what lets the chunk bake below capture them as ambient free
+		// variables that rebind here every frame.
 		cf_draw3d_set_uniform_v3("u_eye", player);
 		cf_draw3d_set_uniform_v3("u_sun_dir", sun_dir);
 		cf_draw3d_set_uniform_color("u_sun_color", sun_color);
@@ -1406,6 +1402,54 @@ int main(int argc, char* argv[])
 		for (int i = nl; i < FIREFLY_LIGHTS; ++i) lights[i] = cf_v4(0, -1000.0f, 0, 0);
 		cf_draw3d_set_uniform("u_lights", lights, CF_UNIFORM_TYPE_FLOAT4, FIREFLY_LIGHTS);
 
+		// First frame only: bake the chunks, now that every ambient uniform name is live.
+		if (!world_baked) {
+			s_bake_chunks(cube);
+			world_baked = true;
+		}
+
+		// Pass 1 + 2: render the world's shadow moments into each cascade. Same baked chunk
+		// lists as the lit pass, moment shader pushed, light matrix as the camera --
+		// multi-pass exactly as the draw3d header prescribes: one recording, one instanced
+		// draw per visible chunk per pass. No depth bias anywhere: EVSM doesn't need one.
+		// (The cull-off state the moment pass wants is frozen inside the bakes.)
+		for (int cascade = 0; cascade < 2; ++cascade) {
+			cf_draw3d_push_projection(shadow_vp[cascade]);
+			cf_draw3d_push_view(cf_m4_identity());
+			cf_draw3d_push_shader(moment_shd);
+			CF_V3 cc = cf_add_v3(player, cf_mul_v3_f(flat_fwd, cascade_r[cascade] * 0.55f));
+			CF_Sphere cull = cf_make_sphere(cc, cascade_r[cascade] * 1.75f);
+			for (int i = 0; i < CHUNKS * CHUNKS; ++i) {
+				Chunk* c = &g_world.chunks[i];
+				if (!c->count) continue;
+				if (!cf_sphere_to_aabb3(cull, c->bounds)) continue;
+				cf_draw_list(c->list);
+			}
+			cf_draw3d_pop_shader();
+			cf_draw3d_pop_view();
+			cf_draw3d_pop_projection();
+			cf_render_to(shadow_canvas[cascade], true);
+
+			// Separable gaussian over the cascade's moments: horizontal into the scratch
+			// layer, vertical back into the moment map. This blur is what a comparison
+			// sampler could never allow -- and why the acne is gone.
+			for (int dir = 0; dir < 2; ++dir) {
+				CF_V4 dir_layer = dir == 0
+					? cf_v4(1.0f / SHADOW_RES, 0, (float)cascade, 0)
+					: cf_v4(0, 1.0f / SHADOW_RES, (float)cascade, 0);
+				cf_apply_canvas(dir == 0 ? shadow_blur_h[cascade] : shadow_blur_v[cascade], true);
+				cf_apply_mesh(post.fullscreen);
+				cf_material_set_texture_fs(shadow_blur_mat, "u_src", dir == 0 ? shadow_tex : shadow_scratch);
+				cf_material_set_uniform_fs(shadow_blur_mat, "u_dir_layer", &dir_layer, CF_UNIFORM_TYPE_FLOAT4, 1);
+				cf_apply_shader(shadow_blur_shd, shadow_blur_mat);
+				cf_draw_elements();
+			}
+		}
+
+		// Pass 3: the scene, in HDR.
+		cf_draw3d_push_projection(proj);
+		cf_draw3d_push_view(view);
+
 		// Sky beneath the world.
 		cf_draw_push_layer(-1);
 		cf_draw3d_push_shader(sky_shd);
@@ -1429,7 +1473,9 @@ int main(int argc, char* argv[])
 		cf_draw3d_pop_shader();
 		cf_draw_pop_layer();
 
-		// The world.
+		// The world: frustum-cull chunk bounds, replay the survivors' bakes -- one
+		// instanced draw per visible chunk, zero per-block CPU cost. Dynamic pieces
+		// (lantern, shrine, glass) stay immediate on top.
 		cf_draw3d_push_shader(block_shd);
 		int visible_chunks = 0;
 		for (int i = 0; i < CHUNKS * CHUNKS; ++i) {
@@ -1437,7 +1483,7 @@ int main(int argc, char* argv[])
 			if (!c->count) continue;
 			if (!cf_frustum_test_aabb3(&frustum, c->bounds)) continue;
 			visible_chunks++;
-			for (int k = 0; k < c->count; ++k) s_submit_block(cube, &c->blocks[k]);
+			cf_draw_list(c->list);
 		}
 		s_draw_dynamic(cube, player, fwd, t);
 		cf_draw3d_pop_shader();
@@ -1492,6 +1538,9 @@ int main(int argc, char* argv[])
 		if (exit_at > 0 && t >= exit_at) break;
 	}
 
+	for (int i = 0; i < CHUNKS * CHUNKS; ++i) {
+		if (g_world.chunks[i].count) cf_destroy_draw_list(g_world.chunks[i].list);
+	}
 	s_post_destroy_targets(&post);
 	cf_destroy_material(post.mat_bright);
 	cf_destroy_material(post.mat_down);

--- a/samples/model3d.c
+++ b/samples/model3d.c
@@ -31,8 +31,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// CF's library compiles the loader's implementation (src/cute_model.cpp); consumers just
+// include the headers for the CM_* data and animation API.
 #include <cute/ckit.h>
-#define CUTE_MODEL_IMPLEMENTATION
 #include <cute/cute_model.h>
 
 typedef struct Vertex
@@ -129,34 +130,6 @@ static CF_Mesh s_make_mesh(const CM_Primitive* prim, int* out_count)
 	return mesh;
 }
 
-// The base color texture ships inside the GLB as encoded bytes -- PNG or JPEG, sniffed by
-// magic number (glTF from Blender/Substance very commonly embeds JPEGs).
-static CF_Texture s_make_texture(const CM_Model* model)
-{
-	if (model->material_count && model->materials[0].base_color_texture.image >= 0) {
-		CM_Image* image = model->images + model->materials[0].base_color_texture.image;
-		const uint8_t* bytes = (const uint8_t*)image->data;
-		bool jpg = image->size > 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
-		CF_Image img;
-		CF_Result decoded = jpg
-			? cf_image_load_jpg_from_memory(image->data, image->size, &img)
-			: cf_image_load_png_from_memory(image->data, image->size, &img);
-		if (!cf_is_error(decoded)) {
-			CF_TextureParams params = cf_texture_defaults(img.w, img.h);
-			params.filter = CF_FILTER_LINEAR;
-			CF_Texture tex = cf_make_texture(params);
-			cf_texture_update(tex, img.pix, img.w * img.h * (int)sizeof(CF_Pixel));
-			cf_image_free(&img);
-			return tex;
-		}
-	}
-	// Fallback: 1x1 white.
-	CF_Pixel white = cf_make_pixel_rgb(255, 255, 255);
-	CF_Texture tex = cf_make_texture(cf_texture_defaults(1, 1));
-	cf_texture_update(tex, &white, (int)sizeof(white));
-	return tex;
-}
-
 // Screenshot/exit harness, same contract as the fireflies sample: --shot <t> saves a
 // numbered png of the app canvas, --exit-at <t> quits cleanly. Smoke-testable in CI.
 static int s_shot_count;
@@ -210,25 +183,22 @@ int main(int argc, char* argv[])
 
 	cf_canvas_set_clear_color(cf_app_get_canvas(), cf_make_color_rgb_f(0.10f, 0.11f, 0.13f));
 
-	size_t size = 0;
-	void* data = cf_fs_read_entire_file_to_memory("/model3d_data/Fox.glb", &size);
-	if (!data) {
-		printf("Failed to read /model3d_data/Fox.glb\n");
-		cf_destroy_app();
-		return -1;
-	}
-	CM_Model* model = cm_load(data, (int)size);
-	cf_free(data);
+	// One call: VFS read, GLB parse, and external URI resolution (had this been a .gltf
+	// with sidecar files) all happen inside CF.
+	CM_Model* model = cf_make_model("/model3d_data/Fox.glb");
 	if (!model) {
-		printf("cm_load failed: %s\n", cm_error());
+		printf("cf_make_model failed: %s\n", cf_model_error());
 		cf_destroy_app();
 		return -1;
 	}
 
-	// The fox is one mesh, one primitive, one skin.
+	// The fox is one mesh, one primitive, one skin. The base color texture ships inside
+	// the GLB as encoded PNG or JPEG bytes; CF decodes, mips, and uploads it (a -1 or
+	// absent slot would yield a 1x1 white texture).
 	int vertex_count = 0;
 	CF_Mesh mesh = s_make_mesh(&model->meshes[0].primitives[0], &vertex_count);
-	CF_Texture texture = s_make_texture(model);
+	CF_Texture texture = cf_make_texture_from_model_image(model,
+		model->material_count ? model->materials[0].base_color_texture.image : -1);
 	cf_draw3d_set_texture("u_image", texture);
 
 	const CM_Skin* skin = &model->skins[0];
@@ -376,7 +346,7 @@ int main(int argc, char* argv[])
 	cf_free(world);
 	cf_free(palettes);
 	cf_destroy_storage_buffer(bones_buf);
-	cm_free(model);
+	cf_destroy_model(model);
 	cf_destroy_mesh(mesh);
 	cf_destroy_texture(texture);
 	cf_destroy_shader(shader);

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -624,31 +624,29 @@ CF_TextureParams cf_texture_defaults(int w, int h)
 
 CF_CanvasParams cf_canvas_defaults(int w, int h)
 {
+	// Formats and usages fill in regardless of size, so cf_canvas_defaults(0, 0) hands back
+	// fully-formed params for attach-mode canvases (`attach_target`), which take their size
+	// from the attached texture and mip. Standalone canvases still require a real size --
+	// cf_make_canvas rejects zero-sized targets.
 	CF_CanvasParams params = { 0 };
-	if (w == 0 || h == 0) {
-		params.name = NULL;
-		params.target = { };
-		params.depth_stencil_target = { };
-	} else {
-		params.name = NULL;
-		params.target = cf_texture_defaults(w, h);
-		params.target.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT;
-		// Pre-fill every color target slot identically, so a multi-target canvas only needs
-		// target_count set (and usually pixel formats tweaked) rather than full param setup.
-		for (int i = 1; i < CF_MAX_CANVAS_TARGETS; ++i) params.targets[i] = params.target;
-		params.target_count = 1;
-		params.depth_stencil_enable = false;
-		params.depth_stencil_target = cf_texture_defaults(w, h);
-		params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D16_UNORM;
-		if (cf_texture_supports_format(CF_PIXEL_FORMAT_D24_UNORM_S8_UINT, CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT)) {
-			params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D24_UNORM_S8_UINT;
-		} else if (cf_texture_supports_format(CF_PIXEL_FORMAT_D32_FLOAT_S8_UINT, CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT)) {
-			// Metal has no D24S8; without this fallback canvases silently lose their
-			// stencil entirely (D16), breaking stencil-based rendering on macOS.
-			params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D32_FLOAT_S8_UINT;
-		}
-		params.depth_stencil_target.usage = CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT;
+	params.name = NULL;
+	params.target = cf_texture_defaults(w, h);
+	params.target.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT;
+	// Pre-fill every color target slot identically, so a multi-target canvas only needs
+	// target_count set (and usually pixel formats tweaked) rather than full param setup.
+	for (int i = 1; i < CF_MAX_CANVAS_TARGETS; ++i) params.targets[i] = params.target;
+	params.target_count = 1;
+	params.depth_stencil_enable = false;
+	params.depth_stencil_target = cf_texture_defaults(w, h);
+	params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D16_UNORM;
+	if (cf_texture_supports_format(CF_PIXEL_FORMAT_D24_UNORM_S8_UINT, CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT)) {
+		params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D24_UNORM_S8_UINT;
+	} else if (cf_texture_supports_format(CF_PIXEL_FORMAT_D32_FLOAT_S8_UINT, CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT)) {
+		// Metal has no D24S8; without this fallback canvases silently lose their
+		// stencil entirely (D16), breaking stencil-based rendering on macOS.
+		params.depth_stencil_target.pixel_format = CF_PIXEL_FORMAT_D32_FLOAT_S8_UINT;
 	}
+	params.depth_stencil_target.usage = CF_TEXTURE_USAGE_DEPTH_STENCIL_TARGET_BIT;
 	return params;
 }
 

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -1298,6 +1298,12 @@ CF_Canvas cf_gles_make_canvas(CF_CanvasParams params)
 	// depth target requests SAMPLER usage (the shadow-map case). Depth-attached canvases
 	// already have their depth: the attach target itself.
 	if (params.depth_stencil_enable && !c->attached_depth) {
+	// Attach-mode canvases size their depth to the attached face/mip, not to whatever the
+	// caller's params happen to hold (cf_canvas_defaults(0, 0) holds zero).
+	if (c->attached) {
+		params.depth_stencil_target.width = c->w;
+		params.depth_stencil_target.height = c->h;
+	}
 	CF_GL_PixelFormatInfo* depth_info = s_find_pixel_format_info(params.depth_stencil_target.pixel_format);
 	c->has_depth = depth_info && (depth_info->caps & CF_GL_FMT_CAP_DEPTH);
 	c->has_stencil = depth_info && depth_info->has_stencil && (depth_info->caps & CF_GL_FMT_CAP_STENCIL);

--- a/src/cute_model.cpp
+++ b/src/cute_model.cpp
@@ -1,0 +1,110 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include <cute_alloc.h>
+#include <cute_file_system.h>
+#include <cute_image.h>
+#include <cute_graphics.h>
+#include <cute_model.h>
+
+// CKIT_IMPLEMENTATION lives in cute_ckit.cpp; this TU only borrows the macros. String
+// handling below stays on ckit's s-api so every allocation in this file is ckit-side.
+#include <cute/ckit.h>
+#define CUTE_MODEL_IMPLEMENTATION
+#include <cute/cute_model.h>
+
+// cm_error() covers loader failures; this covers the one failure that happens before the
+// loader ever runs (the VFS read).
+static const char* s_model_error;
+
+static void* s_model_read_fn(const char* path, int* size_out, void* udata)
+{
+	// `path` is a .gltf's external URI, percent-decoded, relative to the model's directory.
+	const char* dir = (const char*)udata;
+	char* full = sfmake("%s/%s", dir, path);
+	size_t size = 0;
+	void* data = cf_fs_read_entire_file_to_memory(full, &size);
+	sfree(full);
+	*size_out = (int)size;
+	return data;
+}
+
+static void s_model_free_fn(void* data, void* udata)
+{
+	CF_UNUSED(udata);
+	cf_free(data);
+}
+
+CM_Model* cf_make_model(const char* virtual_path)
+{
+	s_model_error = NULL;
+	size_t size = 0;
+	void* data = cf_fs_read_entire_file_to_memory(virtual_path, &size);
+	if (!data) {
+		s_model_error = "Unable to read the model file from the virtual file system.";
+		return NULL;
+	}
+
+	// The model's directory, so external references resolve next to the file.
+	int dir_len = 0;
+	for (int i = 0; virtual_path[i]; ++i) {
+		if (virtual_path[i] == '/') dir_len = i;
+	}
+	char* dir = sfmake("%.*s", dir_len, virtual_path);
+
+	CM_LoadParams params = { };
+	params.read_fn = s_model_read_fn;
+	params.free_fn = s_model_free_fn;
+	params.udata = dir;
+	CM_Model* model = cm_load_ex(data, (int)size, params);
+
+	sfree(dir);
+	cf_free(data);
+	return model;
+}
+
+void cf_destroy_model(CM_Model* model)
+{
+	if (model) cm_free(model);
+}
+
+const char* cf_model_error(void)
+{
+	return s_model_error ? s_model_error : cm_error();
+}
+
+CF_Texture cf_make_texture_from_model_image(const CM_Model* model, int image_index)
+{
+	if (model && image_index >= 0 && image_index < model->image_count) {
+		CM_Image* image = model->images + image_index;
+		const uint8_t* bytes = image->data;
+		// Sniff PNG vs JPEG by magic number; glTF exporters commonly embed either.
+		bool jpg = image->size > 2 && bytes[0] == 0xFF && bytes[1] == 0xD8;
+		CF_Image img;
+		CF_Result decoded = jpg
+			? cf_image_load_jpg_from_memory(image->data, image->size, &img)
+			: cf_image_load_png_from_memory(image->data, image->size, &img);
+		if (!cf_is_error(decoded)) {
+			CF_TextureParams params = cf_texture_defaults(img.w, img.h);
+			params.filter = CF_FILTER_LINEAR;
+			params.allocate_mipmaps = true;
+			// cf_generate_mipmaps downsamples with GPU blits, which need render-target usage.
+			params.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT;
+			CF_Texture tex = cf_make_texture(params);
+			cf_texture_update(tex, img.pix, img.w * img.h * (int)sizeof(CF_Pixel));
+			cf_generate_mipmaps(tex);
+			cf_image_free(&img);
+			return tex;
+		}
+	}
+
+	// Unused slot (-1), bad index, or undecodable bytes: 1x1 white, always drawable.
+	CF_Pixel white = cf_make_pixel_rgb(255, 255, 255);
+	CF_Texture tex = cf_make_texture(cf_texture_defaults(1, 1));
+	cf_texture_update(tex, &white, (int)sizeof(white));
+	return tex;
+}

--- a/test/test_math3d.c
+++ b/test/test_math3d.c
@@ -355,6 +355,125 @@ TEST_CASE(test_m4_decompose_c) {
 	return true;
 }
 
+// Reflect, project, and slide: reflect preserves length, and project + slide must
+// reassemble the original vector (they are complementary components).
+TEST_CASE(test_v3_reflect_project_slide_c) {
+	CF_V3 n = cf_v3(0, 1, 0);
+	CF_V3 v = cf_v3(1, -1, 0);
+	REQUIRE(near_v3(cf_reflect_v3(v, n), cf_v3(1, 1, 0)));
+	REQUIRE(near_f(cf_len_v3(cf_reflect_v3(cf_v3(0.3f, -0.7f, 1.1f), n)), cf_len_v3(cf_v3(0.3f, -0.7f, 1.1f))));
+
+	// Sliding along a flat floor keeps the horizontal motion and drops the vertical.
+	REQUIRE(near_v3(cf_slide_v3(v, n), cf_v3(1, 0, 0)));
+
+	// Project onto an unnormalized direction still lands on that direction.
+	CF_V3 p = cf_project_v3(cf_v3(2, 2, 0), cf_v3(10.0f, 0, 0));
+	REQUIRE(near_v3(p, cf_v3(2, 0, 0)));
+	REQUIRE(near_v3(cf_project_v3(v, cf_v3(0.0f)), cf_v3(0.0f)));
+
+	// project + slide = original.
+	CF_V3 arbitrary = cf_v3(0.3f, -0.7f, 1.1f);
+	CF_V3 axis = cf_norm(cf_v3(1, 2, -3));
+	REQUIRE(near_v3(cf_add(cf_project_v3(arbitrary, axis), cf_slide_v3(arbitrary, axis)), arbitrary));
+	return true;
+}
+
+// cf_orthonormal_basis: (x, y, n) must be right-handed and orthonormal for any unit n,
+// including the branch-hazard normals straight up and straight down.
+TEST_CASE(test_orthonormal_basis_c) {
+	CF_V3 normals[] = {
+		{ 0, 0, 1 }, { 0, 0, -1 }, { 1, 0, 0 }, { 0, -1, 0 },
+		{ 0.5345225f, 0.2672612f, -0.8017837f },
+	};
+	for (int i = 0; i < 5; ++i) {
+		CF_V3 n = normals[i];
+		CF_V3 x, y;
+		cf_orthonormal_basis(n, &x, &y);
+		REQUIRE(near_f(cf_len_v3(x), 1.0f));
+		REQUIRE(near_f(cf_len_v3(y), 1.0f));
+		REQUIRE(near_f(cf_dot(x, y), 0.0f));
+		REQUIRE(near_f(cf_dot(x, n), 0.0f));
+		REQUIRE(near_f(cf_dot(y, n), 0.0f));
+		REQUIRE(near_v3(cf_cross(x, y), n));
+	}
+	return true;
+}
+
+// cf_quat_inverse must undo a rotation even for non-unit quaternions, where the conjugate alone
+// is off by the squared length.
+TEST_CASE(test_quat_inverse_c) {
+	CF_Quat q = cf_quat_from_axis_angle(cf_norm(cf_v3(1, -2, 0.5f)), 0.9f);
+	CF_V3 p = cf_v3(0.3f, -0.7f, 1.1f);
+	REQUIRE(near_v3(cf_mul(cf_mul_q(q, cf_quat_inverse(q)), p), p));
+
+	// Scale the quaternion: rotation is unchanged, and the inverse must still cancel exactly.
+	CF_Quat big = cf_quat(q.x * 3.0f, q.y * 3.0f, q.z * 3.0f, q.w * 3.0f);
+	CF_Quat prod = cf_mul_q(big, cf_quat_inverse(big));
+	REQUIRE(near_f(prod.x, 0.0f) && near_f(prod.y, 0.0f) && near_f(prod.z, 0.0f) && near_f(prod.w, 1.0f));
+
+	// Zero quaternion has no inverse; identity beats NaNs.
+	CF_Quat zero_inv = cf_quat_inverse(cf_quat(0, 0, 0, 0));
+	REQUIRE(near_f(zero_inv.w, 1.0f));
+	return true;
+}
+
+// cf_quat_nlerp shares slerp's endpoints and its shortest-arc choice; only the pacing differs.
+TEST_CASE(test_quat_nlerp_c) {
+	CF_Quat a = cf_quat_identity();
+	CF_Quat b = cf_quat_from_axis_angle(cf_v3(0, 1, 0), CF_PI * 0.5f);
+	CF_V3 x = cf_v3(1, 0, 0);
+
+	REQUIRE(near_v3(cf_mul(cf_quat_nlerp(a, b, 0.0f), x), x));
+	REQUIRE(near_v3(cf_mul(cf_quat_nlerp(a, b, 1.0f), x), cf_mul(b, x)));
+
+	// Halfway between identity and a 90deg turn is exactly 45deg for nlerp too (symmetry).
+	REQUIRE(near_v3(cf_mul(cf_quat_nlerp(a, b, 0.5f), x), cf_v3(0.7071068f, 0.0f, -0.7071068f)));
+
+	// The double-cover: nlerp against -b must take the same short arc, not spin the long way.
+	CF_Quat neg_b = cf_quat(-b.x, -b.y, -b.z, -b.w);
+	REQUIRE(near_v3(cf_mul(cf_quat_nlerp(a, neg_b, 0.5f), x), cf_mul(cf_quat_nlerp(a, b, 0.5f), x)));
+	return true;
+}
+
+// cf_quat_to_axis_angle inverts cf_quat_from_axis_angle, and survives the identity.
+TEST_CASE(test_quat_to_axis_angle_c) {
+	CF_V3 axis_in = cf_norm(cf_v3(1, 2, -1));
+	float angle_in = 1.3f;
+	CF_V3 axis;
+	float angle;
+	cf_quat_to_axis_angle(cf_quat_from_axis_angle(axis_in, angle_in), &axis, &angle);
+	REQUIRE(near_v3(axis, axis_in));
+	REQUIRE(near_f(angle, angle_in));
+
+	cf_quat_to_axis_angle(cf_quat_identity(), &axis, &angle);
+	REQUIRE(near_f(angle, 0.0f));
+	REQUIRE(near_f(cf_len_v3(axis), 1.0f));
+
+	// NULL outputs are allowed.
+	cf_quat_to_axis_angle(cf_quat_from_axis_angle(axis_in, angle_in), NULL, NULL);
+	return true;
+}
+
+// cf_m4_from_trs must match composing the three matrices by hand, and round-trip
+// through cf_m4_decompose.
+TEST_CASE(test_m4_from_trs_c) {
+	CF_V3 t = cf_v3(3, -4, 5);
+	CF_Quat r = cf_quat_from_axis_angle(cf_norm(cf_v3(1, 2, 3)), 1.1f);
+	CF_V3 s = cf_v3(2, 3, 4);
+
+	CF_M4x4 direct = cf_m4_from_trs(t, r, s);
+	CF_M4x4 composed = cf_mul(cf_mul(cf_m4_translate(t), cf_quat_to_m4(r)), cf_m4_scale(s));
+	for (int k = 0; k < 16; ++k) REQUIRE(near_f(direct.elements[k], composed.elements[k]));
+
+	CF_V3 dt, ds;
+	CF_Quat dr;
+	cf_m4_decompose(direct, &dt, &dr, &ds);
+	REQUIRE(near_v3(dt, t));
+	REQUIRE(near_v3(ds, s));
+	REQUIRE(near_v3(cf_mul(dr, cf_v3(1, 0, 0)), cf_mul(r, cf_v3(1, 0, 0))));
+	return true;
+}
+
 // cf_quat_from_basis round-trips against cf_quat_to_m4's columns.
 TEST_CASE(test_quat_from_basis_c) {
 	CF_Quat r = cf_quat_from_axis_angle(cf_norm(cf_v3(-2, 1, 0.5f)), 2.3f);
@@ -388,5 +507,11 @@ TEST_SUITE(test_math3d_c) {
 	RUN_TEST_CASE(test_mul_macros_c);
 	RUN_TEST_CASE(test_quat_from_to_c);
 	RUN_TEST_CASE(test_m4_decompose_c);
+	RUN_TEST_CASE(test_v3_reflect_project_slide_c);
+	RUN_TEST_CASE(test_orthonormal_basis_c);
+	RUN_TEST_CASE(test_quat_inverse_c);
+	RUN_TEST_CASE(test_quat_nlerp_c);
+	RUN_TEST_CASE(test_quat_to_axis_angle_c);
+	RUN_TEST_CASE(test_m4_from_trs_c);
 	RUN_TEST_CASE(test_quat_from_basis_c);
 }

--- a/test/test_math3d.cpp
+++ b/test/test_math3d.cpp
@@ -92,6 +92,41 @@ TEST_CASE(test_quat_operators_cpp) {
 	return true;
 }
 
+// The new helper overloads: each unsuffixed C++ name must reach its 3d backend, without
+// disturbing the 2d overloads that share the name (reflect, project).
+TEST_CASE(test_helper_overloads_cpp) {
+	// 3d reflect resolves alongside 2d reflect.
+	REQUIRE(near_v3(cf_reflect(V3(1, -1, 0), V3(0, 1, 0)), V3(1, 1, 0)));
+	v2 r2 = cf_reflect(V2(1, -1), V2(0, 1));
+	REQUIRE(near_f(r2.x, 1.0f) && near_f(r2.y, 1.0f));
+	REQUIRE(near_v3(reflect(V3(1, -1, 0), V3(0, 1, 0)), V3(1, 1, 0)));
+
+	// project(v3, v3) overloads next to project(Halfspace, v2).
+	REQUIRE(near_v3(cf_project(V3(2, 2, 0), V3(10, 0, 0)), V3(2, 0, 0)));
+	REQUIRE(near_v3(project(V3(2, 2, 0), V3(10, 0, 0)), V3(2, 0, 0)));
+	REQUIRE(near_v3(cf_slide(V3(1, -1, 0), V3(0, 1, 0)), V3(1, 0, 0)));
+	REQUIRE(near_v3(slide(V3(1, -1, 0), V3(0, 1, 0)), V3(1, 0, 0)));
+
+	v3 x, y;
+	orthonormal_basis(V3(0, 1, 0), &x, &y);
+	REQUIRE(near_v3(cross(x, y), V3(0, 1, 0)));
+
+	quat q = quat_from_axis_angle(norm(V3(1, -2, 0.5f)), 0.9f);
+	v3 p = V3(0.3f, -0.7f, 1.1f);
+	REQUIRE(near_v3((q * inverse(q)) * p, p));
+	REQUIRE(near_v3(nlerp(quat_identity(), q, 1.0f) * p, q * p));
+
+	v3 axis;
+	float angle;
+	quat_to_axis_angle(q, &axis, &angle);
+	REQUIRE(near_f(angle, 0.9f));
+
+	m4 direct = m4_from_trs(V3(3, -4, 5), q, V3(2, 3, 4));
+	m4 composed = m4_translate(V3(3, -4, 5)) * to_m4(q) * m4_scale(V3(2, 3, 4));
+	for (int i = 0; i < 16; ++i) REQUIRE(near_f(direct.elements[i], composed.elements[i]));
+	return true;
+}
+
 // Same convention checks as the C suite, through the C++ names -- these are what a C++ user
 // actually calls, and a wrapper could plausibly be wired to the wrong function.
 TEST_CASE(test_projection_cpp) {
@@ -216,6 +251,7 @@ TEST_SUITE(test_math3d) {
 	RUN_TEST_CASE(test_v3_operators_cpp);
 	RUN_TEST_CASE(test_m4_operators_cpp);
 	RUN_TEST_CASE(test_quat_operators_cpp);
+	RUN_TEST_CASE(test_helper_overloads_cpp);
 	RUN_TEST_CASE(test_projection_cpp);
 	RUN_TEST_CASE(test_geometry_raycasts_cpp);
 	RUN_TEST_CASE(test_geometry_overlaps_cpp);

--- a/test/test_model.cpp
+++ b/test/test_model.cpp
@@ -6,11 +6,11 @@
 */
 
 #include "test_harness.h"
+#include "test_app_shared.h"
 
 #include <cute.h>
 #include <cute/ckit.h>
-#define CUTE_MODEL_IMPLEMENTATION
-#include <cute/cute_model.h>
+#include <cute/cute_model.h> // Implementation compiled into CF (src/cute_model.cpp).
 
 // cute_model loader tests: pure CPU, no app or GPU. A handcrafted .gltf with an external
 // binary buffer and image exercises the read callback (with percent-decoded URIs), the
@@ -384,9 +384,62 @@ TEST_CASE(test_model_malformed_rejected)
 	return true;
 }
 
+// The CF-side glue (include/cute_model.h): cf_make_model resolves a .gltf's external
+// references through the virtual file system -- including the percent-encoded URI, which
+// must land on the on-disk file with the literal space -- and
+// cf_make_texture_from_model_image turns an embedded image into a ready-to-sample texture.
+TEST_CASE(test_model_vfs_load)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+
+	// Build the model + its sidecar files under the write directory.
+	cf_fs_set_write_directory(cf_fs_get_base_directory());
+	cf_fs_create_directory("/model_vfs_test");
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/model_vfs_test/model.gltf", s_gltf)));
+
+	int bin_size = 0;
+	void* bin = s_read("test data.bin", &bin_size, NULL);
+	REQUIRE(!cf_is_error(cf_fs_write_entire_buffer_to_file("/model_vfs_test/test data.bin", bin, (size_t)bin_size)));
+
+	// A real png in the image slot, so the texture path exercises an actual decode.
+	CF_Pixel px[16];
+	for (int i = 0; i < 16; ++i) px[i] = cf_make_pixel_rgb(255, 0, 0);
+	CF_Image img;
+	img.w = 4;
+	img.h = 4;
+	img.pix = px;
+	REQUIRE(!cf_is_error(cf_image_save_png("/model_vfs_test/tex.png", &img)));
+
+	CM_Model* model = cf_make_model("/model_vfs_test/model.gltf");
+	REQUIRE(model);
+	REQUIRE(model->mesh_count == 1);
+	REQUIRE(model->meshes[0].primitives[0].vertex_count == 4);
+	REQUIRE(model->image_count == 1);
+	REQUIRE(model->images[0].size > 8); // The real png bytes round-tripped through the VFS.
+
+	CF_Texture tex = cf_make_texture_from_model_image(model, 0);
+	REQUIRE(tex.id);
+	cf_destroy_texture(tex);
+
+	// An unused slot (-1) falls back to 1x1 white instead of failing.
+	CF_Texture white = cf_make_texture_from_model_image(model, -1);
+	REQUIRE(white.id);
+	cf_destroy_texture(white);
+
+	cf_destroy_model(model);
+
+	// A missing file reports through cf_model_error.
+	REQUIRE(!cf_make_model("/model_vfs_test/nope.glb"));
+	REQUIRE(cf_model_error()[0]);
+
+	test_destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_model)
 {
 	RUN_TEST_CASE(test_model_gltf_external);
 	RUN_TEST_CASE(test_model_interleave);
 	RUN_TEST_CASE(test_model_malformed_rejected);
+	RUN_TEST_CASE(test_model_vfs_load);
 }


### PR DESCRIPTION
Fallout from a shipping-a-3D-game review of the new 3D API. Four commits, reviewable independently:

## math3d helpers
The small functions gameplay code reaches for first: `cf_m4_from_trs` (decompose finally has its composer), `cf_quat_inverse`, `cf_quat_nlerp`, `cf_quat_to_axis_angle`, `cf_reflect_v3`/`cf_project_v3`/`cf_slide_v3` (the move-and-slide primitive), and `cf_orthonormal_basis` (branchless Duff et al., right-handed, stable for straight-up/straight-down). C++ overloads + `Cute::` wrappers, tested in both the C `_Generic` suite and the C++ overload suite.

## `cf_make_model`: public VFS glue for cute_model.h
Every consumer wrote the same ~50 lines: VFS read, a `read_fn` resolving external URIs, PNG/JPEG sniff + decode. That ships now as `include/cute_model.h`: `cf_make_model` / `cf_destroy_model` / `cf_model_error` / `cf_make_texture_from_model_image` (decode + upload + full mip chain, white-fallback on `-1`). CF compiles the loader implementation, so consumers include the headers and never define `CUTE_MODEL_IMPLEMENTATION`; the library header grows `CM_API` (wired like `CK_API`) and `extern C` guards so the DLL exports unmangled symbols. `model3d.c` consumes it; `test_model` gains an end-to-end VFS case (percent-encoded external URI included).

## Canvas defaults + a documented crash
`cf_canvas_defaults(0, 0)` now fills formats/usages regardless of size, so attach-mode canvases no longer pass a fake size just to get the depth format negotiated (the fireflies workaround + comment are gone). The GLES backend gains the attach-size depth override SDL_GPU already had.

Found along the way: **the Shipping 3D mip recipe crashed as written** -- `cf_generate_mipmaps` downsamples via GPU blits, which needs `COLOR_TARGET` usage the recipe never requested (no test covered it; the new `test_model_vfs_load` now exercises the path). Recipe and header remark fixed.

## Fireflies: the showcase now uses its own headline feature
The world bakes into per-chunk `CF_DrawList`s once; all three passes cull chunk bounds and replay -- one instanced draw per visible chunk per pass, instead of re-walking every block three times a frame. **Verified pixel-identical to the immediate path** (deterministic `--auto --record` run, frame-59 diff: 0 pixels).

Getting there surfaced a contract subtlety now documented in the header + topic page: **ambient uniform capture is by name at record time** -- bake at startup before any uniform exists and replays bind no uniforms at all. Worth a design pass later: should `cf_draw_list` bind *all* live ambient uniforms at replay rather than only captured names? Same open question for render state, which is not a free variable today (the sample freezes cull-off into its bakes since the moment pass needs it and closed boxes don't care).

Also: dead `look_dx` assignment removed, EVSM constant deduped across C/GLSL, screenshot/record share one readback helper, inert fullscreen-triangle floats dropped.

## Verification
- Full test suite: 321/321 (includes new math + VFS model cases).
- `docsparser`: zero warnings against the empty baseline.
- `fireflies` + `model3d` screenshot harnesses verified visually; fireflies pixel-diffed against master.