### PR TITLE
Flip the direction of v adjustment for uv

### DIFF
--- a/src/cute_draw3d.cpp
+++ b/src/cute_draw3d.cpp
@@ -2019,7 +2019,7 @@ void cf_draw3d_process(CF_Command* cmd, CF_Canvas canvas, bool clear)
 			CF_MeshInstance3d inst = instances[i];
 			float du = image_refs[i].bordered && uv.tex_w ? 1.0f / (float)uv.tex_w : 0;
 			float dv = image_refs[i].bordered && uv.tex_h ? 1.0f / (float)uv.tex_h : 0;
-			inst.uv_rect = cf_v4(uv.minx + du, uv.maxy - dv, uv.maxx - du, uv.miny + dv);
+			inst.uv_rect = cf_v4(uv.minx + du, uv.maxy + dv, uv.maxx - du, uv.miny - dv);
 			s_draw3d->staged.add(inst);
 		}
 	}


### PR DESCRIPTION
Before:

<img width="642" height="391" alt="image" src="https://github.com/user-attachments/assets/08e236f1-776c-4265-ae27-c71c701633f2" />

After:

<img width="642" height="391" alt="image" src="https://github.com/user-attachments/assets/bb9f0bd2-260d-4b4a-aa11-0c7112c79472" />

All tiles are just drawn using `cf_draw3d_sprite` with different transforms.
There is a black bar probably from atlas background.

It seems the meaning of miny and maxy is a bit unintuitive in the first place.