### PR TITLE
Swap CF_OFFSET_OF's manual null-deref idiom for standard offsetof

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(CF_FRAMEWORK_STATIC "Build static library for Cute Framework." ON)
 option(CF_CUTE_SHADERC "Build cute-shaderc, an offline shader compiler." ON)
 option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
+option(CF_SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer (Clang/GCC)." OFF)
 
 # Make sure all libraries are placed into the same output folder.
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -296,6 +297,17 @@ if(EMSCRIPTEN)
 	target_compile_options(cute-box3d PRIVATE -msimd128 -msse2)
 endif()
 target_sources(cute PRIVATE $<TARGET_OBJECTS:cute-box3d>)
+
+if(CF_SANITIZE)
+	if(MSVC OR EMSCRIPTEN)
+		message(WARNING "CF_SANITIZE is not supported with MSVC or Emscripten; ignoring.")
+	else()
+		# PUBLIC so the flags propagate to executables linking against cute (tests,
+		# samples) without instrumenting vendored SDL3, which is built separately.
+		target_compile_options(cute PUBLIC -fsanitize=address,undefined -fno-omit-frame-pointer)
+		target_link_options(cute PUBLIC -fsanitize=address,undefined)
+	endif()
+endif()
 
 if(EMSCRIPTEN)
 	message(STATUS "Configuring CF for Web (Emscripten)")

--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -62,6 +62,7 @@
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifndef NOMINMAX
 #	define NOMINMAX WINDOWS_IS_ANNOYING_AINT_IT
@@ -116,7 +117,7 @@
 #define CF_STATIC_ASSERT(condition, error_message_string) static_assert(condition, error_message_string)
 #define CF_STRINGIZE_INTERNAL(...) #__VA_ARGS__
 #define CF_STRINGIZE(...) CF_STRINGIZE_INTERNAL(__VA_ARGS__)
-#define CF_OFFSET_OF(T, member) ((int)((uintptr_t)(&(((T*)0)->member))))
+#define CF_OFFSET_OF(T, member) ((int)offsetof(T, member))
 #define CF_DEBUG_PRINTF(...)
 #define CF_ALIGN_TRUNCATE(v, n) ((v) & ~((n) - 1))
 #define CF_ALIGN_FORWARD(v, n) CF_ALIGN_TRUNCATE((v) + (n) - 1, (n))

--- a/test/test_doubly_list.cpp
+++ b/test/test_doubly_list.cpp
@@ -11,6 +11,36 @@
 
 using namespace Cute;
 
+/* CF_OFFSET_OF must be a compile-time constant expression -- CF_LIST_NODE/CF_LIST_HOST
+ * are used inside CF_STATIC_ASSERT-able contexts, and the intrusive-list pattern from
+ * cute_doubly_list.h's own docs relies on offsets being computed correctly at compile time. */
+struct CF_OffsetOfTestStruct
+{
+	int a;
+	float b;
+	CF_ListNode node;
+};
+CF_STATIC_ASSERT(CF_OFFSET_OF(CF_OffsetOfTestStruct, node) == offsetof(CF_OffsetOfTestStruct, node), "CF_OFFSET_OF must match the standard offsetof.");
+CF_STATIC_ASSERT(CF_OFFSET_OF(CF_OffsetOfTestStruct, a) == 0, "CF_OFFSET_OF must report the first member at offset 0.");
+
+/* Round-trip a host struct through CF_LIST_NODE/CF_LIST_HOST, per the documented example. */
+TEST_CASE(test_doubly_list_offset_of_node_host_roundtrip)
+{
+	CF_OffsetOfTestStruct s;
+	s.a = 42;
+	s.b = 3.14f;
+	cf_list_init_node(&s.node);
+
+	CF_ListNode* node = CF_LIST_NODE(CF_OffsetOfTestStruct, node, &s);
+	REQUIRE(node == &s.node);
+
+	CF_OffsetOfTestStruct* host = CF_LIST_HOST(CF_OffsetOfTestStruct, node, node);
+	REQUIRE(host == &s);
+	REQUIRE(host->a == 42);
+
+	return true;
+}
+
 /* Make list of three elements, perform all operations on it, assert correctness. */
 TEST_CASE(test_doubly_list_operations)
 {
@@ -66,5 +96,6 @@ TEST_CASE(test_doubly_list_operations)
 
 TEST_SUITE(test_doubly_list)
 {
+	RUN_TEST_CASE(test_doubly_list_offset_of_node_host_roundtrip);
 	RUN_TEST_CASE(test_doubly_list_operations);
 }


### PR DESCRIPTION
Stacked on #566 — the diff here will include that PR's commit until it merges, at which point GitHub recomputes this PR down to just the one commit below.

`CF_OFFSET_OF(T, member)` computed its result via `&(((T*)0)->member)`, the pre-C++11 offsetof workaround. It's not a constant expression, so UBSan flags every use (`CF_LIST_NODE`/`CF_LIST_HOST`, vertex attribute setup in `cute_draw.cpp`/`cute_draw3d.cpp`) as a null-pointer dereference even though no memory is ever touched -- 21 of the 67 sanitizer events in the discovery run traced to this one macro. Standard `offsetof` is a real constant expression compilers special-case, so it doesn't trip the check, and it now lets `CF_OFFSET_OF` be used in `CF_STATIC_ASSERT`.

Added a `CF_STATIC_ASSERT`-based regression test in `test_doubly_list.cpp`: it fails to *compile* against the old macro (not a constant expression) and compiles cleanly against `offsetof`.

Note: `CF_LIST_NODE`/`CF_LIST_HOST` take a user-supplied `T`, so C++ code using them on a non-standard-layout type may now see `-Winvalid-offsetof` where it previously compiled silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jk78XZ1Lv4TNx98XEfM6Sn