### PR TITLE
Clamp float components before the uint8 cast in pixel/color conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 option(CF_FRAMEWORK_STATIC "Build static library for Cute Framework." ON)
 option(CF_CUTE_SHADERC "Build cute-shaderc, an offline shader compiler." ON)
 option(CF_FRAMEWORK_APPLE_FRAMEWORK "Build CF libraries as Apple Framework" OFF)
+option(CF_SANITIZE "Build with AddressSanitizer + UndefinedBehaviorSanitizer (Clang/GCC)." OFF)
 
 # Make sure all libraries are placed into the same output folder.
 if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -296,6 +297,17 @@ if(EMSCRIPTEN)
 	target_compile_options(cute-box3d PRIVATE -msimd128 -msse2)
 endif()
 target_sources(cute PRIVATE $<TARGET_OBJECTS:cute-box3d>)
+
+if(CF_SANITIZE)
+	if(MSVC OR EMSCRIPTEN)
+		message(WARNING "CF_SANITIZE is not supported with MSVC or Emscripten; ignoring.")
+	else()
+		# PUBLIC so the flags propagate to executables linking against cute (tests,
+		# samples) without instrumenting vendored SDL3, which is built separately.
+		target_compile_options(cute PUBLIC -fsanitize=address,undefined -fno-omit-frame-pointer)
+		target_link_options(cute PUBLIC -fsanitize=address,undefined)
+	endif()
+endif()
 
 if(EMSCRIPTEN)
 	message(STATUS "Configuring CF for Web (Emscripten)")

--- a/include/cute_color.h
+++ b/include/cute_color.h
@@ -169,7 +169,7 @@ CF_INLINE CF_Color cf_make_color_hex_string(const char* hex) {
  * @remarks  The alpha component is set to 255.
  * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
  */
-CF_INLINE CF_Pixel cf_make_pixel_rgb_f(float r, float g, float b) { CF_Pixel p; p.colors.r = (uint8_t)(r * 255.0f); p.colors.g = (uint8_t)(g * 255.0f); p.colors.b = (uint8_t)(b * 255.0f); p.colors.a = 255; return p; }
+CF_INLINE CF_Pixel cf_make_pixel_rgb_f(float r, float g, float b) { CF_Pixel p; p.colors.r = (uint8_t)(cf_clamp01(r) * 255.0f); p.colors.g = (uint8_t)(cf_clamp01(g) * 255.0f); p.colors.b = (uint8_t)(cf_clamp01(b) * 255.0f); p.colors.a = 255; return p; }
 
 /**
  * @function cf_make_pixel_rgba_f
@@ -181,7 +181,7 @@ CF_INLINE CF_Pixel cf_make_pixel_rgb_f(float r, float g, float b) { CF_Pixel p; 
  * @param    a          The alpha component from 0.0f to 1.0f.
  * @related  CF_Pixel cf_make_pixel_rgb_f cf_make_pixel_rgba_f cf_make_pixel_rgb cf_make_pixel_rgba cf_make_pixel_hex cf_make_pixel_hex_string
  */
-CF_INLINE CF_Pixel cf_make_pixel_rgba_f(float r, float g, float b, float a) { CF_Pixel p; p.colors.r = (uint8_t)(r * 255.0f); p.colors.g = (uint8_t)(g * 255.0f); p.colors.b = (uint8_t)(b * 255.0f); p.colors.a = (uint8_t)(a * 255.0f); return p; }
+CF_INLINE CF_Pixel cf_make_pixel_rgba_f(float r, float g, float b, float a) { CF_Pixel p; p.colors.r = (uint8_t)(cf_clamp01(r) * 255.0f); p.colors.g = (uint8_t)(cf_clamp01(g) * 255.0f); p.colors.b = (uint8_t)(cf_clamp01(b) * 255.0f); p.colors.a = (uint8_t)(cf_clamp01(a) * 255.0f); return p; }
 
 /**
  * @function cf_make_pixel_rgb
@@ -640,7 +640,7 @@ CF_INLINE char* cf_pixel_to_string(CF_Pixel p) { char* s = NULL; return shex(s, 
  * @param    c          The color.
  * @related  cf_color_to_pixel cf_color_to_int_rgb cf_color_to_int_rgba cf_color_to_string
  */
-CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c) { CF_Pixel p; p.colors.r = (uint8_t)(c.r * 255.0f); p.colors.g = (uint8_t)(c.g * 255.0f); p.colors.b = (uint8_t)(c.b * 255.0f); p.colors.a = (uint8_t)(c.a * 255.0f); return p; }
+CF_INLINE CF_Pixel cf_color_to_pixel(CF_Color c) { CF_Pixel p; p.colors.r = (uint8_t)(cf_clamp01(c.r) * 255.0f); p.colors.g = (uint8_t)(cf_clamp01(c.g) * 255.0f); p.colors.b = (uint8_t)(cf_clamp01(c.b) * 255.0f); p.colors.a = (uint8_t)(cf_clamp01(c.a) * 255.0f); return p; }
 
 /**
  * @function cf_color_to_int_rgb

--- a/include/cute_defines.h
+++ b/include/cute_defines.h
@@ -62,6 +62,7 @@
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifndef NOMINMAX
 #	define NOMINMAX WINDOWS_IS_ANNOYING_AINT_IT
@@ -116,7 +117,7 @@
 #define CF_STATIC_ASSERT(condition, error_message_string) static_assert(condition, error_message_string)
 #define CF_STRINGIZE_INTERNAL(...) #__VA_ARGS__
 #define CF_STRINGIZE(...) CF_STRINGIZE_INTERNAL(__VA_ARGS__)
-#define CF_OFFSET_OF(T, member) ((int)((uintptr_t)(&(((T*)0)->member))))
+#define CF_OFFSET_OF(T, member) ((int)offsetof(T, member))
 #define CF_DEBUG_PRINTF(...)
 #define CF_ALIGN_TRUNCATE(v, n) ((v) & ~((n) - 1))
 #define CF_ALIGN_FORWARD(v, n) CF_ALIGN_TRUNCATE((v) + (n) - 1, (n))

--- a/test/test_color.cpp
+++ b/test/test_color.cpp
@@ -152,6 +152,17 @@ TEST_CASE(test_make_pixel_rgb_f)
 	REQUIRE(p.colors.b == 0);
 	REQUIRE(p.colors.a == 255);
 
+	// Out-of-[0,1]-range inputs must clamp, not overflow the float->uint8 cast (UB otherwise).
+	CF_Pixel clamped_hi = cf_make_pixel_rgb_f(2.0f, 100.0f, 1.0f);
+	REQUIRE(clamped_hi.colors.r == 255);
+	REQUIRE(clamped_hi.colors.g == 255);
+	REQUIRE(clamped_hi.colors.b == 255);
+
+	CF_Pixel clamped_lo = cf_make_pixel_rgb_f(-1.0f, -100.0f, 0.0f);
+	REQUIRE(clamped_lo.colors.r == 0);
+	REQUIRE(clamped_lo.colors.g == 0);
+	REQUIRE(clamped_lo.colors.b == 0);
+
 	return true;
 }
 
@@ -162,6 +173,19 @@ TEST_CASE(test_make_pixel_rgba_f)
 	REQUIRE(p.colors.g == 127);
 	REQUIRE(p.colors.b == 0);
 	REQUIRE(p.colors.a == 63);
+
+	// Out-of-[0,1]-range inputs must clamp, not overflow the float->uint8 cast (UB otherwise).
+	CF_Pixel clamped_hi = cf_make_pixel_rgba_f(2.0f, 100.0f, 1.0f, 5.0f);
+	REQUIRE(clamped_hi.colors.r == 255);
+	REQUIRE(clamped_hi.colors.g == 255);
+	REQUIRE(clamped_hi.colors.b == 255);
+	REQUIRE(clamped_hi.colors.a == 255);
+
+	CF_Pixel clamped_lo = cf_make_pixel_rgba_f(-1.0f, -100.0f, 0.0f, -5.0f);
+	REQUIRE(clamped_lo.colors.r == 0);
+	REQUIRE(clamped_lo.colors.g == 0);
+	REQUIRE(clamped_lo.colors.b == 0);
+	REQUIRE(clamped_lo.colors.a == 0);
 
 	return true;
 }
@@ -661,6 +685,16 @@ TEST_CASE(test_color_to_pixel)
 	REQUIRE(p.colors.g == 127);
 	REQUIRE(p.colors.b == 0);
 	REQUIRE(p.colors.a == 63);
+
+	// cf_make_color_rgba_f does not clamp, so a color built out-of-[0,1]-range
+	// (e.g. from HDR math or an unclamped blend) must still clamp on conversion,
+	// not overflow the float->uint8 cast (UB otherwise).
+	CF_Color out_of_range = cf_make_color_rgba_f(4.0f, -2.0f, 1.0f, 10.0f);
+	CF_Pixel clamped = cf_color_to_pixel(out_of_range);
+	REQUIRE(clamped.colors.r == 255);
+	REQUIRE(clamped.colors.g == 0);
+	REQUIRE(clamped.colors.b == 255);
+	REQUIRE(clamped.colors.a == 255);
 
 	return true;
 }

--- a/test/test_doubly_list.cpp
+++ b/test/test_doubly_list.cpp
@@ -11,6 +11,36 @@
 
 using namespace Cute;
 
+/* CF_OFFSET_OF must be a compile-time constant expression -- CF_LIST_NODE/CF_LIST_HOST
+ * are used inside CF_STATIC_ASSERT-able contexts, and the intrusive-list pattern from
+ * cute_doubly_list.h's own docs relies on offsets being computed correctly at compile time. */
+struct CF_OffsetOfTestStruct
+{
+	int a;
+	float b;
+	CF_ListNode node;
+};
+CF_STATIC_ASSERT(CF_OFFSET_OF(CF_OffsetOfTestStruct, node) == offsetof(CF_OffsetOfTestStruct, node), "CF_OFFSET_OF must match the standard offsetof.");
+CF_STATIC_ASSERT(CF_OFFSET_OF(CF_OffsetOfTestStruct, a) == 0, "CF_OFFSET_OF must report the first member at offset 0.");
+
+/* Round-trip a host struct through CF_LIST_NODE/CF_LIST_HOST, per the documented example. */
+TEST_CASE(test_doubly_list_offset_of_node_host_roundtrip)
+{
+	CF_OffsetOfTestStruct s;
+	s.a = 42;
+	s.b = 3.14f;
+	cf_list_init_node(&s.node);
+
+	CF_ListNode* node = CF_LIST_NODE(CF_OffsetOfTestStruct, node, &s);
+	REQUIRE(node == &s.node);
+
+	CF_OffsetOfTestStruct* host = CF_LIST_HOST(CF_OffsetOfTestStruct, node, node);
+	REQUIRE(host == &s);
+	REQUIRE(host->a == 42);
+
+	return true;
+}
+
 /* Make list of three elements, perform all operations on it, assert correctness. */
 TEST_CASE(test_doubly_list_operations)
 {
@@ -66,5 +96,6 @@ TEST_CASE(test_doubly_list_operations)
 
 TEST_SUITE(test_doubly_list)
 {
+	RUN_TEST_CASE(test_doubly_list_offset_of_node_host_roundtrip);
 	RUN_TEST_CASE(test_doubly_list_operations);
 }


### PR DESCRIPTION
Stacked on #566, #567 — the diff here will include those PRs' commits until they merge, at which point GitHub recomputes this PR down to just the one commit below.

`cf_make_pixel_rgb_f`, `cf_make_pixel_rgba_f`, and `cf_color_to_pixel` cast `component * 255.0f` straight to `uint8_t` with no range check, so any component outside `[0,1]` (HDR math, an unclamped blend, ...) is UB on the float->integer cast. Routes each component through `cf_clamp01` first; truncation behavior for in-range values is unchanged.

Note: `cf_mul_pixel`/`cf_div_pixel` route `uint8_t` (0-255) results through these same float (0.0-1.0) constructors, effectively multiplying by 255 twice -- a real, separate, pre-existing bug already flagged in `test_color.cpp`'s `test_mul_pixel`/`test_div_pixel` comments. This PR only removes the UB in the constructors; it does not touch that double-scaling logic bug, which needs its own fix and its own callers audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jk78XZ1Lv4TNx98XEfM6Sn