### PR TITLE
Use CF_STATIC_ASSERT instead of bare static_assert

### DIFF
--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -23,7 +23,7 @@ using namespace Cute;
 // SDL_GPUSampleCount -- that's only correct because both enums index 1x/2x/4x/8x as 0/1/2/3
 // in the same order. Catch it at compile time if SDL ever renumbers its enum, rather than
 // silently mis-sampling MSAA targets again.
-static_assert(
+CF_STATIC_ASSERT(
 	(int)CF_SAMPLE_COUNT_1 == (int)SDL_GPU_SAMPLECOUNT_1 &&
 	(int)CF_SAMPLE_COUNT_2 == (int)SDL_GPU_SAMPLECOUNT_2 &&
 	(int)CF_SAMPLE_COUNT_4 == (int)SDL_GPU_SAMPLECOUNT_4 &&

--- a/src/cute_json.cpp
+++ b/src/cute_json.cpp
@@ -230,18 +230,18 @@ CF_JVal cf_json_array_get(CF_JVal val_handle, int index)
 }
 
 // Make sure memory layout is identical.
-static_assert(sizeof(CF_JIter) == sizeof(yyjson_mut_arr_iter));
-static_assert(offsetof(CF_JIter, index) == offsetof(yyjson_mut_arr_iter, idx));
-static_assert(offsetof(CF_JIter, count) == offsetof(yyjson_mut_arr_iter, max));
-static_assert(offsetof(CF_JIter, val) == offsetof(yyjson_mut_arr_iter, cur));
-static_assert(offsetof(CF_JIter, prev) == offsetof(yyjson_mut_arr_iter, pre));
-static_assert(offsetof(CF_JIter, parent) == offsetof(yyjson_mut_arr_iter, arr));
-static_assert(sizeof(CF_JIter) == sizeof(yyjson_mut_obj_iter));
-static_assert(offsetof(CF_JIter, index) == offsetof(yyjson_mut_obj_iter, idx));
-static_assert(offsetof(CF_JIter, count) == offsetof(yyjson_mut_obj_iter, max));
-static_assert(offsetof(CF_JIter, val) == offsetof(yyjson_mut_obj_iter, cur));
-static_assert(offsetof(CF_JIter, prev) == offsetof(yyjson_mut_obj_iter, pre));
-static_assert(offsetof(CF_JIter, parent) == offsetof(yyjson_mut_obj_iter, obj));
+CF_STATIC_ASSERT(sizeof(CF_JIter) == sizeof(yyjson_mut_arr_iter), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, index) == offsetof(yyjson_mut_arr_iter, idx), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, count) == offsetof(yyjson_mut_arr_iter, max), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, val) == offsetof(yyjson_mut_arr_iter, cur), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, prev) == offsetof(yyjson_mut_arr_iter, pre), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, parent) == offsetof(yyjson_mut_arr_iter, arr), "CF_JIter must match yyjson_mut_arr_iter's layout");
+CF_STATIC_ASSERT(sizeof(CF_JIter) == sizeof(yyjson_mut_obj_iter), "CF_JIter must match yyjson_mut_obj_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, index) == offsetof(yyjson_mut_obj_iter, idx), "CF_JIter must match yyjson_mut_obj_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, count) == offsetof(yyjson_mut_obj_iter, max), "CF_JIter must match yyjson_mut_obj_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, val) == offsetof(yyjson_mut_obj_iter, cur), "CF_JIter must match yyjson_mut_obj_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, prev) == offsetof(yyjson_mut_obj_iter, pre), "CF_JIter must match yyjson_mut_obj_iter's layout");
+CF_STATIC_ASSERT(offsetof(CF_JIter, parent) == offsetof(yyjson_mut_obj_iter, obj), "CF_JIter must match yyjson_mut_obj_iter's layout");
 
 CF_JIter cf_json_iter(CF_JVal val_handle)
 {


### PR DESCRIPTION
Keeps compile-time layout/enum checks consistent with the project's static-assert macro instead of calling static_assert directly. The cute_json.cpp checks had no failure message before; added one describing the layout invariant each assert verifies.