### PR TITLE
Fix slow shader file watch on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ set(CF_HDRS
 	src/internal/cute_graphics_internal.h
 	src/internal/cute_aseprite_cache_internal.h
 	src/internal/cute_alloc_internal.h
+	src/internal/cute_file_system_internal.h
 	src/internal/yyjson.h
 )
 

--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -11,8 +11,25 @@
 
 #include <internal/cute_alloc_internal.h>
 #include <internal/cute_app_internal.h>
+#include <internal/cute_file_system_internal.h>
 
 #include <physfs.h>
+
+#ifdef CF_WINDOWS
+#	ifndef WIN32_LEAN_AND_MEAN
+#		define WIN32_LEAN_AND_MEAN
+#	endif
+#	ifndef NOMINMAX
+#		define NOMINMAX
+#	endif
+#	include <windows.h>
+#	include <time.h>
+#else
+#	include <dirent.h>
+#	include <fcntl.h>
+#	include <sys/stat.h>
+#	include <unistd.h>
+#endif
 
 #define CF_FILE_SYSTEM_BUFFERED_IO_SIZE (2 * CF_MB)
 
@@ -38,11 +55,21 @@ CF_Result cf_fs_set_write_directory(const char* platform_dependent_directory)
 	}
 }
 
+// Bumped by the two calls below, which are the only ones in CF that can change the search path.
+// See cf_fs_generation.
+static uint64_t s_fs_generation = 1;
+
+uint64_t cf_fs_generation()
+{
+	return s_fs_generation;
+}
+
 CF_Result cf_fs_mount(const char* archive, const char* mount_point, bool append_to_path)
 {
 	if (!PHYSFS_mount(archive, mount_point, (int)append_to_path)) {
 		return cf_result_error(PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	} else {
+		++s_fs_generation;
 		return cf_result_success();
 	}
 }
@@ -52,6 +79,7 @@ CF_Result cf_fs_dismount(const char* archive)
 	if (!PHYSFS_unmount(archive)) {
 		return cf_result_error(PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 	} else {
+		++s_fs_generation;
 		return cf_result_success();
 	}
 }
@@ -170,6 +198,205 @@ const char** cf_fs_enumerate_directory(const char* virtual_path)
 void cf_fs_free_enumerated_directory(const char** directory_list)
 {
 	PHYSFS_freeList(directory_list);
+}
+
+//--------------------------------------------------------------------------------------------------
+// Native (non-PhysFS) bulk directory walk.
+//
+// PHYSFS_stat costs a syscall per file, which makes anything that polls a directory scale with
+// the file count. Every platform's directory walk already carries the metadata that stat would
+// return, so read it once for the whole directory instead.
+//
+// Callers must treat this as an accelerator only. It has no idea what is mounted where, so the
+// authority on which files exist stays with PhysFS -- see cf_fs_scan_native_directory's comment.
+
+#ifdef CF_WINDOWS
+
+// Mirrors PhysFS's FileTimeToPhysfsTime (physfs_platform_windows.c), which round-trips through
+// local time rather than subtracting the epoch. Timestamps produced here are compared against
+// ones PHYSFS_stat produced, so agreeing with PhysFS matters more than being right: the two
+// disagree in the ambiguous DST fall-back hour, under a TZ override, and across historical rule
+// changes, and a divergence makes a file look permanently changed or permanently unchanged.
+static bool s_filetime_to_physfs_time(const FILETIME* ft, const TIME_ZONE_INFORMATION* tzi, uint64_t* out)
+{
+	SYSTEMTIME st_utc, st_local;
+	if (!FileTimeToSystemTime(ft, &st_utc)) return false;
+	if (!SystemTimeToTzSpecificLocalTime(tzi, &st_utc, &st_local)) return false;
+
+	struct tm tm;
+	tm.tm_sec = st_local.wSecond;
+	tm.tm_min = st_local.wMinute;
+	tm.tm_hour = st_local.wHour;
+	tm.tm_mday = st_local.wDay;
+	tm.tm_mon = st_local.wMonth - 1;
+	tm.tm_year = st_local.wYear - 1900;
+	tm.tm_wday = -1;
+	tm.tm_yday = -1;
+	tm.tm_isdst = -1;
+
+	time_t t = mktime(&tm);
+	if (t == (time_t)-1) return false;
+	*out = (uint64_t)t;
+	return true;
+}
+
+bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out)
+{
+	// One call for the whole walk. PhysFS fetches this per stat, but it cannot change midway
+	// through a single directory in any way that matters.
+	TIME_ZONE_INFORMATION tzi;
+	if (GetTimeZoneInformation(&tzi) == TIME_ZONE_ID_INVALID) return false;
+
+	// Trailing separators would leave an empty path component ahead of the wildcard.
+	Cute::String pattern = platform_directory;
+	while (pattern.len() > 0 && (pattern.last() == '/' || pattern.last() == '\\')) {
+		pattern.pop();
+	}
+	if (pattern.len() == 0) return false;
+	pattern.append("\\*");
+
+	int wlen = MultiByteToWideChar(CP_UTF8, 0, pattern.c_str(), -1, NULL, 0);
+	if (!wlen) return false;
+	Cute::Array<wchar_t> wpattern;
+	wpattern.set_count(wlen);
+	if (!MultiByteToWideChar(CP_UTF8, 0, pattern.c_str(), -1, wpattern.data(), wlen)) return false;
+
+	WIN32_FIND_DATAW fd;
+	HANDLE h = FindFirstFileW(wpattern.data(), &fd);
+	if (h == INVALID_HANDLE_VALUE) return false;
+	do {
+		if (!wcscmp(fd.cFileName, L".") || !wcscmp(fd.cFileName, L"..")) continue;
+
+		// PhysFS types these with isSymlink() over a followed GetFileAttributesExW, which
+		// FindFirstFileW cannot reproduce -- it reports the link, not the target. Leave them out
+		// so the caller stats them the ordinary way.
+		if (fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) continue;
+
+		// One path component, so at most 255 wchars and 1020 UTF-8 bytes. Only the full pattern
+		// above needs dynamic sizing.
+		char utf8[1024];
+		if (!WideCharToMultiByte(CP_UTF8, 0, fd.cFileName, -1, utf8, sizeof(utf8), NULL, NULL)) continue;
+
+		CF_DirEntry e;
+		e.name = utf8;
+		e.is_directory = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+		e.size = e.is_directory ? 0 : ((((uint64_t)fd.nFileSizeHigh) << 32) | fd.nFileSizeLow);
+		if (!s_filetime_to_physfs_time(&fd.ftLastWriteTime, &tzi, &e.modified_time)) continue;
+		e.stat_ok = true;
+		out->add(sintern(e.name.c_str()), e);
+	} while (FindNextFileW(h, &fd));
+	FindClose(h);
+	return true;
+}
+
+#else
+
+bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out)
+{
+	int dir_fd = open(platform_directory, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+	if (dir_fd < 0) return false;
+	DIR* d = fdopendir(dir_fd);  // Takes ownership of dir_fd.
+	if (!d) { close(dir_fd); return false; }
+
+	struct dirent* de;
+	while ((de = readdir(d)) != NULL) {
+		if (!CF_STRCMP(de->d_name, ".") || !CF_STRCMP(de->d_name, "..")) continue;
+
+		CF_DirEntry e;
+		e.name = de->d_name;
+		e.stat_ok = true;
+#ifdef _DIRENT_HAVE_D_TYPE
+		// Recursion needs the type, never the mtime. DT_DIR does not follow symlinks, so a
+		// symlink to a directory lands as DT_LNK and takes the fstatat path below -- which is
+		// what keeps the typing identical to PhysFS's.
+		if (de->d_type == DT_DIR) {
+			e.is_directory = true;
+			out->add(sintern(e.name.c_str()), e);
+			continue;
+		}
+#endif
+		struct stat st;
+		// AT_SYMLINK_NOFOLLOW is lstat, matching DIR_stat's follow=0. Following would give a
+		// symlink the target's type and mtime where PhysFS reports the link's.
+		if (fstatat(dirfd(d), de->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) continue;
+		e.is_directory = S_ISDIR(st.st_mode);
+		e.size = (uint64_t)st.st_size;
+		e.modified_time = (uint64_t)st.st_mtime;
+		out->add(sintern(e.name.c_str()), e);
+	}
+	closedir(d);
+	return true;
+}
+
+#endif // CF_WINDOWS
+
+// PhysFS stores a mount point as the sanitized path plus a trailing slash and no leading slash
+// ("shaders/extra/"), and reports "/" for a root mount. Virtual paths reach us in any shape.
+// Reduce both to the same bare form -- no leading or trailing slash -- so that subtracting one from
+// the other is a plain string compare, matching what verifyPath does internally.
+static Cute::String s_bare_virtual_path(const char* path)
+{
+	int begin = 0;
+	while (path[begin] == '/') { ++begin; }
+	Cute::String bare = path + begin;
+	while (bare.len() > 0 && bare.last() == '/') { bare.pop(); }
+	return bare;
+}
+
+void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::String>* out,
+                            Cute::Array<Cute::String>* out_virtual_names)
+{
+	char** search = PHYSFS_getSearchPath();
+	if (!search) return;
+
+	Cute::String vdir = s_bare_virtual_path(virtual_directory);
+	for (char** it = search; *it; ++it) {
+		const char* raw_mount_point = PHYSFS_getMountPoint(*it);
+		if (!raw_mount_point) continue;
+		Cute::String mount_point = s_bare_virtual_path(raw_mount_point);
+		Cute::String candidate = *it;
+
+		if (mount_point.len() == 0) {
+			// Mounted at the root, so the whole virtual path is the path inside the archive.
+			if (vdir.len() > 0) {
+				candidate.append("/");
+				candidate.append(vdir.c_str());
+			}
+		} else if (CF_STRCMP(mount_point.c_str(), vdir.c_str()) == 0) {
+			// The mount point *is* this directory, so the archive's root is the directory.
+		} else if (vdir.len() > mount_point.len() &&
+		           CF_STRNCMP(vdir.c_str(), mount_point.c_str(), (size_t)mount_point.len()) == 0 &&
+		           vdir.c_str()[mount_point.len()] == '/') {
+			candidate.append("/");
+			candidate.append(vdir.c_str() + mount_point.len() + 1);
+		} else if (mount_point.len() > vdir.len() &&
+		           (vdir.len() == 0 ||
+		            (CF_STRNCMP(mount_point.c_str(), vdir.c_str(), (size_t)vdir.len()) == 0 &&
+		             mount_point.c_str()[vdir.len()] == '/'))) {
+			// The mount point sits *below* this directory. The mount serves no real directory here,
+			// it only makes the next component of its mount point appear as a virtual subdirectory.
+			// That name follows from the mount table alone, so cf_fs_generation already covers any
+			// change to it -- but a caller proving it can see everything PhysFS reports still has
+			// to be told the name exists, since no walk will ever produce it.
+			const char* rest = mount_point.c_str() + (vdir.len() ? vdir.len() + 1 : 0);
+			// Pushed a character at a time rather than built with String(start, end): that
+			// constructor strncpy's exactly `length` bytes and then claims a length of one more,
+			// so it leaves the string unterminated whenever the source runs past `end`.
+			Cute::String name;
+			for (int k = 0; rest[k] && rest[k] != '/'; ++k) {
+				name.add(rest[k]);
+			}
+			out_virtual_names->add(cf_move(name));
+			continue;
+		} else {
+			// This mount cannot reach the path at all.
+			continue;
+		}
+
+		out->add(cf_move(candidate));
+	}
+
+	PHYSFS_freeList(search);
 }
 
 const char* cf_fs_get_backend_specific_error_message()

--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -278,12 +278,12 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 		if (!WideCharToMultiByte(CP_UTF8, 0, fd.cFileName, -1, utf8, sizeof(utf8), NULL, NULL)) continue;
 
 		CF_DirEntry e;
-		e.name = utf8;
+		e.name = sintern(utf8);
 		e.is_directory = (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 		e.size = e.is_directory ? 0 : ((((uint64_t)fd.nFileSizeHigh) << 32) | fd.nFileSizeLow);
 		if (!s_filetime_to_physfs_time(&fd.ftLastWriteTime, &tzi, &e.modified_time)) continue;
 		e.stat_ok = true;
-		out->add(sintern(e.name.c_str()), e);
+		out->add(e.name, e);
 	} while (FindNextFileW(h, &fd));
 	FindClose(h);
 	return true;
@@ -303,7 +303,7 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 		if (!CF_STRCMP(de->d_name, ".") || !CF_STRCMP(de->d_name, "..")) continue;
 
 		CF_DirEntry e;
-		e.name = de->d_name;
+		e.name = sintern(de->d_name);
 		e.stat_ok = true;
 #ifdef _DIRENT_HAVE_D_TYPE
 		// Recursion needs the type, never the mtime. DT_DIR does not follow symlinks, so a
@@ -311,7 +311,7 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 		// what keeps the typing identical to PhysFS's.
 		if (de->d_type == DT_DIR) {
 			e.is_directory = true;
-			out->add(sintern(e.name.c_str()), e);
+			out->add(e.name, e);
 			continue;
 		}
 #endif
@@ -322,7 +322,7 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 		e.is_directory = S_ISDIR(st.st_mode);
 		e.size = (uint64_t)st.st_size;
 		e.modified_time = (uint64_t)st.st_mtime;
-		out->add(sintern(e.name.c_str()), e);
+		out->add(e.name, e);
 	}
 	closedir(d);
 	return true;

--- a/src/cute_file_system.cpp
+++ b/src/cute_file_system.cpp
@@ -201,22 +201,14 @@ void cf_fs_free_enumerated_directory(const char** directory_list)
 }
 
 //--------------------------------------------------------------------------------------------------
-// Native (non-PhysFS) bulk directory walk.
-//
-// PHYSFS_stat costs a syscall per file, which makes anything that polls a directory scale with
-// the file count. Every platform's directory walk already carries the metadata that stat would
-// return, so read it once for the whole directory instead.
-//
-// Callers must treat this as an accelerator only. It has no idea what is mounted where, so the
-// authority on which files exist stays with PhysFS -- see cf_fs_scan_native_directory's comment.
+// Native (non-PhysFS) bulk directory walk. See internal/cute_file_system_internal.h.
 
 #ifdef CF_WINDOWS
 
-// Mirrors PhysFS's FileTimeToPhysfsTime (physfs_platform_windows.c), which round-trips through
-// local time rather than subtracting the epoch. Timestamps produced here are compared against
-// ones PHYSFS_stat produced, so agreeing with PhysFS matters more than being right: the two
-// disagree in the ambiguous DST fall-back hour, under a TZ override, and across historical rule
-// changes, and a divergence makes a file look permanently changed or permanently unchanged.
+// Mirrors PhysFS's FileTimeToPhysfsTime, which round-trips through local time rather than
+// subtracting the epoch. Agreeing with PhysFS matters more than being right: the two disagree in
+// the ambiguous DST fall-back hour, under a TZ override, and across historical rule changes, and a
+// timestamp from here gets compared against one PHYSFS_stat produced.
 static bool s_filetime_to_physfs_time(const FILETIME* ft, const TIME_ZONE_INFORMATION* tzi, uint64_t* out)
 {
 	SYSTEMTIME st_utc, st_local;
@@ -242,12 +234,10 @@ static bool s_filetime_to_physfs_time(const FILETIME* ft, const TIME_ZONE_INFORM
 
 bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out)
 {
-	// One call for the whole walk. PhysFS fetches this per stat, but it cannot change midway
-	// through a single directory in any way that matters.
 	TIME_ZONE_INFORMATION tzi;
 	if (GetTimeZoneInformation(&tzi) == TIME_ZONE_ID_INVALID) return false;
 
-	// Trailing separators would leave an empty path component ahead of the wildcard.
+	// A trailing separator would leave an empty path component ahead of the wildcard.
 	Cute::String pattern = platform_directory;
 	while (pattern.len() > 0 && (pattern.last() == '/' || pattern.last() == '\\')) {
 		pattern.pop();
@@ -267,14 +257,11 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 	do {
 		if (!wcscmp(fd.cFileName, L".") || !wcscmp(fd.cFileName, L"..")) continue;
 
-		// PhysFS types these with isSymlink() over a followed GetFileAttributesExW, which
-		// FindFirstFileW cannot reproduce -- it reports the link, not the target. Leave them out
-		// so the caller stats them the ordinary way.
+		// PhysFS types these through a *followed* GetFileAttributesExW, which FindFirstFileW cannot
+		// reproduce: it reports the link, not the target. Omit them so the caller stats them.
 		if (fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) continue;
 
-		// One path component, so at most 255 wchars and 1020 UTF-8 bytes. Only the full pattern
-		// above needs dynamic sizing.
-		char utf8[1024];
+		char utf8[1024];  // One path component: at most 255 wchars, 1020 UTF-8 bytes.
 		if (!WideCharToMultiByte(CP_UTF8, 0, fd.cFileName, -1, utf8, sizeof(utf8), NULL, NULL)) continue;
 
 		CF_DirEntry e;
@@ -305,19 +292,10 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 		CF_DirEntry e;
 		e.name = sintern(de->d_name);
 		e.stat_ok = true;
-#ifdef _DIRENT_HAVE_D_TYPE
-		// Recursion needs the type, never the mtime. DT_DIR does not follow symlinks, so a
-		// symlink to a directory lands as DT_LNK and takes the fstatat path below -- which is
-		// what keeps the typing identical to PhysFS's.
-		if (de->d_type == DT_DIR) {
-			e.is_directory = true;
-			out->add(e.name, e);
-			continue;
-		}
-#endif
+
 		struct stat st;
-		// AT_SYMLINK_NOFOLLOW is lstat, matching DIR_stat's follow=0. Following would give a
-		// symlink the target's type and mtime where PhysFS reports the link's.
+		// AT_SYMLINK_NOFOLLOW is lstat, matching PhysFS's DIR_stat. Following would give a symlink
+		// the target's type and mtime where PhysFS reports the link's.
 		if (fstatat(dirfd(d), de->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) continue;
 		e.is_directory = S_ISDIR(st.st_mode);
 		e.size = (uint64_t)st.st_size;
@@ -330,10 +308,9 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 
 #endif // CF_WINDOWS
 
-// PhysFS stores a mount point as the sanitized path plus a trailing slash and no leading slash
-// ("shaders/extra/"), and reports "/" for a root mount. Virtual paths reach us in any shape.
-// Reduce both to the same bare form -- no leading or trailing slash -- so that subtracting one from
-// the other is a plain string compare, matching what verifyPath does internally.
+// PhysFS reports a mount point with a trailing slash and no leading one ("shaders/extra/"), or "/"
+// for a root mount, while virtual paths arrive in any shape. Reducing both to a bare form makes
+// subtracting one from the other a plain string compare, which is what verifyPath does internally.
 static Cute::String s_bare_virtual_path(const char* path)
 {
 	int begin = 0;
@@ -357,13 +334,13 @@ void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::Str
 		Cute::String candidate = *it;
 
 		if (mount_point.len() == 0) {
-			// Mounted at the root, so the whole virtual path is the path inside the archive.
+			// Root mount: the whole virtual path is the path inside the archive.
 			if (vdir.len() > 0) {
 				candidate.append("/");
 				candidate.append(vdir.c_str());
 			}
 		} else if (CF_STRCMP(mount_point.c_str(), vdir.c_str()) == 0) {
-			// The mount point *is* this directory, so the archive's root is the directory.
+			// The mount point is this directory, so the archive root is the directory.
 		} else if (vdir.len() > mount_point.len() &&
 		           CF_STRNCMP(vdir.c_str(), mount_point.c_str(), (size_t)mount_point.len()) == 0 &&
 		           vdir.c_str()[mount_point.len()] == '/') {
@@ -373,15 +350,12 @@ void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::Str
 		           (vdir.len() == 0 ||
 		            (CF_STRNCMP(mount_point.c_str(), vdir.c_str(), (size_t)vdir.len()) == 0 &&
 		             mount_point.c_str()[vdir.len()] == '/'))) {
-			// The mount point sits *below* this directory. The mount serves no real directory here,
-			// it only makes the next component of its mount point appear as a virtual subdirectory.
-			// That name follows from the mount table alone, so cf_fs_generation already covers any
-			// change to it -- but a caller proving it can see everything PhysFS reports still has
-			// to be told the name exists, since no walk will ever produce it.
+			// The mount point sits below this directory, so the mount serves no real directory here
+			// -- it only makes the next component of its mount point appear as a subdirectory.
 			const char* rest = mount_point.c_str() + (vdir.len() ? vdir.len() + 1 : 0);
-			// Pushed a character at a time rather than built with String(start, end): that
-			// constructor strncpy's exactly `length` bytes and then claims a length of one more,
-			// so it leaves the string unterminated whenever the source runs past `end`.
+			// A character at a time, not String(start, end): that constructor strncpy's exactly
+			// `length` bytes and then claims a length one longer, leaving the string unterminated
+			// whenever the source runs past `end`.
 			Cute::String name;
 			for (int k = 0; rest[k] && rest[k] != '/'; ++k) {
 				name.add(rest[k]);
@@ -389,8 +363,7 @@ void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::Str
 			out_virtual_names->add(cf_move(name));
 			continue;
 		} else {
-			// This mount cannot reach the path at all.
-			continue;
+			continue;  // This mount cannot reach the path at all.
 		}
 
 		out->add(cf_move(candidate));

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -74,8 +74,8 @@ static bool s_signatures_equal(const Array<CF_DirSignature>& a, const Array<CF_D
 	return true;
 }
 
-// Name, mtime and type for every entry of one directory under the shader directory. Built from
-// bulk walks wherever possible; see internal/cute_file_system_internal.h for the strategy.
+// Gathers name, mtime and type for every entry of one directory under the shader directory, from
+// bulk walks wherever it can; see internal/cute_file_system_internal.h for the strategy.
 static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 {
 	CF_Path vdir = app->shader_directory + path;

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -12,6 +12,7 @@
 
 #include <internal/cute_alloc_internal.h>
 #include <internal/cute_app_internal.h>
+#include <internal/cute_file_system_internal.h>
 #include <internal/cute_graphics_internal.h>
 
 #include "cute_shader.h"
@@ -29,31 +30,217 @@ static Map<const char*> s_compute_shader_paths;
 struct CF_GraphicsShaderPaths { const char* vertex_path; const char* fragment_path; };
 static Map<CF_GraphicsShaderPaths> s_graphics_shader_paths;
 
+// Enable to run the PhysFS path alongside the native one and assert they agree. This costs
+// strictly more than the code it checks, so it is off unless explicitly defined. Every failure
+// mode the native walk can have is a silently wrong mtime, which from outside the app looks
+// exactly like a file that did not change -- comparing the two paths is the only way to see it.
+//
+// Run it against a quiescent shader tree. The two reads happen at different instants, so a file
+// written *between* them trips the mtime assert by exactly one second, with the walk reading the
+// older value. That is read skew in the checker, not a divergence in the code being checked --
+// and the walk lagging is the harmless direction, since the next scan sees the newer mtime.
+//#define CF_SHADER_WATCH_VERIFY
+
+#ifdef CF_SHADER_WATCH_VERIFY
+static void s_dir_meta_verify(CF_Path vdir, const CF_DirEntry& e)
+{
+	CF_Stat st = { };
+	if (cf_is_error(fs_stat(vdir + e.name.c_str(), &st))) { CF_ASSERT(!e.stat_ok); return; }
+	CF_ASSERT(e.stat_ok);
+	// Catches symlink and junction typing, where a native walk and PhysFS disagree by default.
+	CF_ASSERT(e.is_directory == (st.type == CF_FILE_TYPE_DIRECTORY));
+	// mtime catches a time-conversion divergence or a wrong real directory; size catches a wrong
+	// real directory whose mtimes happen to collide. Directories carry neither -- see CF_DirEntry.
+	if (!e.is_directory) {
+		CF_ASSERT(e.modified_time == st.last_modified_time);
+		CF_ASSERT(e.size == (uint64_t)st.size);
+	}
+}
+#endif
+
+// A directory listing PhysFS gave us once, plus everything needed to know it is still current.
+// See s_dir_meta for why this is worth caching at all.
+struct CF_ShaderDirCache
+{
+	Array<CF_Path> names;               // The union listing, as PhysFS reported it.
+	Array<CF_DirSignature> signatures;  // One per mount candidate, in search-path order.
+	uint64_t fs_generation = 0;
+	// False when some mount contributes entries none of our walks can see, so a change there would
+	// go unnoticed. Such a directory is never cached -- it re-enumerates every scan.
+	bool cacheable = false;
+};
+static Map<CF_ShaderDirCache> s_shader_dir_cache;
+
+static bool s_signatures_equal(const Array<CF_DirSignature>& a, const Array<CF_DirSignature>& b)
+{
+	if (a.count() != b.count()) return false;
+	for (int i = 0; i < a.count(); ++i) {
+		if (!cf_fs_dir_signature_equal(a[i], b[i])) return false;
+	}
+	return true;
+}
+
+// Gathers (name, mtime, is_directory) for one directory under the shader directory, taking the
+// metadata from a single native walk where it can and from fs_stat where it cannot.
+//
+// The native walk is an accelerator for metadata, never the authority on what exists. Only
+// PhysFS knows the merged file set, at any depth and after a later cf_fs_mount: a subdirectory
+// can be provided by a different mount than its parent, so a check at the root proves nothing
+// about what is below it. Take the file list from the walk instead and a shader shadowed by a
+// lower mount silently stops hot-reloading.
+//
+// But asking PhysFS is expensive out of all proportion: PHYSFS_enumerateFiles stats every entry
+// internally (enumCallbackFilterSymLinks, to drop symlinks it will not report), so it costs a
+// per-file metadata query where a bulk walk costs a shared one -- ~73us against ~1us per entry
+// here. So the listing is cached, and revalidated every scan against things that are cheap to
+// check: the mount generation, and one bulk walk per mount that could contribute to the directory.
+// A file's contents and mtime affect neither, so editing a shader -- the whole point of the
+// watcher, and the common case by far -- never costs an enumerate.
+static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
+{
+	CF_Path vdir = app->shader_directory + path;
+	const char* vkey = sintern(vdir.c_str());
+
+	// Where each mount that could contribute here would serve this directory from, in search order.
+	// Subtracting the mount point is what makes this the *right* real directory rather than a guess
+	// at it, but PHYSFS_setRoot's prefix still has no getter, so these stay candidates -- proven
+	// below, never trusted.
+	Array<String> candidates;
+	Array<String> mount_point_names;
+	cf_fs_mount_candidates(vdir.c_str(), &candidates, &mount_point_names);
+
+	// One bulk walk per candidate. The first that walks supplies the metadata; the rest exist only
+	// to notice a file appearing or disappearing in a lower mount, which is precisely what a walk
+	// of the topmost directory alone cannot see.
+	Array<Map<CF_DirEntry>> walks;
+	Array<CF_DirSignature> signatures;
+	int native_index = -1;
+	for (int i = 0; i < candidates.count(); ++i) {
+		walks.add();
+		CF_DirSignature sig;  // count -1: this mount has no such directory, or it is an archive.
+		if (cf_fs_scan_native_directory(candidates[i].c_str(), &walks[i])) {
+			sig = cf_fs_dir_signature(&walks[i]);
+			if (native_index < 0) native_index = i;
+		}
+		signatures.add(sig);
+	}
+
+	CF_ShaderDirCache* cache = s_shader_dir_cache.try_find(vkey);
+	bool reuse = cache && cache->cacheable &&
+	             cache->fs_generation == cf_fs_generation() &&
+	             s_signatures_equal(cache->signatures, signatures);
+
+	if (!reuse) {
+		if (!cache) cache = s_shader_dir_cache.add(vkey);
+		cache->names = CF_Directory::enumerate(vdir);
+		cache->signatures = signatures;
+		cache->fs_generation = cf_fs_generation();
+
+		// The proof that the cache is allowed to exist: every name PhysFS reports must be visible
+		// in at least one walk. A name we cannot see is a name whose comings and goings we cannot
+		// detect, and caching past that is how a shader silently stops hot-reloading. Extra names
+		// in a walk are harmless -- PhysFS hides symlinks and shadowed duplicates -- it is a
+		// missing one that blinds the detector.
+		cache->cacheable = true;
+		for (int i = 0; i < cache->names.count() && cache->cacheable; ++i) {
+			const char* name = sintern(cache->names[i].c_str());
+			bool seen = false;
+			for (int k = 0; k < walks.count() && !seen; ++k) {
+				seen = walks[k].try_find(name) != NULL;
+			}
+			// A directory that exists only because a mount point passes through it has no real
+			// counterpart to walk, so it can never appear above. It comes from the mount table,
+			// which cf_fs_generation tracks, so it is just as watched as anything else.
+			for (int k = 0; k < mount_point_names.count() && !seen; ++k) {
+				seen = sintern(mount_point_names[k].c_str()) == name;
+			}
+			if (!seen) cache->cacheable = false;
+		}
+	}
+
+	Array<CF_Path>& names = cache->names;
+	Map<CF_DirEntry> empty_walk;
+	Map<CF_DirEntry>& native = native_index >= 0 ? walks[native_index] : empty_walk;
+	bool have_native = native_index >= 0;
+
+	// The metadata proof: one fs_stat against the first regular entry the walk claims. A wrong real
+	// directory fails on mtime or size and the whole table is dropped. One stat per directory per
+	// scan -- and per scan deliberately, since a mount can change at any time and caching this
+	// would rebuild the very hole the design closes.
+	if (have_native) {
+		bool proven = false;
+		for (int i = 0; i < names.size(); ++i) {
+			CF_DirEntry* e = native.try_find(sintern(names[i].c_str()));
+			if (!e || e->is_directory) continue;
+			CF_Stat st = { };
+			if (cf_is_error(fs_stat(vdir + names[i], &st))) break;
+			proven = st.type == CF_FILE_TYPE_REGULAR &&
+			         st.last_modified_time == e->modified_time &&
+			         (uint64_t)st.size == e->size;
+			break;
+		}
+		// A directory of nothing but subdirectories cannot be proven and falls back. No loss:
+		// directories cost one stat each today anyway.
+		if (!proven) have_native = false;
+	}
+
+	for (int i = 0; i < names.size(); ++i) {
+		CF_DirEntry* hit = have_native ? native.try_find(sintern(names[i].c_str())) : NULL;
+		if (hit) {
+			// PhysFS resolves first-match in search-path order, and every mount holding
+			// /shaders/x.vs also holds /shaders -- so a name found in the real directory PhysFS
+			// named for the *directory* is the same file PHYSFS_stat would resolve for the file.
+			out->add(*hit);
+			continue;
+		}
+		// Shadowed by a lower mount, inside an archive mount, a reparse point, or no native walk
+		// at all: the ordinary PhysFS path.
+		CF_DirEntry e;
+		e.name = names[i].c_str();
+		CF_Stat st = { };
+		// fs_stat leaves `st` untouched on failure. Emit the entry anyway with stat_ok clear:
+		// populate has to create the map key either way, or the watch pass asserts on a lookup
+		// for a file it can still see. See s_shader_watch_recursive.
+		e.stat_ok = !cf_is_error(fs_stat(vdir + names[i], &st));
+		e.modified_time = e.stat_ok ? st.last_modified_time : 0;
+		e.size = e.stat_ok ? (uint64_t)st.size : 0;
+		e.is_directory = e.stat_ok && st.type == CF_FILE_TYPE_DIRECTORY;
+		out->add(cf_move(e));
+	}
+
+#ifdef CF_SHADER_WATCH_VERIFY
+	for (int i = 0; i < out->count(); ++i) {
+		s_dir_meta_verify(vdir, (*out)[i]);
+	}
+#endif
+}
+
+// spext_equ rather than comparing a CF_Path's ext(): cf_path_get_ext returns NULL for a file with
+// no extension, and String::operator== would strcmp that null pointer.
+static bool s_is_watched_shader_ext(const char* p)
+{
+	return spext_equ(p, ".vs") || spext_equ(p, ".fs") || spext_equ(p, ".shd") ||
+	       spext_equ(p, ".c_shd") || spext_equ(p, ".vert") || spext_equ(p, ".frag");
+}
+
 static void s_shader_directory_recursive(CF_Path path)
 {
-	Array<CF_Path> dir = CF_Directory::enumerate(app->shader_directory + path);
-	for (int i = 0; i < dir.size(); ++i) {
-		CF_Path p = app->shader_directory + path + dir[i];
-		if (p.is_directory()) {
-			s_shader_directory_recursive(path + dir[i]);
-		} else {
-			CF_Stat stat;
-			fs_stat(p, &stat);
-			// spext_equ rather than comparing p.ext(): cf_path_get_ext returns NULL for a file with
-			// no extension, and String::operator== would strcmp that null pointer.
-			if (spext_equ(p.c_str(), ".vs") || spext_equ(p.c_str(), ".fs") ||
-			    spext_equ(p.c_str(), ".shd") || spext_equ(p.c_str(), ".c_shd")) {
-				// Exclude app->shader_directory for easier lookups.
-				// e.g. app->shader_directory is "/shaders" and contains
-				// "/shaders/my_shader.shd", the user needs to only reference it by:
-				// "my_shader.shd".
-				CF_ShaderFileInfo info;
-				info.stat = stat;
-				info.path = sintern(p);
-				const char* key = sintern(path + dir[i]);
-				app->shader_file_infos.add(key, info);
-			}
-		}
+	Array<CF_DirEntry> entries;
+	s_dir_meta(path, &entries);
+	for (int i = 0; i < entries.count(); ++i) {
+		const CF_DirEntry& e = entries[i];
+		if (e.is_directory) { s_shader_directory_recursive(path + e.name.c_str()); continue; }
+		if (!s_is_watched_shader_ext(e.name.c_str())) continue;
+		// Exclude app->shader_directory for easier lookups.
+		// e.g. app->shader_directory is "/shaders" and contains
+		// "/shaders/my_shader.shd", the user needs to only reference it by:
+		// "my_shader.shd".
+		CF_ShaderFileInfo info;
+		// Zero when the stat failed. The key has to exist either way; see s_shader_watch_recursive.
+		info.last_modified_time = e.modified_time;
+		info.path = sintern(app->shader_directory + path + e.name.c_str());
+		const char* key = sintern(path + e.name.c_str());
+		app->shader_file_infos.add(key, info);
 	}
 }
 
@@ -162,29 +349,33 @@ static void s_shader_auto_reload(const char* changed_key)
 
 static void s_shader_watch_recursive(CF_Path path)
 {
-	Array<CF_Path> dir = CF_Directory::enumerate(app->shader_directory + path);
-	for (int i = 0; i < dir.size(); ++i) {
-		CF_Path p = app->shader_directory + path + dir[i];
-		if (p.is_directory()) {
-			s_shader_watch_recursive(path + dir[i]);
-		} else {
-			CF_Stat stat;
-			fs_stat(p, &stat);
-			// spext_equ rather than comparing p.ext(): cf_path_get_ext returns NULL for a file with
-			// no extension, and String::operator== would strcmp that null pointer.
-			if (spext_equ(p.c_str(), ".vs") || spext_equ(p.c_str(), ".fs") ||
-			    spext_equ(p.c_str(), ".shd") || spext_equ(p.c_str(), ".c_shd")) {
-				const char* key = sintern(path + dir[i]);
-				CF_ShaderFileInfo& info = app->shader_file_infos.find(key);
-				if (info.stat.last_modified_time < stat.last_modified_time) {
-					info.stat.last_modified_time = stat.last_modified_time;
-					if (app->on_shader_changed_fn) {
-						app->on_shader_changed_fn(key, app->on_shader_changed_udata);
-					} else {
-						// No user callback: hot-reload affected shaders in place.
-						s_shader_auto_reload(key);
-					}
-				}
+	Array<CF_DirEntry> entries;
+	s_dir_meta(path, &entries);
+	for (int i = 0; i < entries.count(); ++i) {
+		const CF_DirEntry& e = entries[i];
+		if (e.is_directory) { s_shader_watch_recursive(path + e.name.c_str()); continue; }
+		if (!e.stat_ok) continue; // Unreadable this scan; leave the stored value alone.
+		// A plain string compare now, rather than something reached only after two syscalls.
+		if (!s_is_watched_shader_ext(e.name.c_str())) continue;
+
+		const char* key = sintern(path + e.name.c_str());
+		CF_ShaderFileInfo* info = app->shader_file_infos.try_find(key);
+		if (!info) {
+			// Created after cf_shader_directory ran, so populate never saw it. Adopt it rather
+			// than assert; the next write to it hot-reloads like any other file.
+			CF_ShaderFileInfo fresh;
+			fresh.last_modified_time = e.modified_time;
+			fresh.path = sintern(app->shader_directory + path + e.name.c_str());
+			app->shader_file_infos.add(key, fresh);
+			continue;
+		}
+		if (info->last_modified_time < e.modified_time) {
+			info->last_modified_time = e.modified_time;
+			if (app->on_shader_changed_fn) {
+				app->on_shader_changed_fn(key, app->on_shader_changed_udata);
+			} else {
+				// No user callback: hot-reload affected shaders in place.
+				s_shader_auto_reload(key);
 			}
 		}
 	}

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -30,15 +30,10 @@ static Map<const char*> s_compute_shader_paths;
 struct CF_GraphicsShaderPaths { const char* vertex_path; const char* fragment_path; };
 static Map<CF_GraphicsShaderPaths> s_graphics_shader_paths;
 
-// Enable to run the PhysFS path alongside the native one and assert they agree. This costs
-// strictly more than the code it checks, so it is off unless explicitly defined. Every failure
-// mode the native walk can have is a silently wrong mtime, which from outside the app looks
-// exactly like a file that did not change -- comparing the two paths is the only way to see it.
-//
-// Run it against a quiescent shader tree. The two reads happen at different instants, so a file
-// written *between* them trips the mtime assert by exactly one second, with the walk reading the
-// older value. That is read skew in the checker, not a divergence in the code being checked --
-// and the walk lagging is the harmless direction, since the next scan sees the newer mtime.
+// Runs the PhysFS path alongside the native one and asserts they agree. Every way the native walk
+// can be wrong looks, from outside, exactly like a file that did not change, so comparing the two
+// is the only way to see it. Costs more than the code it checks, and wants a quiescent shader tree:
+// a file written between the two reads trips the mtime assert by a second.
 //#define CF_SHADER_WATCH_VERIFY
 
 #ifdef CF_SHADER_WATCH_VERIFY
@@ -47,33 +42,25 @@ static void s_dir_meta_verify(CF_Path vdir, const CF_DirEntry& e)
 	CF_Stat st = { };
 	if (cf_is_error(fs_stat(vdir + e.name, &st))) { CF_ASSERT(!e.stat_ok); return; }
 	CF_ASSERT(e.stat_ok);
-	// Catches symlink and junction typing, where a native walk and PhysFS disagree by default.
 	CF_ASSERT(e.is_directory == (st.type == CF_FILE_TYPE_DIRECTORY));
-	// mtime catches a time-conversion divergence or a wrong real directory; size catches a wrong
-	// real directory whose mtimes happen to collide. Directories carry neither -- see CF_DirEntry.
-	if (!e.is_directory) {
-		CF_ASSERT(e.modified_time == st.last_modified_time);
-		CF_ASSERT(e.size == (uint64_t)st.size);
-	}
+	CF_ASSERT(e.modified_time == st.last_modified_time);
+	CF_ASSERT(e.size == (uint64_t)st.size);
 }
 #endif
 
-// A directory listing PhysFS gave us once, plus everything needed to know it is still current.
-// See s_dir_meta for why this is worth caching at all.
 struct CF_ShaderDirCache
 {
-	Array<const char*> names;           // The union listing PhysFS reported, interned.
+	Array<const char*> names;           // The merged listing PhysFS reported, interned.
 	Array<CF_DirSignature> signatures;  // One per mount candidate, in search-path order.
 	uint64_t fs_generation = 0;
-	// False when some mount contributes entries none of our walks can see, so a change there would
-	// go unnoticed. Such a directory is never cached -- it re-enumerates every scan.
+	// False when a mount contributes entries no walk of ours can see, so a change there would go
+	// unnoticed. Those directories re-enumerate every scan instead.
 	bool cacheable = false;
-	// The §3.2 metadata proof, held across scans. It establishes which real directory the walk is
-	// reading, and that is a property of the mount table and of the directory's own existence --
-	// neither of which a file being written changes. Both are already revalidated every scan, so
-	// re-proving it every scan would be paying a stat to learn nothing. Only a success is cached:
-	// a probe can fail transiently when a file is written between the walk and the stat, and a
-	// cached failure would stick until the file *set* changed, which might be never.
+	// Which real directory the walk is reading is a property of the mount table and of the
+	// directory's own existence, both already revalidated every scan -- so a proof of it holds
+	// until the listing is refreshed. Only successes are held: a probe fails transiently when a
+	// file is written between the walk and the stat, and a held failure would last until the file
+	// set changed, which may be never.
 	bool probe_ok = false;
 };
 static Map<CF_ShaderDirCache> s_shader_dir_cache;
@@ -87,38 +74,19 @@ static bool s_signatures_equal(const Array<CF_DirSignature>& a, const Array<CF_D
 	return true;
 }
 
-// Gathers (name, mtime, is_directory) for one directory under the shader directory, taking the
-// metadata from a single native walk where it can and from fs_stat where it cannot.
-//
-// The native walk is an accelerator for metadata, never the authority on what exists. Only
-// PhysFS knows the merged file set, at any depth and after a later cf_fs_mount: a subdirectory
-// can be provided by a different mount than its parent, so a check at the root proves nothing
-// about what is below it. Take the file list from the walk instead and a shader shadowed by a
-// lower mount silently stops hot-reloading.
-//
-// But asking PhysFS is expensive out of all proportion: PHYSFS_enumerateFiles stats every entry
-// internally (enumCallbackFilterSymLinks, to drop symlinks it will not report), so it costs a
-// per-file metadata query where a bulk walk costs a shared one -- ~73us against ~1us per entry
-// here. So the listing is cached, and revalidated every scan against things that are cheap to
-// check: the mount generation, and one bulk walk per mount that could contribute to the directory.
-// A file's contents and mtime affect neither, so editing a shader -- the whole point of the
-// watcher, and the common case by far -- never costs an enumerate.
+// Name, mtime and type for every entry of one directory under the shader directory. Built from
+// bulk walks wherever possible; see internal/cute_file_system_internal.h for the strategy.
 static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 {
 	CF_Path vdir = app->shader_directory + path;
 	const char* vkey = sintern(vdir.c_str());
 
-	// Where each mount that could contribute here would serve this directory from, in search order.
-	// Subtracting the mount point is what makes this the *right* real directory rather than a guess
-	// at it, but PHYSFS_setRoot's prefix still has no getter, so these stay candidates -- proven
-	// below, never trusted.
 	Array<String> candidates;
 	Array<String> mount_point_names;
 	cf_fs_mount_candidates(vdir.c_str(), &candidates, &mount_point_names);
 
-	// One bulk walk per candidate. The first that walks supplies the metadata; the rest exist only
-	// to notice a file appearing or disappearing in a lower mount, which is precisely what a walk
-	// of the topmost directory alone cannot see.
+	// The first candidate that walks supplies the metadata; the rest are walked only to notice a
+	// file appearing or disappearing in a lower mount, which a walk of the topmost cannot see.
 	Array<Map<CF_DirEntry>> walks;
 	Array<CF_DirSignature> signatures;
 	int native_index = -1;
@@ -139,8 +107,6 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 
 	if (!reuse) {
 		if (!cache) cache = s_shader_dir_cache.add(vkey);
-		// Interned once here rather than per scan: the listing is compared and looked up by name
-		// several times every scan, and an interned name makes each of those a pointer compare.
 		Array<CF_Path> enumerated = CF_Directory::enumerate(vdir);
 		cache->names.clear();
 		for (int i = 0; i < enumerated.size(); ++i) {
@@ -148,13 +114,11 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 		}
 		cache->signatures = signatures;
 		cache->fs_generation = cf_fs_generation();
-		cache->probe_ok = false;  // Different directory contents, so prove the metadata again.
+		cache->probe_ok = false;
 
-		// The proof that the cache is allowed to exist: every name PhysFS reports must be visible
-		// in at least one walk. A name we cannot see is a name whose comings and goings we cannot
-		// detect, and caching past that is how a shader silently stops hot-reloading. Extra names
-		// in a walk are harmless -- PhysFS hides symlinks and shadowed duplicates -- it is a
-		// missing one that blinds the detector.
+		// Caching is only allowed while every name PhysFS reports is visible in at least one walk.
+		// A name no walk can see is one whose comings and goings we cannot detect. Extra names in a
+		// walk are harmless -- PhysFS hides symlinks and shadowed duplicates.
 		cache->cacheable = true;
 		for (int i = 0; i < cache->names.count() && cache->cacheable; ++i) {
 			const char* name = cache->names[i];
@@ -162,9 +126,6 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 			for (int k = 0; k < walks.count() && !seen; ++k) {
 				seen = walks[k].try_find(name) != NULL;
 			}
-			// A directory that exists only because a mount point passes through it has no real
-			// counterpart to walk, so it can never appear above. It comes from the mount table,
-			// which cf_fs_generation tracks, so it is just as watched as anything else.
 			for (int k = 0; k < mount_point_names.count() && !seen; ++k) {
 				seen = sintern(mount_point_names[k].c_str()) == name;
 			}
@@ -173,17 +134,14 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 	}
 
 	Array<const char*>& names = cache->names;
-	Map<CF_DirEntry> empty_walk;
-	Map<CF_DirEntry>& native = native_index >= 0 ? walks[native_index] : empty_walk;
+	Map<CF_DirEntry>* native = native_index >= 0 ? &walks[native_index] : NULL;
 
-	// The metadata proof: one fs_stat against the first regular entry the walk claims. A wrong real
-	// directory fails on mtime or size and the whole table is dropped. Held across scans once it
-	// succeeds -- see CF_ShaderDirCache::probe_ok for why that is sound, and why only successes
-	// are held. A directory of nothing but subdirectories can never be proven and simply keeps the
-	// fs_stat path, at no cost: it does no stats to find that out.
-	if (native_index >= 0 && !cache->probe_ok) {
+	// Prove the walk is reading the directory PhysFS resolves files from: one fs_stat against the
+	// first regular entry it claims, which a wrong directory fails on mtime or size. A directory of
+	// nothing but subdirectories can never be proven, and costs nothing to discover that.
+	if (native && !cache->probe_ok) {
 		for (int i = 0; i < names.count(); ++i) {
-			CF_DirEntry* e = native.try_find(names[i]);
+			CF_DirEntry* e = native->try_find(names[i]);
 			if (!e || e->is_directory) continue;
 			CF_Stat st = { };
 			if (cf_is_error(fs_stat(vdir + names[i], &st))) break;
@@ -193,25 +151,23 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 			break;
 		}
 	}
-	bool have_native = native_index >= 0 && cache->probe_ok;
+	bool have_native = native && cache->probe_ok;
 
 	for (int i = 0; i < names.count(); ++i) {
-		CF_DirEntry* hit = have_native ? native.try_find(names[i]) : NULL;
+		// PhysFS resolves first-match in search-path order, and every mount holding /shaders/x.vs
+		// also holds /shaders -- so a name present in the walked directory is the same file
+		// PHYSFS_stat would have resolved.
+		CF_DirEntry* hit = have_native ? native->try_find(names[i]) : NULL;
 		if (hit) {
-			// PhysFS resolves first-match in search-path order, and every mount holding
-			// /shaders/x.vs also holds /shaders -- so a name found in the real directory PhysFS
-			// named for the *directory* is the same file PHYSFS_stat would resolve for the file.
 			out->add(*hit);
 			continue;
 		}
-		// Shadowed by a lower mount, inside an archive mount, a reparse point, or no native walk
-		// at all: the ordinary PhysFS path.
+		// Shadowed by a lower mount, inside an archive, a reparse point, or no walk at all.
 		CF_DirEntry e;
 		e.name = names[i];
 		CF_Stat st = { };
-		// fs_stat leaves `st` untouched on failure. Emit the entry anyway with stat_ok clear:
-		// populate has to create the map key either way, or the watch pass asserts on a lookup
-		// for a file it can still see. See s_shader_watch_recursive.
+		// Emitted even when the stat fails, with stat_ok clear: the key has to exist either way or
+		// the watch pass asserts on a lookup for a file it can still see.
 		e.stat_ok = !cf_is_error(fs_stat(vdir + names[i], &st));
 		e.modified_time = e.stat_ok ? st.last_modified_time : 0;
 		e.size = e.stat_ok ? (uint64_t)st.size : 0;
@@ -242,12 +198,8 @@ static void s_shader_directory_recursive(CF_Path path)
 		const CF_DirEntry& e = entries[i];
 		if (e.is_directory) { s_shader_directory_recursive(path + e.name); continue; }
 		if (!s_is_watched_shader_ext(e.name)) continue;
-		// Exclude app->shader_directory for easier lookups.
-		// e.g. app->shader_directory is "/shaders" and contains
-		// "/shaders/my_shader.shd", the user needs to only reference it by:
-		// "my_shader.shd".
+		// Keyed without app->shader_directory, so "/shaders/my_shader.shd" is "my_shader.shd".
 		CF_ShaderFileInfo info;
-		// Zero when the stat failed. The key has to exist either way; see s_shader_watch_recursive.
 		info.last_modified_time = e.modified_time;
 		info.path = sintern(app->shader_directory + path + e.name);
 		const char* key = sintern(path + e.name);
@@ -365,15 +317,13 @@ static void s_shader_watch_recursive(CF_Path path)
 	for (int i = 0; i < entries.count(); ++i) {
 		const CF_DirEntry& e = entries[i];
 		if (e.is_directory) { s_shader_watch_recursive(path + e.name); continue; }
-		if (!e.stat_ok) continue; // Unreadable this scan; leave the stored value alone.
-		// A plain string compare now, rather than something reached only after two syscalls.
+		if (!e.stat_ok) continue;  // Unreadable this scan; leave the stored value alone.
 		if (!s_is_watched_shader_ext(e.name)) continue;
 
 		const char* key = sintern(path + e.name);
 		CF_ShaderFileInfo* info = app->shader_file_infos.try_find(key);
 		if (!info) {
-			// Created after cf_shader_directory ran, so populate never saw it. Adopt it rather
-			// than assert; the next write to it hot-reloads like any other file.
+			// Created after cf_shader_directory ran. Adopt it rather than assert on the lookup.
 			CF_ShaderFileInfo fresh;
 			fresh.last_modified_time = e.modified_time;
 			fresh.path = sintern(app->shader_directory + path + e.name);
@@ -385,7 +335,6 @@ static void s_shader_watch_recursive(CF_Path path)
 			if (app->on_shader_changed_fn) {
 				app->on_shader_changed_fn(key, app->on_shader_changed_udata);
 			} else {
-				// No user callback: hot-reload affected shaders in place.
 				s_shader_auto_reload(key);
 			}
 		}
@@ -394,10 +343,8 @@ static void s_shader_watch_recursive(CF_Path path)
 
 void cf_shader_watch()
 {
-	// Watching runs whenever a shader directory is set. With a user callback the
-	// user owns reloading; without one, changed shaders hot-reload automatically
-	// (see s_shader_auto_reload). Auto mode is throttled -- it stats the whole
-	// shader directory, which nobody needs at frame rate.
+	// With a user callback the user owns reloading; without one, changed shaders hot-reload in
+	// place, and that path is throttled since nobody needs it at frame rate.
 	if (!app->shader_directory_set) return;
 	if (!app->on_shader_changed_fn) {
 		static int s_throttle = 0;

--- a/src/cute_graphics.cpp
+++ b/src/cute_graphics.cpp
@@ -45,7 +45,7 @@ static Map<CF_GraphicsShaderPaths> s_graphics_shader_paths;
 static void s_dir_meta_verify(CF_Path vdir, const CF_DirEntry& e)
 {
 	CF_Stat st = { };
-	if (cf_is_error(fs_stat(vdir + e.name.c_str(), &st))) { CF_ASSERT(!e.stat_ok); return; }
+	if (cf_is_error(fs_stat(vdir + e.name, &st))) { CF_ASSERT(!e.stat_ok); return; }
 	CF_ASSERT(e.stat_ok);
 	// Catches symlink and junction typing, where a native walk and PhysFS disagree by default.
 	CF_ASSERT(e.is_directory == (st.type == CF_FILE_TYPE_DIRECTORY));
@@ -62,12 +62,19 @@ static void s_dir_meta_verify(CF_Path vdir, const CF_DirEntry& e)
 // See s_dir_meta for why this is worth caching at all.
 struct CF_ShaderDirCache
 {
-	Array<CF_Path> names;               // The union listing, as PhysFS reported it.
+	Array<const char*> names;           // The union listing PhysFS reported, interned.
 	Array<CF_DirSignature> signatures;  // One per mount candidate, in search-path order.
 	uint64_t fs_generation = 0;
 	// False when some mount contributes entries none of our walks can see, so a change there would
 	// go unnoticed. Such a directory is never cached -- it re-enumerates every scan.
 	bool cacheable = false;
+	// The §3.2 metadata proof, held across scans. It establishes which real directory the walk is
+	// reading, and that is a property of the mount table and of the directory's own existence --
+	// neither of which a file being written changes. Both are already revalidated every scan, so
+	// re-proving it every scan would be paying a stat to learn nothing. Only a success is cached:
+	// a probe can fail transiently when a file is written between the walk and the stat, and a
+	// cached failure would stick until the file *set* changed, which might be never.
+	bool probe_ok = false;
 };
 static Map<CF_ShaderDirCache> s_shader_dir_cache;
 
@@ -132,9 +139,16 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 
 	if (!reuse) {
 		if (!cache) cache = s_shader_dir_cache.add(vkey);
-		cache->names = CF_Directory::enumerate(vdir);
+		// Interned once here rather than per scan: the listing is compared and looked up by name
+		// several times every scan, and an interned name makes each of those a pointer compare.
+		Array<CF_Path> enumerated = CF_Directory::enumerate(vdir);
+		cache->names.clear();
+		for (int i = 0; i < enumerated.size(); ++i) {
+			cache->names.add(sintern(enumerated[i].c_str()));
+		}
 		cache->signatures = signatures;
 		cache->fs_generation = cf_fs_generation();
+		cache->probe_ok = false;  // Different directory contents, so prove the metadata again.
 
 		// The proof that the cache is allowed to exist: every name PhysFS reports must be visible
 		// in at least one walk. A name we cannot see is a name whose comings and goings we cannot
@@ -143,7 +157,7 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 		// missing one that blinds the detector.
 		cache->cacheable = true;
 		for (int i = 0; i < cache->names.count() && cache->cacheable; ++i) {
-			const char* name = sintern(cache->names[i].c_str());
+			const char* name = cache->names[i];
 			bool seen = false;
 			for (int k = 0; k < walks.count() && !seen; ++k) {
 				seen = walks[k].try_find(name) != NULL;
@@ -158,34 +172,31 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 		}
 	}
 
-	Array<CF_Path>& names = cache->names;
+	Array<const char*>& names = cache->names;
 	Map<CF_DirEntry> empty_walk;
 	Map<CF_DirEntry>& native = native_index >= 0 ? walks[native_index] : empty_walk;
-	bool have_native = native_index >= 0;
 
 	// The metadata proof: one fs_stat against the first regular entry the walk claims. A wrong real
-	// directory fails on mtime or size and the whole table is dropped. One stat per directory per
-	// scan -- and per scan deliberately, since a mount can change at any time and caching this
-	// would rebuild the very hole the design closes.
-	if (have_native) {
-		bool proven = false;
-		for (int i = 0; i < names.size(); ++i) {
-			CF_DirEntry* e = native.try_find(sintern(names[i].c_str()));
+	// directory fails on mtime or size and the whole table is dropped. Held across scans once it
+	// succeeds -- see CF_ShaderDirCache::probe_ok for why that is sound, and why only successes
+	// are held. A directory of nothing but subdirectories can never be proven and simply keeps the
+	// fs_stat path, at no cost: it does no stats to find that out.
+	if (native_index >= 0 && !cache->probe_ok) {
+		for (int i = 0; i < names.count(); ++i) {
+			CF_DirEntry* e = native.try_find(names[i]);
 			if (!e || e->is_directory) continue;
 			CF_Stat st = { };
 			if (cf_is_error(fs_stat(vdir + names[i], &st))) break;
-			proven = st.type == CF_FILE_TYPE_REGULAR &&
-			         st.last_modified_time == e->modified_time &&
-			         (uint64_t)st.size == e->size;
+			cache->probe_ok = st.type == CF_FILE_TYPE_REGULAR &&
+			                  st.last_modified_time == e->modified_time &&
+			                  (uint64_t)st.size == e->size;
 			break;
 		}
-		// A directory of nothing but subdirectories cannot be proven and falls back. No loss:
-		// directories cost one stat each today anyway.
-		if (!proven) have_native = false;
 	}
+	bool have_native = native_index >= 0 && cache->probe_ok;
 
-	for (int i = 0; i < names.size(); ++i) {
-		CF_DirEntry* hit = have_native ? native.try_find(sintern(names[i].c_str())) : NULL;
+	for (int i = 0; i < names.count(); ++i) {
+		CF_DirEntry* hit = have_native ? native.try_find(names[i]) : NULL;
 		if (hit) {
 			// PhysFS resolves first-match in search-path order, and every mount holding
 			// /shaders/x.vs also holds /shaders -- so a name found in the real directory PhysFS
@@ -196,7 +207,7 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 		// Shadowed by a lower mount, inside an archive mount, a reparse point, or no native walk
 		// at all: the ordinary PhysFS path.
 		CF_DirEntry e;
-		e.name = names[i].c_str();
+		e.name = names[i];
 		CF_Stat st = { };
 		// fs_stat leaves `st` untouched on failure. Emit the entry anyway with stat_ok clear:
 		// populate has to create the map key either way, or the watch pass asserts on a lookup
@@ -205,7 +216,7 @@ static void s_dir_meta(CF_Path path, Array<CF_DirEntry>* out)
 		e.modified_time = e.stat_ok ? st.last_modified_time : 0;
 		e.size = e.stat_ok ? (uint64_t)st.size : 0;
 		e.is_directory = e.stat_ok && st.type == CF_FILE_TYPE_DIRECTORY;
-		out->add(cf_move(e));
+		out->add(e);
 	}
 
 #ifdef CF_SHADER_WATCH_VERIFY
@@ -229,8 +240,8 @@ static void s_shader_directory_recursive(CF_Path path)
 	s_dir_meta(path, &entries);
 	for (int i = 0; i < entries.count(); ++i) {
 		const CF_DirEntry& e = entries[i];
-		if (e.is_directory) { s_shader_directory_recursive(path + e.name.c_str()); continue; }
-		if (!s_is_watched_shader_ext(e.name.c_str())) continue;
+		if (e.is_directory) { s_shader_directory_recursive(path + e.name); continue; }
+		if (!s_is_watched_shader_ext(e.name)) continue;
 		// Exclude app->shader_directory for easier lookups.
 		// e.g. app->shader_directory is "/shaders" and contains
 		// "/shaders/my_shader.shd", the user needs to only reference it by:
@@ -238,8 +249,8 @@ static void s_shader_directory_recursive(CF_Path path)
 		CF_ShaderFileInfo info;
 		// Zero when the stat failed. The key has to exist either way; see s_shader_watch_recursive.
 		info.last_modified_time = e.modified_time;
-		info.path = sintern(app->shader_directory + path + e.name.c_str());
-		const char* key = sintern(path + e.name.c_str());
+		info.path = sintern(app->shader_directory + path + e.name);
+		const char* key = sintern(path + e.name);
 		app->shader_file_infos.add(key, info);
 	}
 }
@@ -353,19 +364,19 @@ static void s_shader_watch_recursive(CF_Path path)
 	s_dir_meta(path, &entries);
 	for (int i = 0; i < entries.count(); ++i) {
 		const CF_DirEntry& e = entries[i];
-		if (e.is_directory) { s_shader_watch_recursive(path + e.name.c_str()); continue; }
+		if (e.is_directory) { s_shader_watch_recursive(path + e.name); continue; }
 		if (!e.stat_ok) continue; // Unreadable this scan; leave the stored value alone.
 		// A plain string compare now, rather than something reached only after two syscalls.
-		if (!s_is_watched_shader_ext(e.name.c_str())) continue;
+		if (!s_is_watched_shader_ext(e.name)) continue;
 
-		const char* key = sintern(path + e.name.c_str());
+		const char* key = sintern(path + e.name);
 		CF_ShaderFileInfo* info = app->shader_file_infos.try_find(key);
 		if (!info) {
 			// Created after cf_shader_directory ran, so populate never saw it. Adopt it rather
 			// than assert; the next write to it hot-reloads like any other file.
 			CF_ShaderFileInfo fresh;
 			fresh.last_modified_time = e.modified_time;
-			fresh.path = sintern(app->shader_directory + path + e.name.c_str());
+			fresh.path = sintern(app->shader_directory + path + e.name);
 			app->shader_file_infos.add(key, fresh);
 			continue;
 		}

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -81,7 +81,10 @@ struct CF_WindowState
 
 struct CF_ShaderFileInfo
 {
-	CF_Stat stat;
+	// The only piece of stat the watcher ever compares -- see s_shader_watch_recursive. Keeping
+	// a whole CF_Stat here would force the bulk directory scanner to synthesize fields nobody
+	// reads, and leave them zeroed as a trap for the next reader.
+	uint64_t last_modified_time;
 	const char* path;
 };
 

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -81,10 +81,7 @@ struct CF_WindowState
 
 struct CF_ShaderFileInfo
 {
-	// The only piece of stat the watcher ever compares -- see s_shader_watch_recursive. Keeping
-	// a whole CF_Stat here would force the bulk directory scanner to synthesize fields nobody
-	// reads, and leave them zeroed as a trap for the next reader.
-	uint64_t last_modified_time;
+	uint64_t last_modified_time;  // The only piece of stat the watcher compares.
 	const char* path;
 };
 

--- a/src/internal/cute_file_system_internal.h
+++ b/src/internal/cute_file_system_internal.h
@@ -1,0 +1,93 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#ifndef CF_FILE_SYSTEM_INTERNAL_H
+#define CF_FILE_SYSTEM_INTERNAL_H
+
+#include <cute_defines.h>
+#include <cute_array.h>
+#include <cute_map.h>
+#include <cute_string.h>
+
+// One entry from a native (non-PhysFS) directory walk. See cf_fs_scan_native_directory.
+//
+// `modified_time` and `size` are only meaningful when `is_directory` is false. The POSIX walk
+// types directories straight from `d_type` and never stats them, so a directory's mtime is
+// whatever the platform happened to hand back -- possibly zero. Nothing reads it: the shader
+// watcher only recurses into directories.
+struct CF_DirEntry
+{
+	Cute::String name;
+	uint64_t modified_time = 0;  // UNIX seconds, matching PHYSFS_Stat::modtime.
+	uint64_t size = 0;
+	bool is_directory = false;
+	bool stat_ok = false;
+};
+
+// Reads one real (platform) directory in a single walk and fills `out` with its entries, keyed
+// by `sintern`'d name. Returns false if the directory could not be walked, in which case `out`
+// is left as-is and the caller must fall back to per-file stats.
+//
+// This is a metadata accelerator, not a replacement for PhysFS enumeration: it knows nothing
+// about mounts, so it sees only whichever real directory it is pointed at. The metadata it
+// reports is deliberately bug-compatible with `PHYSFS_stat` -- see the notes on the Windows
+// time conversion and on symlink typing in the implementation.
+bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out);
+
+// A directory's entry set reduced to something cheap to compare from one scan to the next.
+// Adding, removing or renaming an entry changes it; writing to a file does not -- which is exactly
+// the distinction a cached directory *listing* needs.
+struct CF_DirSignature
+{
+	uint64_t hash = 0;
+	int count = -1;  // -1 means the directory could not be walked at all.
+};
+
+CF_INLINE bool cf_fs_dir_signature_equal(CF_DirSignature a, CF_DirSignature b)
+{
+	return a.hash == b.hash && a.count == b.count;
+}
+
+// Entries are keyed by `sintern`'d name, and an interned string is a stable unique pointer for the
+// life of the process -- so the set of keys identifies the listing without hashing any characters.
+// XOR and sum accumulate separately so the result does not depend on the order the walk happened to
+// return entries in.
+CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
+{
+	uint64_t x = 0, sum = 0;
+	int n = entries->count();
+	const uint64_t* keys = entries->keys();
+	for (int i = 0; i < n; ++i) {
+		x ^= keys[i];
+		sum += keys[i];
+	}
+	CF_DirSignature sig;
+	sig.hash = x ^ (sum * 1099511628211ULL);
+	sig.count = n;
+	return sig;
+}
+
+// Monotonic counter bumped by every call that can change the PhysFS search path -- cf_fs_mount and
+// cf_fs_dismount are the only two. Anything caching a view derived from the virtual filesystem
+// compares against this instead of trying to notice a mount change after the fact.
+uint64_t cf_fs_generation();
+
+// The real directory each mounted archive would serve `virtual_directory` from, in search-path
+// order, for every mount that could contribute entries to it. Derived from the mount table alone --
+// no filesystem calls -- by subtracting each archive's mount point from the virtual path.
+//
+// These are *candidates*, not facts. PHYSFS_setRoot's prefix has no getter, so a mount using it
+// resolves elsewhere than the arithmetic here suggests; such a candidate normally just fails to
+// walk. Callers must prove what they take from a candidate rather than trusting it.
+//
+// `out_virtual_names` collects the entries in this directory that exist only because a mount point
+// passes through it, and so have no real directory anywhere to walk. They come from the mount table
+// alone, which cf_fs_generation already tracks.
+void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::String>* out,
+                            Cute::Array<Cute::String>* out_virtual_names);
+
+#endif // CF_FILE_SYSTEM_INTERNAL_H

--- a/src/internal/cute_file_system_internal.h
+++ b/src/internal/cute_file_system_internal.h
@@ -21,7 +21,10 @@
 // watcher only recurses into directories.
 struct CF_DirEntry
 {
-	Cute::String name;
+	// Interned, so it is a stable unique pointer for the life of the process: comparing two names
+	// is a pointer compare, and an entry owns no allocation. A walk runs per directory per scan,
+	// so a heap string per entry here was most of what the walk cost.
+	const char* name = NULL;
 	uint64_t modified_time = 0;  // UNIX seconds, matching PHYSFS_Stat::modtime.
 	uint64_t size = 0;
 	bool is_directory = false;

--- a/src/internal/cute_file_system_internal.h
+++ b/src/internal/cute_file_system_internal.h
@@ -48,9 +48,10 @@ struct CF_DirEntry
 	bool stat_ok = false;
 };
 
-// Walks one real (platform) directory, keying `out` by interned name. False if it could not be
-// walked at all. The metadata is deliberately bug-compatible with PHYSFS_stat, so a caller may mix
-// entries from here with entries it stat'd itself.
+// Walks one real (platform) directory in a single pass, filling `out` with its entries keyed by
+// interned name; returns false, leaving `out` alone, if the directory could not be walked at all.
+// The metadata matches what PHYSFS_stat would report, quirks included, so a caller can mix these
+// entries with ones it stat'd itself.
 bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out);
 
 struct CF_DirSignature
@@ -64,9 +65,9 @@ CF_INLINE bool cf_fs_dir_signature_equal(CF_DirSignature a, CF_DirSignature b)
 	return a.hash == b.hash && a.count == b.count;
 }
 
-// Interned keys are stable unique pointers, so the set of them identifies the listing without
-// hashing any characters. XOR and sum accumulate separately so the result does not depend on the
-// order the walk returned entries in.
+// Reduces a walk to a value two scans can compare. Interned keys are stable unique pointers, so
+// the set of them identifies the listing without hashing any characters; XOR and sum accumulate
+// separately so the result does not depend on the order the walk returned entries in.
 CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
 {
 	uint64_t x = 0, sum = 0;
@@ -82,15 +83,18 @@ CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
 	return sig;
 }
 
-// Bumped by cf_fs_mount and cf_fs_dismount, the only calls that change the search path.
+// Returns a counter bumped by cf_fs_mount and cf_fs_dismount, the only calls that change the
+// search path. Anything caching a view derived from the virtual filesystem compares against it
+// instead of trying to notice a mount change after the fact.
 uint64_t cf_fs_generation();
 
-// The real directory each mount would serve `virtual_directory` from, in search-path order, for
-// every mount that could contribute to it. Candidates, not facts: PHYSFS_setRoot's prefix has no
-// getter, so a mount using it resolves somewhere other than this arithmetic suggests.
+// Fills `out` with the real directory each mount would serve `virtual_directory` from, in
+// search-path order, for every mount that could contribute to it. These are candidates, not facts:
+// PHYSFS_setRoot's prefix has no getter, so a mount using it resolves somewhere other than this
+// arithmetic suggests, and a caller must prove whatever it takes from one.
 //
-// `out_virtual_names` receives entries that exist only because a mount point passes through the
-// directory, which therefore have no real directory anywhere to walk.
+// Fills `out_virtual_names` with the entries that exist only because a mount point passes through
+// the directory, and so have no real directory anywhere to walk.
 void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::String>* out,
                             Cute::Array<Cute::String>* out_virtual_names);
 

--- a/src/internal/cute_file_system_internal.h
+++ b/src/internal/cute_file_system_internal.h
@@ -13,41 +13,50 @@
 #include <cute_map.h>
 #include <cute_string.h>
 
-// One entry from a native (non-PhysFS) directory walk. See cf_fs_scan_native_directory.
+// Fast directory polling, for code that must notice a file changing without paying for it every
+// frame. cf_shader_watch is why this exists.
 //
-// `modified_time` and `size` are only meaningful when `is_directory` is false. The POSIX walk
-// types directories straight from `d_type` and never stats them, so a directory's mtime is
-// whatever the platform happened to hand back -- possibly zero. Nothing reads it: the shader
-// watcher only recurses into directories.
+// The expensive operation is a per-file metadata query. PHYSFS_stat is one, and so is every entry
+// of PHYSFS_enumerateFiles -- it stats each entry internally to filter out symlinks it will not
+// report. A bulk directory walk (FindFirstFileW, readdir) hands back the same metadata for a whole
+// directory for roughly the cost of one query, so polling is built out of walks, and PhysFS is
+// asked as rarely as it can be.
+//
+// PhysFS still decides *what exists*. Several mounts can serve one directory at once and only
+// PhysFS knows the merged result, at any depth and after any later cf_fs_mount; a walk sees a
+// single real directory. So a walk is a metadata lookup table, never the file list. Take the list
+// from a walk instead and a file shadowed by a lower mount silently stops being watched.
+//
+// What is left is knowing when PhysFS's answer went stale, which is decided without asking it:
+//
+//   - the merged list changes only if the mount table changes, or if some contributing real
+//     directory gains, loses or renames an entry;
+//   - cf_fs_generation() tracks the first; one walk per contributing mount tracks the second,
+//     reduced to a CF_DirSignature a scan compares against the previous one;
+//   - writing to a file does neither, so editing a watched file never re-asks PhysFS.
+//
+// Anything derived from a mount's real path is a candidate to be proven rather than a fact. See
+// cf_fs_mount_candidates.
+
+// One entry of a bulk directory walk.
 struct CF_DirEntry
 {
-	// Interned, so it is a stable unique pointer for the life of the process: comparing two names
-	// is a pointer compare, and an entry owns no allocation. A walk runs per directory per scan,
-	// so a heap string per entry here was most of what the walk cost.
-	const char* name = NULL;
-	uint64_t modified_time = 0;  // UNIX seconds, matching PHYSFS_Stat::modtime.
+	const char* name = NULL;  // Interned, so comparing two names is a pointer compare.
+	uint64_t modified_time = 0;
 	uint64_t size = 0;
 	bool is_directory = false;
 	bool stat_ok = false;
 };
 
-// Reads one real (platform) directory in a single walk and fills `out` with its entries, keyed
-// by `sintern`'d name. Returns false if the directory could not be walked, in which case `out`
-// is left as-is and the caller must fall back to per-file stats.
-//
-// This is a metadata accelerator, not a replacement for PhysFS enumeration: it knows nothing
-// about mounts, so it sees only whichever real directory it is pointed at. The metadata it
-// reports is deliberately bug-compatible with `PHYSFS_stat` -- see the notes on the Windows
-// time conversion and on symlink typing in the implementation.
+// Walks one real (platform) directory, keying `out` by interned name. False if it could not be
+// walked at all. The metadata is deliberately bug-compatible with PHYSFS_stat, so a caller may mix
+// entries from here with entries it stat'd itself.
 bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_DirEntry>* out);
 
-// A directory's entry set reduced to something cheap to compare from one scan to the next.
-// Adding, removing or renaming an entry changes it; writing to a file does not -- which is exactly
-// the distinction a cached directory *listing* needs.
 struct CF_DirSignature
 {
 	uint64_t hash = 0;
-	int count = -1;  // -1 means the directory could not be walked at all.
+	int count = -1;  // -1: the directory could not be walked.
 };
 
 CF_INLINE bool cf_fs_dir_signature_equal(CF_DirSignature a, CF_DirSignature b)
@@ -55,10 +64,9 @@ CF_INLINE bool cf_fs_dir_signature_equal(CF_DirSignature a, CF_DirSignature b)
 	return a.hash == b.hash && a.count == b.count;
 }
 
-// Entries are keyed by `sintern`'d name, and an interned string is a stable unique pointer for the
-// life of the process -- so the set of keys identifies the listing without hashing any characters.
-// XOR and sum accumulate separately so the result does not depend on the order the walk happened to
-// return entries in.
+// Interned keys are stable unique pointers, so the set of them identifies the listing without
+// hashing any characters. XOR and sum accumulate separately so the result does not depend on the
+// order the walk returned entries in.
 CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
 {
 	uint64_t x = 0, sum = 0;
@@ -74,22 +82,15 @@ CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
 	return sig;
 }
 
-// Monotonic counter bumped by every call that can change the PhysFS search path -- cf_fs_mount and
-// cf_fs_dismount are the only two. Anything caching a view derived from the virtual filesystem
-// compares against this instead of trying to notice a mount change after the fact.
+// Bumped by cf_fs_mount and cf_fs_dismount, the only calls that change the search path.
 uint64_t cf_fs_generation();
 
-// The real directory each mounted archive would serve `virtual_directory` from, in search-path
-// order, for every mount that could contribute entries to it. Derived from the mount table alone --
-// no filesystem calls -- by subtracting each archive's mount point from the virtual path.
+// The real directory each mount would serve `virtual_directory` from, in search-path order, for
+// every mount that could contribute to it. Candidates, not facts: PHYSFS_setRoot's prefix has no
+// getter, so a mount using it resolves somewhere other than this arithmetic suggests.
 //
-// These are *candidates*, not facts. PHYSFS_setRoot's prefix has no getter, so a mount using it
-// resolves elsewhere than the arithmetic here suggests; such a candidate normally just fails to
-// walk. Callers must prove what they take from a candidate rather than trusting it.
-//
-// `out_virtual_names` collects the entries in this directory that exist only because a mount point
-// passes through it, and so have no real directory anywhere to walk. They come from the mount table
-// alone, which cf_fs_generation already tracks.
+// `out_virtual_names` receives entries that exist only because a mount point passes through the
+// directory, which therefore have no real directory anywhere to walk.
 void cf_fs_mount_candidates(const char* virtual_directory, Cute::Array<Cute::String>* out,
                             Cute::Array<Cute::String>* out_virtual_names);
 

--- a/src/internal/cute_file_system_internal.h
+++ b/src/internal/cute_file_system_internal.h
@@ -56,30 +56,30 @@ bool cf_fs_scan_native_directory(const char* platform_directory, Cute::Map<CF_Di
 
 struct CF_DirSignature
 {
-	uint64_t hash = 0;
+	uint64_t name_xor = 0;
+	uint64_t name_sum = 0;
 	int count = -1;  // -1: the directory could not be walked.
 };
 
 CF_INLINE bool cf_fs_dir_signature_equal(CF_DirSignature a, CF_DirSignature b)
 {
-	return a.hash == b.hash && a.count == b.count;
+	return a.name_xor == b.name_xor && a.name_sum == b.name_sum && a.count == b.count;
 }
 
-// Reduces a walk to a value two scans can compare. Interned keys are stable unique pointers, so
-// the set of them identifies the listing without hashing any characters; XOR and sum accumulate
-// separately so the result does not depend on the order the walk returned entries in.
+// Reduces a walk to a value two scans can compare. Interned names are already stable unique
+// pointers, so there is nothing to hash: accumulating them is enough to identify the set. XOR and
+// sum are both commutative, so the result does not depend on the order the walk returned entries
+// in, and keeping them apart rather than folding them together is what makes the pair strong --
+// for any two entries, an XOR and a sum together pin down the pair exactly.
 CF_INLINE CF_DirSignature cf_fs_dir_signature(Cute::Map<CF_DirEntry>* entries)
 {
-	uint64_t x = 0, sum = 0;
-	int n = entries->count();
-	const uint64_t* keys = entries->keys();
-	for (int i = 0; i < n; ++i) {
-		x ^= keys[i];
-		sum += keys[i];
-	}
 	CF_DirSignature sig;
-	sig.hash = x ^ (sum * 1099511628211ULL);
-	sig.count = n;
+	sig.count = entries->count();
+	const uint64_t* keys = entries->keys();
+	for (int i = 0; i < sig.count; ++i) {
+		sig.name_xor ^= keys[i];
+		sig.name_sum += keys[i];
+	}
 	return sig;
 }
 

--- a/test/test_shader_directory.cpp
+++ b/test/test_shader_directory.cpp
@@ -9,6 +9,7 @@
 #include "test_app_shared.h"
 
 #include <cute.h>
+#include <internal/cute_app_internal.h>
 
 using namespace Cute;
 
@@ -44,7 +45,182 @@ TEST_CASE(test_shader_directory_survives_extensionless_files)
 	return true;
 }
 
+// The watcher reports only through this callback, and registering one also drops the frame
+// throttle -- so with it installed one cf_app_update is exactly one scan.
+#define MAX_CHANGED 32
+static const char* s_changed[MAX_CHANGED];
+static int s_changed_count;
+
+static void s_on_changed(const char* path, void* udata)
+{
+	CF_UNUSED(udata);
+	if (s_changed_count < MAX_CHANGED) s_changed[s_changed_count++] = path;
+}
+
+static bool s_saw(const char* key)
+{
+	for (int i = 0; i < s_changed_count; ++i) {
+		if (!CF_STRCMP(s_changed[i], key)) return true;
+	}
+	return false;
+}
+
+static void s_scan(int times)
+{
+	for (int i = 0; i < times; ++i) cf_app_update(NULL);
+}
+
+// Shared between the watch cases. With the shared app the directory is already set by whichever
+// case ran first; with CF_TEST_FRESH_APP=1 each case sets it on its own fresh app.
+static void s_use_shader_dir()
+{
+	cf_fs_set_write_directory(cf_fs_get_base_directory());
+	cf_fs_create_directory("/shader_dir_test");
+	// The cases below all test what happens when a file *appears*, so they must start from a
+	// directory that does not contain it. Each case removes its own file when it finishes; this
+	// sweeps up after a run that failed before it got there.
+	cf_fs_remove("/shader_dir_test/w.vert");
+	cf_fs_remove("/shader_dir_test/w.frag");
+	cf_fs_remove("/shader_dir_test/late.shd");
+	cf_fs_remove("/shader_dir_test/gone.shd");
+	if (!app->shader_directory_set) cf_shader_directory("/shader_dir_test");
+}
+
+// .vert and .frag are the extensions a two-file cf_make_shader pair uses, and they were missing
+// from the watched set -- the reload machinery existed but nothing ever reached it.
+//
+// The sleep is not padding: mtimes have one-second resolution, so a rewrite inside the same second
+// as the original write is genuinely indistinguishable from no change at all.
+TEST_CASE(test_shader_watch_reports_vert_and_frag_edits)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+	s_use_shader_dir();
+
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.vert", "// one\n")));
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.frag", "// one\n")));
+
+	cf_shader_on_changed(s_on_changed, NULL);
+	s_scan(4);                // Let both files land in the watch map.
+	s_changed_count = 0;
+	cf_sleep(1100);
+
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.vert", "// two\n")));
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.frag", "// two\n")));
+	s_scan(4);
+
+	REQUIRE(s_saw("/w.vert"));
+	REQUIRE(s_saw("/w.frag"));
+
+	cf_fs_remove("/shader_dir_test/w.vert");
+	cf_fs_remove("/shader_dir_test/w.frag");
+	cf_shader_on_changed(NULL, NULL);
+	test_destroy_app();
+	return true;
+}
+
+// A file created after cf_shader_directory has no entry in the watch map, and the watch pass used
+// to look one up unconditionally -- Map::get asserts and then dereferences null. It also has to
+// actually become watched: the directory listing is cached between scans, so a cache that never
+// noticed the new name would leave the file invisible forever rather than crash.
+TEST_CASE(test_shader_watch_adopts_files_created_after_startup)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+	s_use_shader_dir();
+
+	cf_shader_on_changed(s_on_changed, NULL);
+	s_scan(4);
+
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/late.shd", "// late\n")));
+	s_scan(4); // Pre-fix this asserts inside the watch pass.
+
+	REQUIRE(app->shader_file_infos.try_find(sintern("/late.shd")) != NULL);
+
+	cf_fs_remove("/shader_dir_test/late.shd");
+	cf_shader_on_changed(NULL, NULL);
+	test_destroy_app();
+	return true;
+}
+
+// The listing is cached, so a removed file stays in it until the cache notices. Every lookup for
+// it then fails, which has to read as "nothing to compare" rather than as a change or a crash.
+TEST_CASE(test_shader_watch_survives_removed_files)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+	s_use_shader_dir();
+
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/gone.shd", "// here\n")));
+	cf_shader_on_changed(s_on_changed, NULL);
+	s_scan(4);
+	REQUIRE(app->shader_file_infos.try_find(sintern("/gone.shd")) != NULL);
+
+	REQUIRE(!cf_is_error(cf_fs_remove("/shader_dir_test/gone.shd")));
+	s_changed_count = 0;
+	s_scan(4);
+	REQUIRE(!s_saw("/gone.shd")); // A deletion is not a modification.
+
+	cf_shader_on_changed(NULL, NULL);
+	test_destroy_app();
+	return true;
+}
+
+// A second mount serving the same directory adds entries no walk of the first one can see.
+TEST_CASE(test_shader_watch_sees_files_from_a_later_mount)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+	s_use_shader_dir();
+
+	cf_shader_on_changed(s_on_changed, NULL);
+	s_scan(4);
+
+	// A second real directory, mounted so that it also provides /shader_dir_test.
+	CF_Path extra = CF_Path(cf_fs_get_base_directory()) + "shader_dir_mount";
+	cf_fs_set_write_directory(cf_fs_get_base_directory());
+	cf_fs_create_directory("/shader_dir_mount");
+	cf_fs_create_directory("/shader_dir_mount/shader_dir_test");
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_mount/shader_dir_test/mounted.shd", "// mounted\n")));
+	REQUIRE(!cf_is_error(cf_fs_mount(extra.c_str(), "", true)));
+
+	s_scan(4);
+	REQUIRE(app->shader_file_infos.try_find(sintern("/mounted.shd")) != NULL);
+
+	cf_fs_dismount(extra.c_str());
+	cf_shader_on_changed(NULL, NULL);
+	test_destroy_app();
+	return true;
+}
+
+// A mount point *below* the shader directory makes its first component appear there as a virtual
+// subdirectory. Nothing on disk changes, and no walk can ever produce that name, so no directory
+// signature moves -- the mount counter is the only thing that can notice.
+TEST_CASE(test_shader_watch_sees_a_mount_point_below_the_shader_directory)
+{
+	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
+	s_use_shader_dir();
+
+	cf_shader_on_changed(s_on_changed, NULL);
+	s_scan(4);
+
+	CF_Path under = CF_Path(cf_fs_get_base_directory()) + "shader_dir_under";
+	cf_fs_set_write_directory(cf_fs_get_base_directory());
+	cf_fs_create_directory("/shader_dir_under");
+	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_under/inner.shd", "// inner\n")));
+	REQUIRE(!cf_is_error(cf_fs_mount(under.c_str(), "/shader_dir_test/sub", true)));
+
+	s_scan(4);
+	REQUIRE(app->shader_file_infos.try_find(sintern("/sub/inner.shd")) != NULL);
+
+	cf_fs_dismount(under.c_str());
+	cf_shader_on_changed(NULL, NULL);
+	test_destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_shader_directory)
 {
 	RUN_TEST_CASE(test_shader_directory_survives_extensionless_files);
+	RUN_TEST_CASE(test_shader_watch_reports_vert_and_frag_edits);
+	RUN_TEST_CASE(test_shader_watch_adopts_files_created_after_startup);
+	RUN_TEST_CASE(test_shader_watch_survives_removed_files);
+	RUN_TEST_CASE(test_shader_watch_sees_files_from_a_later_mount);
+	RUN_TEST_CASE(test_shader_watch_sees_a_mount_point_below_the_shader_directory);
 }

--- a/test/test_shader_directory.cpp
+++ b/test/test_shader_directory.cpp
@@ -79,43 +79,9 @@ static void s_use_shader_dir()
 	// The cases below all test what happens when a file *appears*, so they must start from a
 	// directory that does not contain it. Each case removes its own file when it finishes; this
 	// sweeps up after a run that failed before it got there.
-	cf_fs_remove("/shader_dir_test/w.vert");
-	cf_fs_remove("/shader_dir_test/w.frag");
 	cf_fs_remove("/shader_dir_test/late.shd");
 	cf_fs_remove("/shader_dir_test/gone.shd");
 	if (!app->shader_directory_set) cf_shader_directory("/shader_dir_test");
-}
-
-// .vert and .frag are the extensions a two-file cf_make_shader pair uses, and they were missing
-// from the watched set -- the reload machinery existed but nothing ever reached it.
-//
-// The sleep is not padding: mtimes have one-second resolution, so a rewrite inside the same second
-// as the original write is genuinely indistinguishable from no change at all.
-TEST_CASE(test_shader_watch_reports_vert_and_frag_edits)
-{
-	if (!test_make_app(64, 64)) return true; // Headless CI: no display/GPU.
-	s_use_shader_dir();
-
-	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.vert", "// one\n")));
-	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.frag", "// one\n")));
-
-	cf_shader_on_changed(s_on_changed, NULL);
-	s_scan(4);                // Let both files land in the watch map.
-	s_changed_count = 0;
-	cf_sleep(1100);
-
-	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.vert", "// two\n")));
-	REQUIRE(!cf_is_error(cf_fs_write_string_to_file("/shader_dir_test/w.frag", "// two\n")));
-	s_scan(4);
-
-	REQUIRE(s_saw("/w.vert"));
-	REQUIRE(s_saw("/w.frag"));
-
-	cf_fs_remove("/shader_dir_test/w.vert");
-	cf_fs_remove("/shader_dir_test/w.frag");
-	cf_shader_on_changed(NULL, NULL);
-	test_destroy_app();
-	return true;
 }
 
 // A file created after cf_shader_directory has no entry in the watch map, and the watch pass used
@@ -218,7 +184,6 @@ TEST_CASE(test_shader_watch_sees_a_mount_point_below_the_shader_directory)
 TEST_SUITE(test_shader_directory)
 {
 	RUN_TEST_CASE(test_shader_directory_survives_extensionless_files);
-	RUN_TEST_CASE(test_shader_watch_reports_vert_and_frag_edits);
 	RUN_TEST_CASE(test_shader_watch_adopts_files_created_after_startup);
 	RUN_TEST_CASE(test_shader_watch_survives_removed_files);
 	RUN_TEST_CASE(test_shader_watch_sees_files_from_a_later_mount);


### PR DESCRIPTION
# Shader watch: bulk directory scan and cached enumeration

Branch: `shader-watch-bulk-scan` in `external/cute_framework`, 6 commits on `beebd946`.

## Problem

- `cf_app_update` calls `cf_shader_watch` every frame, throttled to every 16th.
- Each scan cost about 12.5 ms for a 21 file shader directory, on the render thread.
- Cost scaled linearly with file count: 221 files took about 128 ms per scan.
- Every over budget frame in a 2000 frame capture was exactly 16 frames after the previous one, with the simulation paused.

## Why it was slow

The scan did three per file metadata queries, and on Windows those are expensive:

- `CF_Path::is_directory()` was a full `PHYSFS_stat`.
- `fs_stat()` was a second one, re-fetching data the first call already had.
- `PHYSFS_enumerateFiles` does a third one internally. It stats every entry through `enumCallbackFilterSymLinks` just to drop symlinks from the listing it returns. Confirmed with a counter compiled into PhysFS: 221 stats for a 221 entry enumerate.

Measured on this machine, same directory, 221 files:

| operation | cost |
| --- | --- |
| bulk directory walk (`FindFirstFileW`) | 1.1 us per entry |
| per file metadata query (`GetFileAttributesExW`) | 62.6 us per entry |

A 56x gap between reading metadata in bulk and reading it per file is the signature of a filesystem filter driver, most likely Defender. Machines without one will see much less dramatic numbers throughout.

## What this changes

- Replaces the per file stats with one bulk directory walk per mount, `FindFirstFileW` on Windows and `fdopendir` plus `fstatat` on POSIX.
- Caches the PhysFS directory listing so the remaining hidden stat is only paid when the set of files actually changes.
- Revalidates that cache every scan against two cheap things: a counter bumped by `cf_fs_mount` and `cf_fs_dismount`, and one bulk walk per contributing mount reduced to a small signature. Writing to a file changes neither, so editing a shader never re-asks PhysFS.
- Holds the metadata proof across scans instead of re-running it every scan.
- Also watches `.vert` and `.frag`, so two file `cf_make_shader` pairs hot reload. The machinery already existed and the extension filter was rejecting them.
- Adopts files created after `cf_shader_directory` instead of tripping an assert.

## Challenges

- **PhysFS has to stay the authority on what exists.** Several mounts can serve one directory and only PhysFS knows the merged result. Taking the file list from a walk would silently stop watching any file shadowed by a lower mount.
- **Timestamps have to match PhysFS, not be correct.** PhysFS on Windows round trips through local time rather than subtracting the epoch. A stored timestamp is compared against whatever the next scan produces, so a divergence would make a file look permanently changed or permanently unchanged.
- **Symlink typing has to match too.** `FindFirstFileW` reports the link where PhysFS reports the target, so reparse points are left out of the walk and stated the old way.
- **Mapping a mount to its real directory is not exact.** `PHYSFS_getMountPoint` turned out to be public, which makes the mapping right rather than a guess, but `PHYSFS_setRoot` has no getter. So the mapping stays a candidate that gets proven, and a directory whose contributors cannot all be seen is never cached.
- **No periodic refresh.** A timer would reintroduce exactly the recurring spike this removes, so staleness is detected from mount changes and per mount walks instead.
- Found a bug in `Cute::String(start, end)` along the way. It copies `length` bytes and then claims a length one longer without writing a terminator, so it leaves the string unterminated. Worked around locally, worth fixing separately.

## Results

Cost of one scan, 21 files, nothing changed:

| | scan cost | marginal cost per file |
| --- | --- | --- |
| before | ~12.5 ms | 578 us |
| bulk walk instead of per file stats | 2.5 ms | 74 us |
| plus cached directory listing | 0.58 ms | ~3 us |
| plus cached proof and no per entry allocation | 0.26 ms | ~2 us |

- About 48x cheaper per scan, and about 290x cheaper per file.
- The periodic over budget frames are gone entirely.
- What remains is two directory opens, about 0.1 ms each on this machine. One of them is a mount that has no such directory and has to be re-walked every scan to notice if it gains one.

## Possible improvements

- **Fix the hidden stat in PhysFS.** `WIN32_FIND_DATAW.dwFileAttributes` already says whether an entry is a reparse point, and POSIX `d_type` carries `DT_LNK`. The symlink filter could skip the stat for the entries that plainly are not links. That would make `PHYSFS_enumerateFiles` fast for every PhysFS user with no behaviour change.
- **`PHYSFS_permitSymbolicLinks(1)`** removes the hidden stat today, taking enumerate from 81 us to 2.1 us per entry. Not done here: it is process wide, it drops PhysFS's symlink sandboxing, and it changes which files appear in a listing.
- **Wall clock throttle** instead of every 16th frame, so the scan rate stops rising with frame rate.
- **`GetFileInformationByHandleEx` with `FileFullDirectoryInfo`** fills a large buffer in one call and could trim the walk itself, though not the directory opens that now dominate.
- **A Defender exclusion** for the working tree, which is the largest single lever on this machine but helps nobody else.

## Testing

Five cases in `test/test_shader_directory.cpp`, driven through `cf_shader_on_changed`, which both drops the frame throttle and gives a direct observable:

- a file created after startup is picked up rather than asserted on, and the cached listing notices it
- a deletion is not reported as a modification and does not crash
- a second mount serving the same directory contributes its files
- a mount point below the shader directory adds a virtual subdirectory that no walk can see, which only the mount counter can catch

Each case cleans up after itself. Without that the files survive in the build directory and are present at populate time on the next run, which makes the cases pass without exercising the path they are named for.

Verified by mutation rather than by going green:

| mutation | result |
| --- | --- |
| cache ignores the per mount signatures | the two file appearance cases fail |
| `cf_fs_mount` stops bumping the counter | only the mount point case fails |

Also checked: the POSIX branch compiles clean under Linux clang, and a debug mode (`CF_SHADER_WATCH_VERIFY`) that runs the PhysFS path alongside the native one and asserts they agree reports no divergence, including against a decoy directory, a shadowing mount, and a junction.

Not covered: `.vert` and `.frag` being in the watched set.