### PR TITLE
Add CF_SANITIZE CMake option for ASan+UBSan builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(CF_FRAMEWORK_STATIC "Build static library for Cute Framework." ON)
 option(CF_CUTE_SHADERC "Build cute-shaderc, an offline shader compiler." ON)
 option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
+option(CF_SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer (Clang/GCC)." OFF)
 
 # Make sure all libraries are placed into the same output folder.
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -296,6 +297,17 @@ if(EMSCRIPTEN)
 	target_compile_options(cute-box3d PRIVATE -msimd128 -msse2)
 endif()
 target_sources(cute PRIVATE $<TARGET_OBJECTS:cute-box3d>)
+
+if(CF_SANITIZE)
+	if(MSVC OR EMSCRIPTEN)
+		message(WARNING "CF_SANITIZE is not supported with MSVC or Emscripten; ignoring.")
+	else()
+		# PUBLIC so the flags propagate to executables linking against cute (tests,
+		# samples) without instrumenting vendored SDL3, which is built separately.
+		target_compile_options(cute PUBLIC -fsanitize=address,undefined -fno-omit-frame-pointer)
+		target_link_options(cute PUBLIC -fsanitize=address,undefined)
+	endif()
+endif()
 
 if(EMSCRIPTEN)
 	message(STATUS "Configuring CF for Web (Emscripten)")


### PR DESCRIPTION
Cute Framework has no reproducible way to build with sanitizers today, so a batch of framework/vendored-library sanitizer findings currently has no test that would catch them. This wires `-fsanitize=address,undefined` into the `cute` target (PUBLIC, so it propagates to tests and samples) behind a new opt-in option, leaving vendored SDL3 uninstrumented.

This is the first of a small stack fixing the 5 root causes that build turned up (67 sanitizer events total): #cmake-option (this PR), CF_OFFSET_OF, color clamping, atlas cache alignment, and sivalid. Each subsequent PR is stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jk78XZ1Lv4TNx98XEfM6Sn