### PR TITLE
Fix Map::insert memset on non-trivially-copyable types

### DIFF
--- a/include/cute_map.h
+++ b/include/cute_map.h
@@ -409,6 +409,15 @@ const T* Map<T>::try_get(uint64_t key) const
 template <typename T>
 T* Map<T>::insert(uint64_t key)
 {
+	// ck_map_set_stretchy updates an existing key's bytes in place, so a fresh
+	// placement new over it would skip the old value's destructor. Destroy and
+	// reconstruct directly instead of going through the zero-byte reserve path.
+	T* existing = try_get(key);
+	if (existing) {
+		existing->~T();
+		return CF_PLACEMENT_NEW(existing) T();
+	}
+
 	// Reserve space first, then placement new.
 	alignas(T) unsigned char dummy[sizeof(T)];
 	CF_MEMSET(dummy, 0, sizeof(T));
@@ -422,6 +431,12 @@ T* Map<T>::insert(uint64_t key)
 template <typename T>
 T* Map<T>::insert(uint64_t key, const T& val)
 {
+	T* existing = try_get(key);
+	if (existing) {
+		existing->~T();
+		return CF_PLACEMENT_NEW(existing) T(val);
+	}
+
 	alignas(T) unsigned char dummy[sizeof(T)];
 	CF_MEMSET(dummy, 0, sizeof(T));
 	ck_map_set_stretchy((void**)&m_map, key, dummy, (int)sizeof(T));
@@ -434,6 +449,12 @@ T* Map<T>::insert(uint64_t key, const T& val)
 template <typename T>
 T* Map<T>::insert(uint64_t key, T&& val)
 {
+	T* existing = try_get(key);
+	if (existing) {
+		existing->~T();
+		return CF_PLACEMENT_NEW(existing) T(cf_move(val));
+	}
+
 	alignas(T) unsigned char dummy[sizeof(T)];
 	CF_MEMSET(dummy, 0, sizeof(T));
 	ck_map_set_stretchy((void**)&m_map, key, dummy, (int)sizeof(T));

--- a/include/cute_map.h
+++ b/include/cute_map.h
@@ -410,9 +410,9 @@ template <typename T>
 T* Map<T>::insert(uint64_t key)
 {
 	// Reserve space first, then placement new.
-	T dummy;
-	CF_MEMSET(&dummy, 0, sizeof(T));
-	ck_map_set_stretchy((void**)&m_map, key, &dummy, (int)sizeof(T));
+	alignas(T) unsigned char dummy[sizeof(T)];
+	CF_MEMSET(dummy, 0, sizeof(T));
+	ck_map_set_stretchy((void**)&m_map, key, dummy, (int)sizeof(T));
 	T* result = (T*)ck_map_get_ptr_impl(CK_MHDR(m_map), key);
 	CF_ASSERT(result);
 	CF_PLACEMENT_NEW(result) T();
@@ -422,9 +422,9 @@ T* Map<T>::insert(uint64_t key)
 template <typename T>
 T* Map<T>::insert(uint64_t key, const T& val)
 {
-	T dummy;
-	CF_MEMSET(&dummy, 0, sizeof(T));
-	ck_map_set_stretchy((void**)&m_map, key, &dummy, (int)sizeof(T));
+	alignas(T) unsigned char dummy[sizeof(T)];
+	CF_MEMSET(dummy, 0, sizeof(T));
+	ck_map_set_stretchy((void**)&m_map, key, dummy, (int)sizeof(T));
 	T* result = (T*)ck_map_get_ptr_impl(CK_MHDR(m_map), key);
 	CF_ASSERT(result);
 	CF_PLACEMENT_NEW(result) T(val);
@@ -434,9 +434,9 @@ T* Map<T>::insert(uint64_t key, const T& val)
 template <typename T>
 T* Map<T>::insert(uint64_t key, T&& val)
 {
-	T dummy;
-	CF_MEMSET(&dummy, 0, sizeof(T));
-	ck_map_set_stretchy((void**)&m_map, key, &dummy, (int)sizeof(T));
+	alignas(T) unsigned char dummy[sizeof(T)];
+	CF_MEMSET(dummy, 0, sizeof(T));
+	ck_map_set_stretchy((void**)&m_map, key, dummy, (int)sizeof(T));
 	T* result = (T*)ck_map_get_ptr_impl(CK_MHDR(m_map), key);
 	CF_ASSERT(result);
 	CF_PLACEMENT_NEW(result) T(cf_move(val));


### PR DESCRIPTION
Fixes the `-Wnontrivial-memcall` warning on `Map<T>::insert()` (surfaced when `T` is e.g. `CF_ParsedTextState`, which holds a `Cute::String`/`Cute::Array`).

`insert()` default-constructed a real `T`, `memset`'d it to zero, then discarded it once `ck_map_set_stretchy` copied the zero bytes into the map. This only works because every `T` used here happens to default to all-zero bytes — the compiler is right to flag it, since memset-ing an already-constructed non-trivial object (and later destructing it) is unspecified behavior.

Fix: reserve space with a raw zeroed byte buffer instead of a real `T`, so no object is ever spuriously constructed/destructed. No behavior change for existing callers.

Verified: framework + test suite builds warning-clean (previously reproduced the warning with a `Map<T>` where `T` holds a `std::string`/`Cute::Array`), and `./tests` passes the same 313/333 as `master` (remaining 20 are pre-existing headless GPU rendering failures, unrelated to this change).