### PR TITLE
Fix HiDPI half-size regression: default 2d projection is logical points

### DIFF
--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -433,10 +433,11 @@ CF_API float CF_CALL cf_app_get_pixel_scale(void);
 /**
  * @function cf_app_set_size
  * @category app
- * @brief    Sets the size of the window in pixels.
- * @param    w          The width of the window in pixels.
- * @param    h          The height of the window in pixels.
- * @related  cf_app_get_size cf_app_get_position cf_app_set_position
+ * @brief    Sets the size of the window in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
+ * @param    w          The width of the window in logical points.
+ * @param    h          The height of the window in logical points.
+ * @remarks  The app's default canvas is recreated immediately at the new size times the display's pixel density.
+ * @related  cf_app_get_size cf_app_get_position cf_app_set_position cf_app_get_pixel_scale
  */
 CF_API void CF_CALL cf_app_set_size(int w, int h);
 

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -156,14 +156,42 @@ static void s_canvas(int w, int h)
 	app->offscreen_canvas = cf_make_canvas(params);
 	app->canvas_w = w;
 	app->canvas_h = h;
-	cf_draw_on_app_canvas_resized(w, h);
+	cf_draw_on_app_canvas_resized();
 }
 
 void cf_app_recreate_default_canvas_if_needed()
 {
-	int w = (int)CF_ROUNDF(app->w * app->pixel_scale);
-	int h = (int)CF_ROUNDF(app->h * app->pixel_scale);
+	// Backends reject a 0x0 canvas (degenerate pixel_scale, or a zero-sized window mid-minimize).
+	int w = cf_max((int)CF_ROUNDF(app->w * app->pixel_scale), 1);
+	int h = cf_max((int)CF_ROUNDF(app->h * app->pixel_scale), 1);
 	s_canvas(w, h);
+}
+
+// Resolution order: NO_HIGH_DPI pins to 1.0, then a cf_app_force_pixel_scale override,
+// then the window's SDL-reported density.
+static float s_resolve_pixel_scale()
+{
+	if (app->options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) return 1.0f;
+	if (app->pixel_scale_override > 0) return app->pixel_scale_override;
+	float scale = app->window ? SDL_GetWindowPixelDensity(app->window) : 1.0f;
+	return scale > 0 ? scale : 1.0f;
+}
+
+void cf_app_refresh_pixel_scale()
+{
+	float scale = s_resolve_pixel_scale();
+	if (scale == app->pixel_scale) return;
+	app->pixel_scale = scale;
+	// NO_GFX apps have no canvas to recreate (cf_make_app only sizes one under use_gfx).
+	if (app->gfx_enabled) cf_app_recreate_default_canvas_if_needed();
+}
+
+void cf_app_force_pixel_scale(float scale)
+{
+	if (!app) return;
+	// Inverted test: NaN fails every ordered comparison, so it clears the override too.
+	app->pixel_scale_override = scale > 0 ? scale : 0;
+	cf_app_refresh_pixel_scale();
 }
 
 CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, int y, int w, int h, CF_AppOptionFlags options, const char* argv0)
@@ -338,15 +366,13 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	app->window = window;
 	app->w = w;
 	app->h = h;
+	::app = app;
 	if (window) {
 		SDL_GetWindowPosition(app->window, &app->x, &app->y);
 		app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
 		app->dpi_scale_prev = app->dpi_scale;
-		app->pixel_scale = window ? SDL_GetWindowPixelDensity(app->window) : 1.0f;
-		if (app->pixel_scale <= 0.0f) app->pixel_scale = 1.0f;
-		if (options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) app->pixel_scale = 1.0f;
+		app->pixel_scale = s_resolve_pixel_scale();
 	}
-	::app = app;
 	cf_make_aseprite_cache();
 	cf_make_custom_sprite_cache();
 

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1001,8 +1001,21 @@ static void s_init_atlas_cache(int w, int h)
 	}
 }
 
+// The default 2d projection spans the window's LOGICAL size (points, never canvas pixels --
+// on a 2x display the canvas is twice as large, and a pixel-sized ortho would halve every
+// draw in point space).
+static CF_M3x2 s_default_projection()
+{
+	return ortho_2d(0, 0, (float)app->w, (float)app->h);
+}
+
 void CF_Draw::reset_cam()
 {
+	// Apply a refresh parked by cf_draw_on_app_canvas_resized.
+	if (pending_projection && !recording_list && projection_stack.count() == 0) {
+		projection = s_default_projection();
+		pending_projection = false;
+	}
 	cam_stack.clear();
 	cam_stack.add(cf_make_identity());
 	mvp = projection;
@@ -1025,7 +1038,7 @@ void cf_make_draw()
 {
 	s_draw = CF_NEW(CF_Draw);
 	s_draw->path_image_id_gen = CF_PATH_ID_RANGE_LO;
-	s_draw->projection = ortho_2d(0, 0, (float)app->w, (float)app->h);
+	s_draw->projection = s_default_projection();
 	s_draw->reset_cam();
 	s_draw->uniform_arena = cf_make_arena(32, CF_MB);
 
@@ -5317,13 +5330,22 @@ static void s_process_command(CF_Canvas canvas, CF_Command* cmd, CF_Command* nex
 // with N mesh/canvas fences into N full defrags. Images first seen after this frame's defrag
 // ride the lonely buffer (own texture, own batch) until the next frame's defrag packs them:
 // one frame of extra draw calls for brand-new content, instead of N defrags every frame.
-void cf_draw_on_app_canvas_resized(int w, int h)
+void cf_draw_on_app_canvas_resized()
 {
-	// The default 2d projection tracks the app canvas 1:1. It used to be computed once at
-	// startup and never again, so any resize (cf_app_set_size or a user dragging a resizable
-	// window) silently rescaled every world-space 2d draw. Refresh it with the canvas; a
-	// custom cf_draw_projection is per-frame state and simply overrides this as usual.
-	if (s_draw) s_draw->projection = ortho_2d(0, 0, (float)w, (float)h);
+	if (!s_draw) return;
+	// Applying mid draw-list-recording would stomp the recording's identity space, and
+	// inside a cf_draw_push/pop pair the pop would just clobber it. Park the refresh;
+	// reset_cam applies it at the frame boundary.
+	if (s_draw->recording_list || s_draw->projection_stack.count() > 0) {
+		s_draw->pending_projection = true;
+		return;
+	}
+	s_draw->pending_projection = false;
+	// cf_draw_projection refreshes mvp too: reset_cam only re-latches it at end of frame,
+	// so the rest of the resize frame would otherwise draw with the stale matrix. Ditto
+	// the AA factor, which divides by pixel_scale.
+	cf_draw_projection(s_default_projection());
+	s_draw->set_aaf();
 }
 
 void cf_atlas_defrag_once()

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1003,10 +1003,11 @@ static void s_init_atlas_cache(int w, int h)
 
 // The default 2d projection spans the window's LOGICAL size (points, never canvas pixels --
 // on a 2x display the canvas is twice as large, and a pixel-sized ortho would halve every
-// draw in point space).
+// draw in point space). Clamped because some platforms report a 0x0 window mid-minimize and
+// ortho_2d divides by the extents.
 static CF_M3x2 s_default_projection()
 {
-	return ortho_2d(0, 0, (float)app->w, (float)app->h);
+	return ortho_2d(0, 0, (float)cf_max(app->w, 1), (float)cf_max(app->h, 1));
 }
 
 void CF_Draw::reset_cam()

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -516,9 +516,14 @@ void cf_pump_input_msgs()
 
 		case SDL_EVENT_WINDOW_RESIZED:
 			app->window_state.resized = true;
-			app->w = event.window.data1;
-			app->h = event.window.data2;
-			cf_app_recreate_default_canvas_if_needed();
+			// A redundant notify reporting the size app->w/h already have (e.g. an X11
+			// ConfigureNotify on window map) must not count as a recreation event -- it
+			// would silently discard an active cf_app_set_canvas_size one-shot override.
+			if (event.window.data1 != app->w || event.window.data2 != app->h) {
+				app->w = event.window.data1;
+				app->h = event.window.data2;
+				cf_app_recreate_default_canvas_if_needed();
+			}
 			break;
 
 		case SDL_EVENT_WINDOW_MOVED:

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -499,26 +499,6 @@ void cf_begin_frame_input()
 	}
 }
 
-// Re-queries the window's physical pixel density and, if it changed, updates
-// app->pixel_scale and recreates the default canvas to match.
-// No-ops entirely when CF_APP_OPTIONS_NO_HIGH_DPI_BIT is set, since pixel_scale
-// must stay pinned at 1.0f in that mode.
-// Called from both SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED and
-// SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED -- the former is the OS's content-scale
-// signal and the latter is the authoritative physical-pixel-size signal;
-// either can fire without the other depending on platform/monitor setup, so
-// both are handled the same way and this is idempotent when both fire together.
-static void s_refresh_pixel_scale()
-{
-	if (app->options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) return;
-	float pixel_scale = SDL_GetWindowPixelDensity(app->window);
-	if (pixel_scale <= 0.0f) pixel_scale = 1.0f;
-	if (pixel_scale != app->pixel_scale) {
-		app->pixel_scale = pixel_scale;
-		cf_app_recreate_default_canvas_if_needed();
-	}
-}
-
 void cf_pump_input_msgs()
 {
 	// Handle SDL messages.
@@ -578,11 +558,11 @@ void cf_pump_input_msgs()
 		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
 			app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
 			app->dpi_scale_was_changed = true;
-			s_refresh_pixel_scale();
+			cf_app_refresh_pixel_scale();
 			break;
 
 		case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-			s_refresh_pixel_scale();
+			cf_app_refresh_pixel_scale();
 			break;
 
 		case SDL_EVENT_KEY_DOWN:

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -36,6 +36,18 @@ CF_API extern struct CF_App* app;
 // cf_app_set_msaa) -- this is what makes cf_app_set_canvas_size a one-shot override.
 void cf_app_recreate_default_canvas_if_needed();
 
+// Re-resolves app->pixel_scale (NO_HIGH_DPI pin wins, then any forced override, then SDL's
+// reported density) and recreates the default canvas when it changed. Called from either
+// display-density event -- they can fire alone or together, so this is idempotent.
+void cf_app_refresh_pixel_scale();
+
+// Test/debug hook: pins app->pixel_scale to `scale` and recreates the default canvas, exactly as
+// a real display-density change would. Pass 0 (NaN/negatives coerce to it) to clear the override
+// and re-query SDL; CF_APP_OPTIONS_NO_HIGH_DPI_BIT still wins. This exists because CI and most
+// dev machines run at pixel_scale 1.0, where points-vs-pixels mixups are invisible; see
+// test/test_hidpi.cpp. CF_API so the separately-linked tests executable can call it.
+CF_API void cf_app_force_pixel_scale(float scale);
+
 // Maps an SDL_PowerState to the corresponding CF_PowerState. Header-inline (rather than
 // CF_API) so it stays testable from test/test_app.cpp without crossing the shared-library
 // export boundary.
@@ -106,14 +118,15 @@ struct CF_App
 	float dpi_scale_prev = 1.0f;
 	bool dpi_scale_was_changed = false;
 	float pixel_scale = 1.0f;   // Physical pixels per logical point (from SDL_GetWindowPixelDensity). Drives default-canvas sizing, AA, and glyph rasterization.
+	float pixel_scale_override = 0; // Nonzero overrides SDL's reported density (cf_app_force_pixel_scale test/debug hook).
 	CF_Filter canvas_blit_filter = CF_FILTER_NEAREST; // Filter used when blitting the app canvas onto the screen, if their sizes differ (e.g. after cf_app_set_canvas_size). Defaults to nearest for a crisp/blocky pixel-art look.
 	bool sync_window = false;
 	int draw_call_count = 0;
-	int w = 0;
+	int w = 0; // Window size in LOGICAL points (what the public API speaks); multiply by pixel_scale for physical pixels.
 	int h = 0;
 	int x = 0;
 	int y = 0;
-	int canvas_w = 0;
+	int canvas_w = 0; // Default canvas size in PHYSICAL pixels: w/h * pixel_scale, or an exact one-shot size from cf_app_set_canvas_size until the next recreation event.
 	int canvas_h = 0;
 	CF_Color clear_color = { 0, 0, 0, 0 };
 	float clear_depth = 1.0f;

--- a/src/internal/cute_draw_internal.h
+++ b/src/internal/cute_draw_internal.h
@@ -355,6 +355,9 @@ struct CF_Draw
 	Cute::Array<CF_M3x2> cam_stack = { cf_make_identity() };
 	Cute::Array<CF_M3x2> projection_stack;
 	float aaf = 0;
+	// A default-projection refresh that arrived mid draw-list recording or inside a
+	// cf_draw_push/pop pair; reset_cam applies it at the frame boundary.
+	bool pending_projection = false;
 	CF_M3x2 projection;
 	CF_M3x2 mvp;
 	void reset_cam();
@@ -469,9 +472,10 @@ void cf_draw3d_free_cmd(CF_Command* cmd);
 // Runs the atlas defrag at most once per frame (see CF_Draw::defragged_this_frame).
 void cf_atlas_defrag_once();
 
-// Called when the app's offscreen canvas is recreated (window resize / cf_app_set_size):
-// refreshes the default 2d projection, which tracks the app canvas 1:1.
-void cf_draw_on_app_canvas_resized(int w, int h);
+// Called when the app's offscreen canvas is recreated (window resize / cf_app_set_size /
+// density change / cf_app_set_canvas_size): refreshes the default 2d projection from the
+// window's logical size.
+void cf_draw_on_app_canvas_resized();
 
 // Called by cf_render_layers_to before the canvas (and its render pass) is applied: stages
 // every in-range untextured mesh command's instance data into one shared GPU instance buffer

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CF_TEST_SRCS
 	test_shader_reload.cpp
 	test_shader_directory.cpp
 	test_canvas_clear.cpp
+	test_hidpi.cpp
 	test_mrt.cpp
 	test_texture_types.cpp
 	test_shadow_sampling.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -50,6 +50,7 @@ TEST_SUITE(test_graphics_3d);
 TEST_SUITE(test_shader_reload);
 TEST_SUITE(test_shader_directory);
 TEST_SUITE(test_canvas_clear);
+TEST_SUITE(test_hidpi);
 TEST_SUITE(test_mrt);
 TEST_SUITE(test_texture_types);
 TEST_SUITE(test_shadow_sampling);
@@ -123,6 +124,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_shader_reload);
 	RUN_TRACED(test_shader_directory);
 	RUN_TRACED(test_canvas_clear);
+	RUN_TRACED(test_hidpi);
 	RUN_TRACED(test_mrt);
 	RUN_TRACED(test_texture_types);
 	RUN_TRACED(test_shadow_sampling);

--- a/test/test_app_shared.cpp
+++ b/test/test_app_shared.cpp
@@ -8,6 +8,7 @@
 #include "test_app_shared.h"
 
 #include <cute.h>
+#include <internal/cute_app_internal.h>
 #include <stdlib.h>
 
 static bool s_alive = false;
@@ -34,6 +35,7 @@ bool test_make_app(int w, int h, int extra_options)
 	}
 
 	if (s_alive && options == s_options) {
+		cf_app_force_pixel_scale(0); // Sweep a forced density leaked by a failed HiDPI test.
 		cf_app_set_size(w, h); // Recreates the app canvas + default 2d projection immediately.
 		// Well-known process globals a test legitimately mutates and rarely thinks to restore
 		// -- with one app per test their reset came free from cf_destroy_app. Everything else

--- a/test/test_hidpi.cpp
+++ b/test/test_hidpi.cpp
@@ -10,6 +10,7 @@
 
 #include <cute.h>
 #include <internal/cute_app_internal.h>
+#include <SDL3/SDL.h>
 
 using namespace Cute;
 
@@ -252,6 +253,32 @@ TEST_CASE(test_hidpi_one_shot_canvas_keeps_points_projection)
 	return true;
 }
 
+// A redundant SDL_EVENT_WINDOW_RESIZED reporting the window's CURRENT size (e.g. an
+// X11/Xvfb ConfigureNotify fired on window map) is not a recreation event and must not
+// stomp a one-shot cf_app_set_canvas_size override.
+TEST_CASE(test_hidpi_noop_resize_event_does_not_recreate_canvas)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	cf_app_set_canvas_size(300, 200);
+	REQUIRE(cf_app_get_canvas_width() == 300);
+	REQUIRE(cf_app_get_canvas_height() == 200);
+
+	SDL_Event e = { };
+	e.type = SDL_EVENT_WINDOW_RESIZED;
+	e.window.windowID = SDL_GetWindowID(app->window);
+	e.window.data1 = LOGICAL_W; // Same size app->w/h already report -- nothing changed.
+	e.window.data2 = LOGICAL_H;
+	SDL_PushEvent(&e);
+	cf_app_update(NULL);
+
+	REQUIRE(cf_app_get_canvas_width() == 300);
+	REQUIRE(cf_app_get_canvas_height() == 200);
+	return true;
+}
+
 // A canvas recreation landing mid-recording must not corrupt the retained draw list:
 // recording runs in identity space and replay composes the live projection on top, so a
 // refresh stomped into the recording would bake the ortho in twice. Deferring it also
@@ -303,5 +330,6 @@ TEST_SUITE(test_hidpi)
 	RUN_TEST_CASE(test_hidpi_full_extent_covers_app_canvas);
 	RUN_TEST_CASE(test_hidpi_first_frame_after_resize);
 	RUN_TEST_CASE(test_hidpi_one_shot_canvas_keeps_points_projection);
+	RUN_TEST_CASE(test_hidpi_noop_resize_event_does_not_recreate_canvas);
 	RUN_TEST_CASE(test_hidpi_draw_list_recorded_across_resize);
 }

--- a/test/test_hidpi.cpp
+++ b/test/test_hidpi.cpp
@@ -50,6 +50,12 @@ static bool s_readback_canvas(CF_Canvas canvas, int w, int h, CF_Pixel* out)
 	REQUIRE(rb.id);
 	while (!cf_readback_ready(rb)) {}
 	int size = w * h * (int)sizeof(CF_Pixel);
+	if (cf_readback_size(rb) != size) {
+		printf("readback size mismatch: got %d expected %d (w=%d h=%d) app_canvas=%dx%d app_window=%dx%d pixel_scale=%f\n",
+			cf_readback_size(rb), size, w, h,
+			cf_app_get_canvas_width(), cf_app_get_canvas_height(),
+			cf_app_get_width(), cf_app_get_height(), (double)cf_app_get_pixel_scale());
+	}
 	REQUIRE(cf_readback_size(rb) == size);
 	cf_readback_data(rb, out, size);
 	cf_destroy_readback(rb);

--- a/test/test_hidpi.cpp
+++ b/test/test_hidpi.cpp
@@ -1,0 +1,307 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+#include "test_app_shared.h"
+
+#include <cute.h>
+#include <internal/cute_app_internal.h>
+
+using namespace Cute;
+
+// On a HiDPI (Retina) display the default app canvas is logical_size * pixel_scale physical
+// pixels while the public draw API stays in logical points. CI and most dev machines run at
+// pixel_scale 1.0 where points and pixels are the same number, so a points/pixels mixup is
+// invisible there -- these tests force a non-unity pixel_scale through the same code path a
+// real display-density change takes, making the HiDPI contract testable everywhere.
+//
+// Regression context: 3f5a8283 set the default 2d projection to the canvas's *pixel*
+// dimensions, which halved everything drawn in point space on 2x displays.
+
+#define LOGICAL_W 320
+#define LOGICAL_H 240
+
+static bool s_px_near(CF_Pixel p, int r, int g, int b, int a, int tol)
+{
+	bool ok = cf_abs((int)p.colors.r - r) <= tol && cf_abs((int)p.colors.g - g) <= tol && cf_abs((int)p.colors.b - b) <= tol && cf_abs((int)p.colors.a - a) <= tol;
+	if (!ok) printf("pixel (%d %d %d %d) expected (%d %d %d %d) +/-%d\n", p.colors.r, p.colors.g, p.colors.b, p.colors.a, r, g, b, a, tol);
+	return ok;
+}
+
+// A failed REQUIRE returns out of the test case early; RAII keeps the forced pixel_scale
+// from leaking into whichever test runs next (see also test_app_shared's own sweep).
+struct HidpiGuard
+{
+	~HidpiGuard()
+	{
+		cf_app_force_pixel_scale(0);
+		test_destroy_app();
+	}
+};
+
+static bool s_readback_canvas(CF_Canvas canvas, int w, int h, CF_Pixel* out)
+{
+	CF_Readback rb = cf_canvas_readback(canvas);
+	REQUIRE(rb.id);
+	while (!cf_readback_ready(rb)) {}
+	int size = w * h * (int)sizeof(CF_Pixel);
+	REQUIRE(cf_readback_size(rb) == size);
+	cf_readback_data(rb, out, size);
+	cf_destroy_readback(rb);
+	return true;
+}
+
+// One empty frame: reset_cam at end of frame latches the DEFAULT projection into mvp, so
+// tests observe the projection itself rather than whatever an earlier test left latched.
+static void s_latch_default_projection()
+{
+	cf_app_update(NULL);
+	cf_app_draw_onto_screen(false);
+	cf_app_update(NULL);
+}
+
+// The force hook itself: forcing 2x must recreate the default canvas at 2x the logical
+// window size, and forcing 0 must restore the true SDL-reported density.
+TEST_CASE(test_hidpi_forced_scale_resizes_canvas)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	REQUIRE(cf_app_get_pixel_scale() == 2.0f);
+	REQUIRE(cf_app_get_canvas_width() == LOGICAL_W * 2);
+	REQUIRE(cf_app_get_canvas_height() == LOGICAL_H * 2);
+	// The logical window size is unchanged -- only the rasterization resolution moved.
+	REQUIRE(cf_app_get_width() == LOGICAL_W);
+	REQUIRE(cf_app_get_height() == LOGICAL_H);
+
+	cf_app_force_pixel_scale(0);
+	float real = cf_app_get_pixel_scale();
+	REQUIRE(real > 0);
+	REQUIRE(cf_app_get_canvas_width() == (int)CF_ROUNDF(LOGICAL_W * real));
+	return true;
+}
+
+// CF_APP_OPTIONS_NO_HIGH_DPI_BIT pins pixel_scale at 1.0 -- a forced value must not
+// manufacture a state production can never reach.
+TEST_CASE(test_hidpi_force_respects_no_high_dpi)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H, CF_APP_OPTIONS_NO_HIGH_DPI_BIT)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	REQUIRE(cf_app_get_pixel_scale() == 1.0f);
+	REQUIRE(cf_app_get_canvas_width() == LOGICAL_W);
+	REQUIRE(cf_app_get_canvas_height() == LOGICAL_H);
+	return true;
+}
+
+// NO_GFX apps never size a canvas, so the force hook must update pixel_scale without
+// recreating one (that would dispatch into a NULL backend).
+TEST_CASE(test_hidpi_force_is_safe_without_gfx)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H, CF_APP_OPTIONS_NO_GFX_BIT)) return true;
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	REQUIRE(cf_app_get_pixel_scale() == 2.0f);
+	return true;
+}
+
+// The default 2d projection spans logical points, so world coordinates land on the same
+// spot of a 1:1 user canvas no matter the display density. At the broken pixel-space
+// projection everything shrinks toward the center and the probe reads background.
+TEST_CASE(test_hidpi_default_projection_is_points)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	s_latch_default_projection();
+
+	int w = LOGICAL_W, h = LOGICAL_H;
+	CF_Canvas canvas = cf_make_canvas(cf_canvas_defaults(w, h));
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(w * h * (int)sizeof(CF_Pixel));
+
+	// A bar left of center, spanning y=0 so the probe row is insensitive to readback
+	// row order: world x in [-140, -60].
+	cf_draw_push_color(cf_make_color_rgb_f(1.0f, 0, 0));
+	cf_draw_quad_fill(cf_make_aabb(cf_v2(-140, -20), cf_v2(-60, 20)), 0);
+	cf_draw_pop_color();
+	cf_render_to(canvas, true);
+	cf_app_draw_onto_screen(false);
+
+	REQUIRE(s_readback_canvas(canvas, w, h, px));
+	// World (-100, 0) is pixel column w/2 - 100 when one world unit is one point.
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2 - 100)], 255, 0, 0, 255, 3));
+	// Just outside the bar: untouched.
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2 - 150)], 0, 0, 0, 0, 0));
+
+	cf_free(px);
+	cf_destroy_canvas(canvas);
+	return true;
+}
+
+// Through the real present path: a quad spanning the exact logical extent must cover every
+// pixel of the (2x larger) default canvas. At the broken projection it covers only the
+// central quarter and the corners read background.
+TEST_CASE(test_hidpi_full_extent_covers_app_canvas)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	s_latch_default_projection();
+
+	int w = cf_app_get_canvas_width();
+	int h = cf_app_get_canvas_height();
+	REQUIRE(w == LOGICAL_W * 2 && h == LOGICAL_H * 2);
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(w * h * (int)sizeof(CF_Pixel));
+
+	cf_draw_push_color(cf_make_color_rgb_f(1.0f, 0, 0));
+	cf_draw_quad_fill(cf_make_aabb(cf_v2(-LOGICAL_W / 2.0f, -LOGICAL_H / 2.0f), cf_v2(LOGICAL_W / 2.0f, LOGICAL_H / 2.0f)), 0);
+	cf_draw_pop_color();
+	cf_app_draw_onto_screen(true); // Renders the remaining draw commands onto the (cleared) app canvas.
+
+	REQUIRE(s_readback_canvas(cf_app_get_canvas(), w, h, px));
+	// Probe 5px inside each corner (clear of the AA band) plus the center.
+	REQUIRE(s_px_near(px[5 * w + 5], 255, 0, 0, 255, 3));
+	REQUIRE(s_px_near(px[5 * w + (w - 6)], 255, 0, 0, 255, 3));
+	REQUIRE(s_px_near(px[(h - 6) * w + 5], 255, 0, 0, 255, 3));
+	REQUIRE(s_px_near(px[(h - 6) * w + (w - 6)], 255, 0, 0, 255, 3));
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2)], 255, 0, 0, 255, 3));
+
+	cf_free(px);
+	return true;
+}
+
+// cf_app_set_size recreates the canvas and refreshes the projection immediately -- and the
+// very next frame must draw with it. The projection's companion mvp is only re-latched at
+// end of frame by reset_cam, so a projection refresh that skips mvp renders the first
+// post-resize frame with the stale matrix.
+TEST_CASE(test_hidpi_first_frame_after_resize)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	cf_app_update(NULL);
+
+	cf_app_set_size(400, 300);
+	int w = cf_app_get_canvas_width();
+	int h = cf_app_get_canvas_height();
+	REQUIRE(w == 800 && h == 600);
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(w * h * (int)sizeof(CF_Pixel));
+
+	// Draw WITHOUT an intervening cf_app_update: this is the same frame the resize
+	// happened on, exactly where a stale mvp would bite.
+	cf_draw_push_color(cf_make_color_rgb_f(0, 1.0f, 0));
+	cf_draw_quad_fill(cf_make_aabb(cf_v2(-200, -150), cf_v2(200, 150)), 0);
+	cf_draw_pop_color();
+	cf_app_draw_onto_screen(true);
+
+	REQUIRE(s_readback_canvas(cf_app_get_canvas(), w, h, px));
+	REQUIRE(s_px_near(px[5 * w + 5], 0, 255, 0, 255, 3));
+	REQUIRE(s_px_near(px[(h - 6) * w + (w - 6)], 0, 255, 0, 255, 3));
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2)], 0, 255, 0, 255, 3));
+
+	cf_free(px);
+	return true;
+}
+
+// cf_app_set_canvas_size is a one-shot override: the canvas takes an exact pixel size
+// until the next recreation event snaps it back. Draw coordinates STAY in window points
+// throughout -- the projection maps them onto whatever canvas is current.
+TEST_CASE(test_hidpi_one_shot_canvas_keeps_points_projection)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	// Exactly 300x200 pixels: distinct from the logical size, 2x of it, and the window's
+	// aspect, so the probes can tell them apart.
+	cf_app_set_canvas_size(300, 200);
+	REQUIRE(cf_app_get_canvas_width() == 300);
+	REQUIRE(cf_app_get_canvas_height() == 200);
+	s_latch_default_projection();
+
+	int w = 300, h = 200;
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(w * h * (int)sizeof(CF_Pixel));
+
+	// The full LOGICAL extent (window points) covers the whole override canvas.
+	cf_draw_push_color(cf_make_color_rgb_f(0, 0, 1.0f));
+	cf_draw_quad_fill(cf_make_aabb(cf_v2(-LOGICAL_W / 2.0f, -LOGICAL_H / 2.0f), cf_v2(LOGICAL_W / 2.0f, LOGICAL_H / 2.0f)), 0);
+	cf_draw_pop_color();
+	cf_app_draw_onto_screen(true);
+
+	REQUIRE(s_readback_canvas(cf_app_get_canvas(), w, h, px));
+	REQUIRE(s_px_near(px[5 * w + 5], 0, 0, 255, 255, 3));
+	REQUIRE(s_px_near(px[(h - 6) * w + (w - 6)], 0, 0, 255, 255, 3));
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2)], 0, 0, 255, 255, 3));
+
+	// The next recreation event snaps the override back to window * pixel_scale.
+	cf_app_set_size(LOGICAL_W, LOGICAL_H);
+	REQUIRE(cf_app_get_canvas_width() == LOGICAL_W * 2);
+	REQUIRE(cf_app_get_canvas_height() == LOGICAL_H * 2);
+
+	cf_free(px);
+	return true;
+}
+
+// A canvas recreation landing mid-recording must not corrupt the retained draw list:
+// recording runs in identity space and replay composes the live projection on top, so a
+// refresh stomped into the recording would bake the ortho in twice. Deferring it also
+// makes post-recording frames render at the NEW size even though cf_draw_list_end's pop
+// restored the pre-resize projection.
+TEST_CASE(test_hidpi_draw_list_recorded_across_resize)
+{
+	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
+	HidpiGuard guard;
+
+	cf_app_force_pixel_scale(2.0f);
+	s_latch_default_projection();
+
+	CF_DrawList list = cf_make_draw_list();
+	cf_draw_list_begin(list);
+	cf_app_set_size(400, 300); // Recreates the default canvas MID-recording.
+	cf_draw_push_color(cf_make_color_rgb_f(1.0f, 0, 0));
+	cf_draw_quad_fill(cf_make_aabb(cf_v2(-40, -40), cf_v2(40, 40)), 0); // Recorded after the resize.
+	cf_draw_pop_color();
+	cf_draw_list_end();
+	cf_app_draw_onto_screen(false); // Frame boundary: the deferred projection refresh applies here.
+
+	int w = cf_app_get_canvas_width();
+	int h = cf_app_get_canvas_height();
+	REQUIRE(w == 800 && h == 600);
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(w * h * (int)sizeof(CF_Pixel));
+
+	cf_app_update(NULL);
+	cf_draw_list(list);
+	cf_app_draw_onto_screen(true);
+
+	REQUIRE(s_readback_canvas(cf_app_get_canvas(), w, h, px));
+	// The 80x80-logical quad replays centered at 160x160 device pixels on the 800x600 canvas.
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2)], 255, 0, 0, 255, 3));      // Center.
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2 + 70)], 255, 0, 0, 255, 3)); // Inside the quad.
+	REQUIRE(s_px_near(px[(h / 2) * w + (w / 2 + 100)], 0, 0, 0, 0, 0));    // Outside the quad.
+
+	cf_free(px);
+	cf_destroy_draw_list(list);
+	return true;
+}
+
+TEST_SUITE(test_hidpi)
+{
+	RUN_TEST_CASE(test_hidpi_forced_scale_resizes_canvas);
+	RUN_TEST_CASE(test_hidpi_force_respects_no_high_dpi);
+	RUN_TEST_CASE(test_hidpi_force_is_safe_without_gfx);
+	RUN_TEST_CASE(test_hidpi_default_projection_is_points);
+	RUN_TEST_CASE(test_hidpi_full_extent_covers_app_canvas);
+	RUN_TEST_CASE(test_hidpi_first_frame_after_resize);
+	RUN_TEST_CASE(test_hidpi_one_shot_canvas_keeps_points_projection);
+	RUN_TEST_CASE(test_hidpi_draw_list_recorded_across_resize);
+}

--- a/test/test_hidpi.cpp
+++ b/test/test_hidpi.cpp
@@ -228,6 +228,12 @@ TEST_CASE(test_hidpi_one_shot_canvas_keeps_points_projection)
 	if (!test_make_app(LOGICAL_W, LOGICAL_H)) return true; // Headless CI: no display/GPU.
 	HidpiGuard guard;
 
+	// test_make_app's cf_app_set_size may still have an SDL_SetWindowSize in flight (on X11
+	// the ConfigureNotify confirmation can arrive late, as a stale-then-fresh burst). Settle
+	// it now so it can't recreate the canvas out from under the one-shot override below.
+	cf_app_draw_onto_screen(false);
+	cf_app_update(NULL);
+
 	cf_app_force_pixel_scale(2.0f);
 	// Exactly 300x200 pixels: distinct from the logical size, 2x of it, and the window's
 	// aspect, so the probes can tell them apart.


### PR DESCRIPTION
3f5a8283 wired `cf_draw_on_app_canvas_resized` to the canvas's *pixel* dimensions. The default canvas is `window_points * pixel_scale`, so on a 2x display the projection extent doubled and everything drawn in point space rendered at half size — from the second frame on, since the hook never refreshed `mvp` and `reset_cam` only latches it at end of frame. At 1x displays points and pixels coincide, which is why CI never saw it, and why it's invisible on most dev machines too.

`s_canvas` now hands the hook window points, and the hook refreshes `mvp` (mirroring `cf_draw_projection`) and the AA factor. When a refresh lands mid draw-list-recording or inside a push/pop pair it parks in `pending_projection` and `reset_cam` applies it at the frame boundary — applying immediately would bake the ortho into recorded draw lists (doubled again at replay) or be clobbered by the pop.

DPI bugs were untestable on 1x machines, so `cf_app_force_pixel_scale` (internal) pins `pixel_scale` through the real recreation path: the new `test_hidpi` suite readback-verifies the projection contract, the resize frame, one-shot `cf_app_set_canvas_size` behavior, and draw-list recording across a resize, at a forced 2x on any machine.

On this Retina Mac, master currently fails 20 `test_draw_tiled` cases; this branch is 346/346.

First of a 3-PR series (viewport/scissor scaling and 3d stroke thickness build on this one's test infra) — holding the rest until this lands so each diff stays reviewable on its own.
