### PR TITLE
Add support for seamless tile map rendering

### DIFF
--- a/include/cute_draw.h
+++ b/include/cute_draw.h
@@ -1897,6 +1897,88 @@ CF_API CF_DrawFilterMode CF_CALL cf_draw_pop_filter(void);
 CF_API CF_DrawFilterMode CF_CALL cf_draw_peek_filter(void);
 
 /**
+ * @enum     CF_SpriteEdge
+ * @category draw
+ * @brief    Control the appearance of a sprite's edge at the border.
+ * @remarks  Sprites are packed into an atlas with a 1 pixel ring of transparent pixels, so that
+ *           filtering along an image's edge can't bleed into a neighboring image.
+ *
+ *           `CF_SPRITE_EDGE_SOFT` draw a sprite with that ring included.
+ *           This gives the sprite a nice soft edge when rotated.
+ *           However, sprites put adjacent to each other (e.g: in a tilemap) will show a transparent seam.
+ *           This is the default.
+ *
+ *           `CF_SPRITE_EDGE_HARD` covers only the image, so neighbors meet seamlessly at any camera offset
+ *           or zoom, at the cost of hard, aliased silhouettes when rotated.
+ *           This should be used for tilemaps, and for sprites used as panels placed next to each other.
+ *
+ *           Sprites from a premade atlas (see `cf_register_premade_atlas`) have no ring to sample,
+ *           and are always drawn as if `CF_SPRITE_EDGE_HARD`.
+ * @related  CF_SpriteEdge cf_sprite_edge_to_string cf_draw_push_sprite_edge cf_draw_pop_sprite_edge cf_draw_peek_sprite_edge
+ */
+#define CF_SPRITE_EDGE_DEFS \
+	/* @entry The quad extends one pixel past the image on all sides, softening silhouettes. The default. */ \
+	CF_ENUM(SPRITE_EDGE_SOFT,  0)                                                                            \
+	/* @entry The quad covers exactly the image, so neighboring sprites meet without overlapping. */         \
+	CF_ENUM(SPRITE_EDGE_HARD,  1)                                                                            \
+	/* @end */
+
+typedef enum CF_SpriteEdge
+{
+#define CF_ENUM(K, V) CF_##K = V,
+	CF_SPRITE_EDGE_DEFS
+#undef CF_ENUM
+} CF_SpriteEdge;
+
+/**
+ * @function cf_sprite_edge_to_string
+ * @category draw
+ * @brief    Returns a `CF_SpriteEdge` converted to a C string.
+ * @param    edge       The sprite edge mode.
+ * @return   Returns the enum name as a string.
+ * @related  CF_SpriteEdge cf_sprite_edge_to_string cf_draw_push_sprite_edge cf_draw_pop_sprite_edge cf_draw_peek_sprite_edge
+ */
+CF_INLINE const char* cf_sprite_edge_to_string(CF_SpriteEdge edge) {
+	switch (edge) {
+#define CF_ENUM(K, V) case CF_##K: return CF_STRINGIZE(CF_##K);
+		CF_SPRITE_EDGE_DEFS
+#undef CF_ENUM
+	default: return NULL;
+	}
+}
+
+/**
+ * @function cf_draw_push_sprite_edge
+ * @category draw
+ * @brief    Pushes the sprite edge mode used by subsequent sprite draws.
+ * @param    edge       The edge mode to use. See `CF_SpriteEdge`. Default is `CF_SPRITE_EDGE_SOFT`.
+ * @remarks  This is a CPU-side property of each sprite's geometry, so mixing modes within a frame costs
+ *           nothing extra -- it won't split batches the way `cf_draw_push_filter` does. Applies to
+ *           `cf_draw_sprite` and the 9-slice draws; text is unaffected, since glyphs carry their own
+ *           padding from the font rasterizer.
+ * @related  CF_SpriteEdge cf_sprite_edge_to_string cf_draw_push_sprite_edge cf_draw_pop_sprite_edge cf_draw_peek_sprite_edge
+ */
+CF_API void CF_CALL cf_draw_push_sprite_edge(CF_SpriteEdge edge);
+
+/**
+ * @function cf_draw_pop_sprite_edge
+ * @category draw
+ * @brief    Pops the sprite edge mode stack.
+ * @return   Returns the popped edge mode.
+ * @related  CF_SpriteEdge cf_sprite_edge_to_string cf_draw_push_sprite_edge cf_draw_pop_sprite_edge cf_draw_peek_sprite_edge
+ */
+CF_API CF_SpriteEdge CF_CALL cf_draw_pop_sprite_edge(void);
+
+/**
+ * @function cf_draw_peek_sprite_edge
+ * @category draw
+ * @brief    Returns the current sprite edge mode without popping the stack.
+ * @return   Returns the current edge mode.
+ * @related  CF_SpriteEdge cf_sprite_edge_to_string cf_draw_push_sprite_edge cf_draw_pop_sprite_edge cf_draw_peek_sprite_edge
+ */
+CF_API CF_SpriteEdge CF_CALL cf_draw_peek_sprite_edge(void);
+
+/**
  * @enum     CF_DrawBlend
  * @category draw
  * @brief    Per-drawable blend modes for the draw system.
@@ -2492,6 +2574,9 @@ CF_INLINE bool draw_peek_alpha_discard() { return cf_draw_peek_alpha_discard(); 
 CF_INLINE void draw_push_filter(CF_DrawFilterMode mode) { cf_draw_push_filter(mode); }
 CF_INLINE CF_DrawFilterMode draw_pop_filter() { return cf_draw_pop_filter(); }
 CF_INLINE CF_DrawFilterMode draw_peek_filter() { return cf_draw_peek_filter(); }
+CF_INLINE void draw_push_sprite_edge(CF_SpriteEdge edge) { cf_draw_push_sprite_edge(edge); }
+CF_INLINE CF_SpriteEdge draw_pop_sprite_edge() { return cf_draw_pop_sprite_edge(); }
+CF_INLINE CF_SpriteEdge draw_peek_sprite_edge() { return cf_draw_peek_sprite_edge(); }
 CF_INLINE void draw_set_texture(const char* name, CF_Texture texture) { cf_draw_set_texture(name, texture); }
 CF_INLINE void draw_set_uniform(const char* name, void* data, CF_UniformType type, int array_length) { cf_draw_set_uniform(name, data, type, array_length); }
 CF_INLINE void draw_set_uniform(const char* name, int val) { cf_draw_set_uniform_int(name, val); }

--- a/libraries/cute/cute_atlas_cache.h
+++ b/libraries/cute/cute_atlas_cache.h
@@ -3,7 +3,7 @@
 		Licensing information can be found at the end of the file.
 	------------------------------------------------------------------------------
 
-	cute_atlas_cache.h - v1.12
+	cute_atlas_cache.h - v1.13
 
 	To create implementation (the function definitions)
 		#define ATLAS_CACHE_IMPLEMENTATION
@@ -189,6 +189,18 @@
 		                  (after the new pages are assembled) so they can serve as copy
 		                  sources. When any callback is NULL the old CPU path runs,
 		                  byte-for-byte unchanged.
+		1.13 (08/13/2026) Reported uvs now span an image's *content* instead of its
+		                  padded slot when `atlas_use_border_pixels` is set, making the
+		                  border ring an implementation detail callers never see. Local
+		                  uvs pushed on an entry are likewise fractions of the image, so
+		                  partial-uv draws (9-slice) land where they say they do. Renderers
+		                  that compensated by inflating their geometry by one texel per
+		                  edge, or by insetting the reported uvs themselves, should drop
+		                  that compensation. `entry.w/h` report image dims, not slot dims.
+		                  Also fixed partial local uvs on a lonely (not yet atlased) image:
+		                  they were passed through and then y-flipped wholesale, so a sub-
+		                  rect picked the mirrored part of the image until the image landed
+		                  in an atlas page. Both residencies now remap identically.
 */
 
 /*
@@ -234,8 +246,12 @@ struct atlas_cache_entry_t
 	ATLAS_CACHE_U64 udata;
 
 	int w, h;         // width and height of this entry's image in pixels
-	float minx, miny; // u coordinate - this will be overwritten, except for premade entries
-	float maxx, maxy; // v coordinate - this will be overwritten, except for premade entries
+	// On the way in these are *local* uvs: 0 to 1 spans the image, and a sub-rect draws a
+	// portion of it (e.g. one patch of a 9-slice). On the way out they are overwritten with
+	// absolute uvs into `texture_id` (except for premade entries, which are already absolute).
+	// Any border ring the cache adds internally is excluded from the reported rect.
+	float minx, miny; // u coordinate
+	float maxx, maxy; // v coordinate
 };
 
 // Pushes an entry onto an internal buffer. Does no other logic.
@@ -341,7 +357,8 @@ typedef void (destroy_texture_handle_fn)(ATLAS_CACHE_U64 texture_id, void* udata
 //
 // Note on the 1-pixel border (`atlas_use_border_pixels`): the CPU path pads each image with a ring of
 // *zero* pixels (not edge replication). Lonely textures and old atlas slots already contain that zero
-// ring baked in, so whole-slot copies reproduce the CPU path's result exactly.
+// ring baked in, so whole-slot copies reproduce the CPU path's result exactly. The ring is invisible
+// to callers: reported uvs span the image's content, never the ring.
 
 // Create an atlas page texture of w by h pixels with no particular contents, *cleared to the same
 // empty color the CPU path uses* (see ATLAS_CACHE_ATLAS_EMPTY_COLOR, transparent-zero by default).
@@ -1207,16 +1224,37 @@ int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 imag
 
 		if (entry_out) {
 			entry_out->texture_id = tex->texture_id;
-			// Preserve local UVs already set by the caller (0..1 texture space for lonely
-			// textures). 9-slice and other partial-UV draws depend on this. Callers that
-			// want the full texture (e.g. atlas_cache_fetch) should set 0..1 first.
+			// Local uvs already set by the caller are preserved -- 9-slice and other
+			// partial-uv draws depend on it. Callers that want the whole image (e.g.
+			// atlas_cache_fetch) should set 0..1 first.
+			//
+			// A lonely texture is exactly one padded slot, so the image's content rect is
+			// the whole texture minus the border ring. Remap the local uvs onto it exactly
+			// the way the atlas path does, so a partial rect picks the same part of the
+			// image whether or not the image happens to be atlased yet.
+			float u0 = 0, u1 = 1;
+			float v0 = 0, v1 = 1;
+			if (cache->atlas_use_border_pixels)
+			{
+				float iw = 1.0f / (float)(tex->w + 2);
+				float ih = 1.0f / (float)(tex->h + 2);
+				u0 = iw; u1 = 1.0f - iw;
+				v0 = ih; v1 = 1.0f - ih;
+			}
 
 			if (ATLAS_CACHE_LONELY_FLIP_Y_AXIS_FOR_UV)
 			{
-				float tmp = entry_out->miny;
-				entry_out->miny = entry_out->maxy;
-				entry_out->maxy = tmp;
+				float tmp = v0;
+				v0 = v1;
+				v1 = tmp;
 			}
+
+			float dx = u1 - u0;
+			float dy = v1 - v0;
+			entry_out->minx = dx * entry_out->minx + u0;
+			entry_out->maxx = dx * entry_out->maxx + u0;
+			entry_out->miny = dy * entry_out->miny + v0;
+			entry_out->maxy = dy * entry_out->maxy + v0;
 		}
 
 		return 0;
@@ -1262,13 +1300,15 @@ int atlas_cache_internal_push_entry(atlas_cache_t* cache, atlas_cache_internal_e
 			atlas_cache_internal_texture_t* tex = (atlas_cache_internal_texture_t*)atlas_cache_map_find(&atlas->textures, s->image_id);
 			ATLAS_CACHE_ASSERT(tex);
 			tex->timestamp = 0;
-			entry.w = tex->w;
-			entry.h = tex->h;
+			// Slot dims are padded by the border ring; report the image's own dims.
+			entry.w = cache->atlas_use_border_pixels ? tex->w - 2 : tex->w;
+			entry.h = cache->atlas_use_border_pixels ? tex->h - 2 : tex->h;
 
-			// Entries are pushed with *local* uvs, remapped here onto the image's slot in
-			// the atlas. Pass minx/miny as 0 and maxx/maxy as 1 to draw the full image;
-			// values between 0-1 draw a portion (e.g. 9-slice), while values outside 0-1
-			// will creep into neighboring images of the atlas.
+			// Entries are pushed with *local* uvs, remapped here onto the image's content
+			// rect within the atlas (the border ring is excluded -- see the uv math in
+			// atlas_cache_internal_make_atlas). Pass minx/miny as 0 and maxx/maxy as 1 to
+			// draw the full image; values between 0-1 draw a portion (e.g. 9-slice), while
+			// values outside 0-1 creep into the border ring and its neighbors.
 			float dx = tex->maxx - tex->minx;
 			float dy = tex->maxy - tex->miny;
 			entry.minx = dx * entry.minx + tex->minx;
@@ -1755,10 +1795,15 @@ void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_atlas_t* 
 			atlas_cache_v2_t max = img->max;
 			volume_used += img->size.x * img->size.y;
 
-			float min_x = (float)min.x * iw;
-			float min_y = (float)min.y * ih;
-			float max_x = (float)max.x * iw;
-			float max_y = (float)max.y * ih;
+			// Reported uvs span the image's *content*, not its slot: the border ring is an
+			// internal detail (it keeps a bilinear tap at an image's edge from reaching into
+			// the neighboring image), so callers never have to know it is there. The slot
+			// coords below stay padded -- the GPU copy path moves whole slots, ring included.
+			int border = cache->atlas_use_border_pixels ? 1 : 0;
+			float min_x = (float)(min.x + border) * iw;
+			float min_y = (float)(min.y + border) * ih;
+			float max_x = (float)(max.x - border) * iw;
+			float max_y = (float)(max.y - border) * ih;
 
 			// flip image on y axis
 			if (ATLAS_CACHE_ATLAS_FLIP_Y_AXIS_FOR_UV)

--- a/libraries/cute/cute_atlas_cache.h
+++ b/libraries/cute/cute_atlas_cache.h
@@ -3,7 +3,7 @@
 		Licensing information can be found at the end of the file.
 	------------------------------------------------------------------------------
 
-	cute_atlas_cache.h - v1.13
+	cute_atlas_cache.h - v1.14
 
 	To create implementation (the function definitions)
 		#define ATLAS_CACHE_IMPLEMENTATION
@@ -125,6 +125,7 @@
 		defined and used. Note that MALLOC/FREE functions can optionally take a context
 		parameter for custom allocation.
 
+		ATLAS_CACHE_API
 		ATLAS_CACHE_MALLOC
 		ATLAS_CACHE_MEMCPY
 		ATLAS_CACHE_MEMSET
@@ -201,6 +202,9 @@
 		                  they were passed through and then y-flipped wholesale, so a sub-
 		                  rect picked the mirrored part of the image until the image landed
 		                  in an atlas page. Both residencies now remap identically.
+		1.14 (08/13/2026) Added ATLAS_CACHE_API to control the linkage of the public API.
+		                  Define it as `static inline` to compile a private copy into one
+		                  translation unit.
 */
 
 /*
@@ -214,6 +218,12 @@
 #ifndef ATLAS_CACHE_U64
 	#define ATLAS_CACHE_U64 unsigned long long
 #endif // ATLAS_CACHE_U64
+
+// Linkage/visibility for this header's public API. Defaults to plain external linkage. Define
+// it as `static inline` to compile a private copy into one translation unit.
+#ifndef ATLAS_CACHE_API
+	#define ATLAS_CACHE_API
+#endif // ATLAS_CACHE_API
 
 typedef struct atlas_cache_t atlas_cache_t;
 typedef struct atlas_cache_config_t atlas_cache_config_t;
@@ -255,14 +265,14 @@ struct atlas_cache_entry_t
 };
 
 // Pushes an entry onto an internal buffer. Does no other logic.
-void atlas_cache_push(atlas_cache_t* cache, atlas_cache_entry_t entry);
+ATLAS_CACHE_API void atlas_cache_push(atlas_cache_t* cache, atlas_cache_entry_t entry);
 
 // Ensures the image associated with your unique `image_id` is loaded up into the cache. This
 // function pretends to draw an entry referencing `image_id` but doesn't actually do any
 // drawing at all. Use this function as an optimization to pre-load images you know will be
 // drawn very soon, e.g. prefetch all ten images within a single animation just as it starts
 // playing.
-void atlas_cache_prefetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h);
+ATLAS_CACHE_API void atlas_cache_prefetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h);
 
 // Useful for re-uploading pixels to the GPU.
 // Invalidates the internal cache for a specific image. If this image resides in a texture atlas
@@ -271,22 +281,22 @@ void atlas_cache_prefetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w,
 // `atlas_cache_config_t` if you want to invalidate images often -- this can help prevent constantly
 // invalidating internal atlases and recompiling them, and instead get your dynamic textures into the
 // lonely buffer.
-void atlas_cache_invalidate(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id);
+ATLAS_CACHE_API void atlas_cache_invalidate(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id);
 
 // If a match for `image_id` is found, the texture id and uv coordinates are looked up and returned
 // as an entry. This is sometimes useful to render images through an external mechanism, such as
 // Dear ImGui. The return result will be valid until the next call to `atlas_cache_defrag`.
-atlas_cache_entry_t atlas_cache_fetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h);
+ATLAS_CACHE_API atlas_cache_entry_t atlas_cache_fetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h);
 
 // Increments internal timestamps on all textures, for use in `atlas_cache_defrag`.
-void atlas_cache_tick(atlas_cache_t* cache);
+ATLAS_CACHE_API void atlas_cache_tick(atlas_cache_t* cache);
 
 // Sorts the internal entries and flushes the buffer built by `atlas_cache_push`. Will call
 // the `submit_batch_fn` function for each batch of entries and return them as an array. Any `image_id`
 // within the `atlas_cache_push` buffer that do not yet have a texture handle will request pixels
 // from the image via `get_pixels_fn` and request a texture handle via `generate_texture_handle_fn`.
 // Returns the number of batches created and submitted.
-int atlas_cache_flush(atlas_cache_t* cache);
+ATLAS_CACHE_API int atlas_cache_flush(atlas_cache_t* cache);
 
 // All textures created so far by `atlas_cache_flush` will be considered as candidates for creating
 // new internal texture atlases. Internal texture atlases compress images together inside of one
@@ -295,10 +305,10 @@ int atlas_cache_flush(atlas_cache_t* cache);
 // As some textures cease to draw on screen, they "decay" over time. Once enough images in an atlas
 // decay, the atlas is removed, and any "live" images in the atlas are used to create new atlases.
 // Can be called every 1/N times `atlas_cache_flush` is called.
-int atlas_cache_defrag(atlas_cache_t* cache);
+ATLAS_CACHE_API int atlas_cache_defrag(atlas_cache_t* cache);
 
-int atlas_cache_init(atlas_cache_t* cache, atlas_cache_config_t* config, void* udata);
-void atlas_cache_term(atlas_cache_t* cache);
+ATLAS_CACHE_API int atlas_cache_init(atlas_cache_t* cache, atlas_cache_config_t* config, void* udata);
+ATLAS_CACHE_API void atlas_cache_term(atlas_cache_t* cache);
 
 typedef struct atlas_cache_premade_entry_t
 {
@@ -319,7 +329,7 @@ typedef struct atlas_cache_premade_entry_t
 // using `atlas_cache_push`, this can be a good option. For example, this makes sense for text
 // rendering systems that create their own font texture atlas. Understanding the performance impact
 // can become a lot simpler than flooding `atlas_cache_push` with a lot of unique glyphs used briefly.
-void atlas_cache_register_premade_atlas(atlas_cache_t* cache, ATLAS_CACHE_U64 texture_id, int w, int h, int entry_count, atlas_cache_premade_entry_t* entries);
+ATLAS_CACHE_API void atlas_cache_register_premade_atlas(atlas_cache_t* cache, ATLAS_CACHE_U64 texture_id, int w, int h, int entry_count, atlas_cache_premade_entry_t* entries);
 
 // Batches are submit via synchronous callback back to the user. This function is called
 // from inside `atlas_cache_flush`. Each time `submit_batch_fn` is called an array of entries
@@ -376,7 +386,7 @@ typedef void (upload_subimage_fn)(ATLAS_CACHE_U64 dst, int x, int y, int w, int 
 
 // Initializes a set of good default paramaters. The users must still set
 // the four callbacks inside of `config`.
-void atlas_cache_set_default_config(atlas_cache_config_t* config);
+ATLAS_CACHE_API void atlas_cache_set_default_config(atlas_cache_config_t* config);
 
 struct atlas_cache_config_t
 {
@@ -598,6 +608,9 @@ struct atlas_cache_t
 #ifdef ATLAS_CACHE_IMPLEMENTATION
 #ifndef ATLAS_CACHE_IMPLEMENTATION_ONCE
 #define ATLAS_CACHE_IMPLEMENTATION_ONCE
+
+#include <stdint.h> // uintptr_t
+#include <limits.h> // INT_MAX
 
 // atlas_cache_map implementation
 
@@ -989,7 +1002,7 @@ void atlas_cache_set_default_config(atlas_cache_config_t* config)
 	} while (0)
 
 
-int atlas_cache_internal_fill_entry(atlas_cache_t* cache, atlas_cache_entry_t entry, atlas_cache_internal_entry_t* out)
+static int atlas_cache_internal_fill_entry(atlas_cache_t* cache, atlas_cache_entry_t entry, atlas_cache_internal_entry_t* out)
 {
 	ATLAS_CACHE_ASSERT(entry.w <= cache->atlas_width_in_pixels);
 	ATLAS_CACHE_ASSERT(entry.h <= cache->atlas_height_in_pixels);
@@ -1036,8 +1049,8 @@ void atlas_cache_register_premade_atlas(atlas_cache_t* cache, ATLAS_CACHE_U64 te
 	}
 }
 
-int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, atlas_cache_entry_t* entry_out, int skip_missing_textures);
-atlas_cache_internal_premade_t* atlas_cache_internal_get_premade(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, atlas_cache_entry_t* entry_out);
+static int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, atlas_cache_entry_t* entry_out, int skip_missing_textures);
+static atlas_cache_internal_premade_t* atlas_cache_internal_get_premade(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, atlas_cache_entry_t* entry_out);
 
 void atlas_cache_prefetch(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h)
 {
@@ -1096,7 +1109,7 @@ static int atlas_cache_internal_entry_less_than_or_equal(atlas_cache_entry_t* a,
 	return a->texture_id <= b->texture_id;
 }
 
-void atlas_cache_internal_merge_sort_iteration(atlas_cache_entry_t* a, int lo, int split, int hi, atlas_cache_entry_t* b)
+static void atlas_cache_internal_merge_sort_iteration(atlas_cache_entry_t* a, int lo, int split, int hi, atlas_cache_entry_t* b)
 {
 	int i = lo, j = split;
 	for (int k = lo; k < hi; k++) {
@@ -1110,7 +1123,7 @@ void atlas_cache_internal_merge_sort_iteration(atlas_cache_entry_t* a, int lo, i
 	}
 }
 
-void atlas_cache_internal_merge_sort_recurse(atlas_cache_entry_t* b, int lo, int hi, atlas_cache_entry_t* a)
+static void atlas_cache_internal_merge_sort_recurse(atlas_cache_entry_t* b, int lo, int hi, atlas_cache_entry_t* a)
 {
 	if (hi - lo <= 1) return;
 	int split = (lo + hi) / 2;
@@ -1119,13 +1132,13 @@ void atlas_cache_internal_merge_sort_recurse(atlas_cache_entry_t* b, int lo, int
 	atlas_cache_internal_merge_sort_iteration(b, lo, split, hi, a);
 }
 
-void atlas_cache_internal_merge_sort(atlas_cache_entry_t* a, atlas_cache_entry_t* b, int n)
+static void atlas_cache_internal_merge_sort(atlas_cache_entry_t* a, atlas_cache_entry_t* b, int n)
 {
 	ATLAS_CACHE_MEMCPY(b, a, sizeof(atlas_cache_entry_t) * n);
 	atlas_cache_internal_merge_sort_recurse(b, 0, n, a);
 }
 
-void atlas_cache_internal_sort_entries(atlas_cache_t* cache)
+static void atlas_cache_internal_sort_entries(atlas_cache_t* cache)
 {
 	atlas_cache_internal_merge_sort(cache->entries, cache->entries_scratch, cache->entry_count);
 }
@@ -1192,7 +1205,7 @@ static inline ATLAS_CACHE_U64 atlas_cache_internal_generate_texture_handle(atlas
 	return cache->generate_texture_callback(cache->pixel_buffer, w, h, cache->udata);
 }
 
-atlas_cache_internal_lonely_texture_t* atlas_cache_internal_lonelybuffer_push(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, int make_tex)
+static atlas_cache_internal_lonely_texture_t* atlas_cache_internal_lonelybuffer_push(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, int make_tex)
 {
 	atlas_cache_internal_lonely_texture_t texture;
 	texture.timestamp = 0;
@@ -1206,7 +1219,7 @@ atlas_cache_internal_lonely_texture_t* atlas_cache_internal_lonelybuffer_push(at
 	return (atlas_cache_internal_lonely_texture_t*)atlas_cache_map_insert(&cache->lonely_buffer, image_id, &texture);
 }
 
-int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, atlas_cache_entry_t* entry_out, int skip_missing_textures)
+static int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, atlas_cache_entry_t* entry_out, int skip_missing_textures)
 {
 	atlas_cache_internal_lonely_texture_t* tex = (atlas_cache_internal_lonely_texture_t*)atlas_cache_map_find(&cache->lonely_buffer, image_id);
 
@@ -1261,7 +1274,7 @@ int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U64 imag
 	}
 }
 
-atlas_cache_internal_premade_t* atlas_cache_internal_get_premade(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, atlas_cache_entry_t* entry_out)
+static atlas_cache_internal_premade_t* atlas_cache_internal_get_premade(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, atlas_cache_entry_t* entry_out)
 {
 	atlas_cache_internal_premade_t* tex = (atlas_cache_internal_premade_t*)atlas_cache_map_find(&cache->premades, image_id);
 	if (!tex) return NULL;
@@ -1272,7 +1285,7 @@ atlas_cache_internal_premade_t* atlas_cache_internal_get_premade(atlas_cache_t* 
 	return tex;
 }
 
-int atlas_cache_internal_push_entry(atlas_cache_t* cache, atlas_cache_internal_entry_t* s, int skip_missing_textures)
+static int atlas_cache_internal_push_entry(atlas_cache_t* cache, atlas_cache_internal_entry_t* s, int skip_missing_textures)
 {
 	int skipped_tex = 0;
 	atlas_cache_entry_t entry;
@@ -1344,7 +1357,7 @@ int atlas_cache_internal_push_entry(atlas_cache_t* cache, atlas_cache_internal_e
 	return skipped_tex;
 }
 
-void atlas_cache_internal_process_input(atlas_cache_t* cache, int skip_missing_textures)
+static void atlas_cache_internal_process_input(atlas_cache_t* cache, int skip_missing_textures)
 {
 	int skipped_index = 0;
 	for (int i = 0; i < cache->input_count; ++i)
@@ -1551,7 +1564,7 @@ static int atlas_cache_internal_image_less_than_or_equal(atlas_cache_internal_in
 	return perimeterB <= perimeterA;
 }
 
-void atlas_cache_internal_image_merge_sort_iteration(atlas_cache_internal_integer_image_t* a, int lo, int split, int hi, atlas_cache_internal_integer_image_t* b)
+static void atlas_cache_internal_image_merge_sort_iteration(atlas_cache_internal_integer_image_t* a, int lo, int split, int hi, atlas_cache_internal_integer_image_t* b)
 {
 	int i = lo, j = split;
 	for (int k = lo; k < hi; k++) {
@@ -1565,7 +1578,7 @@ void atlas_cache_internal_image_merge_sort_iteration(atlas_cache_internal_intege
 	}
 }
 
-void atlas_cache_internal_image_merge_sort_recurse(atlas_cache_internal_integer_image_t* b, int lo, int hi, atlas_cache_internal_integer_image_t* a)
+static void atlas_cache_internal_image_merge_sort_recurse(atlas_cache_internal_integer_image_t* b, int lo, int hi, atlas_cache_internal_integer_image_t* a)
 {
 	if (hi - lo <= 1) return;
 	int split = (lo + hi) / 2;
@@ -1574,7 +1587,7 @@ void atlas_cache_internal_image_merge_sort_recurse(atlas_cache_internal_integer_
 	atlas_cache_internal_image_merge_sort_iteration(b, lo, split, hi, a);
 }
 
-void atlas_cache_internal_image_merge_sort(atlas_cache_internal_integer_image_t* a, atlas_cache_internal_integer_image_t* b, int n)
+static void atlas_cache_internal_image_merge_sort(atlas_cache_internal_integer_image_t* a, atlas_cache_internal_integer_image_t* b, int n)
 {
 	ATLAS_CACHE_MEMCPY(b, a, sizeof(atlas_cache_internal_integer_image_t) * n);
 	atlas_cache_internal_image_merge_sort_recurse(b, 0, n, a);
@@ -1591,7 +1604,7 @@ typedef struct atlas_cache_internal_atlas_image_t
 
 #define ATLAS_CACHE_CHECK( X, Y ) do { if ( !(X) ) { ATLAS_CACHE_LOG(Y); goto cache_err; } } while ( 0 )
 
-void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_atlas_t* atlas_out, const atlas_cache_internal_lonely_texture_t* imgs, int img_count)
+static void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_atlas_t* atlas_out, const atlas_cache_internal_lonely_texture_t* imgs, int img_count)
 {
 	float iw, ih;
 	int atlas_image_size = 0, atlas_stride = 0, sp;
@@ -1876,14 +1889,14 @@ static void atlas_cache_internal_qsort_lonely(atlas_cache_map_t* lonely_table, a
 	atlas_cache_internal_qsort_lonely(lonely_table, items + low + 1, count - 1 - low);
 }
 
-int atlas_cache_internal_buffer_key(atlas_cache_t* cache, ATLAS_CACHE_U64 key)
+static int atlas_cache_internal_buffer_key(atlas_cache_t* cache, ATLAS_CACHE_U64 key)
 {
 	ATLAS_CACHE_CHECK_BUFFER_GROW(cache, key_buffer_count, key_buffer_capacity, key_buffer, ATLAS_CACHE_U64);
 	cache->key_buffer[cache->key_buffer_count++] = key;
 	return 0;
 }
 
-void atlas_cache_internal_remove_table_entries(atlas_cache_t* cache, atlas_cache_map_t* table)
+static void atlas_cache_internal_remove_table_entries(atlas_cache_t* cache, atlas_cache_map_t* table)
 {
 	for (int i = 0; i < cache->key_buffer_count; ++i) atlas_cache_map_remove(table, cache->key_buffer[i]);
 	cache->key_buffer_count = 0;
@@ -1891,14 +1904,14 @@ void atlas_cache_internal_remove_table_entries(atlas_cache_t* cache, atlas_cache
 
 // GPU repack path: queue a texture for destruction at the end of `atlas_cache_defrag`, so it
 // stays alive as a copy source while the new atlas pages are assembled.
-int atlas_cache_internal_defer_texture_destroy(atlas_cache_t* cache, ATLAS_CACHE_U64 texture_id)
+static int atlas_cache_internal_defer_texture_destroy(atlas_cache_t* cache, ATLAS_CACHE_U64 texture_id)
 {
 	ATLAS_CACHE_CHECK_BUFFER_GROW(cache, deferred_texture_count, deferred_texture_capacity, deferred_textures, ATLAS_CACHE_U64);
 	cache->deferred_textures[cache->deferred_texture_count++] = texture_id;
 	return 0;
 }
 
-void atlas_cache_internal_destroy_deferred_textures(atlas_cache_t* cache)
+static void atlas_cache_internal_destroy_deferred_textures(atlas_cache_t* cache)
 {
 	if (!cache->deferred_texture_count) return;
 	for (int i = 0; i < cache->deferred_texture_count; ++i) {
@@ -1914,7 +1927,7 @@ void atlas_cache_internal_destroy_deferred_textures(atlas_cache_t* cache)
 	for (int i = 0; i < count; ++i) lonely[i].prev_texture_id = ~0;
 }
 
-void atlas_cache_internal_flush_atlas(atlas_cache_t* cache, atlas_cache_internal_atlas_t* atlas, atlas_cache_internal_atlas_t** sentinel, atlas_cache_internal_atlas_t** next)
+static void atlas_cache_internal_flush_atlas(atlas_cache_t* cache, atlas_cache_internal_atlas_t* atlas, atlas_cache_internal_atlas_t** sentinel, atlas_cache_internal_atlas_t** next)
 {
 	int ticks_to_decay_texture = cache->ticks_to_decay_texture;
 	int use_gpu_copies = atlas_cache_internal_use_gpu_copies(cache);
@@ -1992,7 +2005,7 @@ void atlas_cache_invalidate(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id)
 	}
 }
 
-void atlas_cache_internal_log_chain(atlas_cache_internal_atlas_t* atlas)
+static void atlas_cache_internal_log_chain(atlas_cache_internal_atlas_t* atlas)
 {
 	if (atlas)
 	{

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -110,6 +110,7 @@ add_sample(canvas_readback canvas_readback.c)
 add_sample(glitch glitch.cpp)
 add_sample(customsprite custom_sprite.c)
 add_sample(sound_pan sound_pan.c)
+add_sample(tilefilters tile_filters.c)
 
 # Ensure that sample data is included in web build
 if (EMSCRIPTEN)
@@ -146,3 +147,4 @@ add_custom_command(TARGET pixel_3d PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_di
 add_custom_command(TARGET obj_loading PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/obj_loading_data $<TARGET_FILE_DIR:obj_loading>/obj_loading_data)
 add_custom_command(TARGET model3d PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/model3d_data $<TARGET_FILE_DIR:model3d>/model3d_data)
 add_custom_command(TARGET customsprite PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/custom_sprite_data $<TARGET_FILE_DIR:customsprite>/custom_sprite_data)
+add_custom_command(TARGET tilefilters PRE_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/import_spritesheet_data $<TARGET_FILE_DIR:tilefilters>/import_spritesheet_data)

--- a/samples/tile_filters.c
+++ b/samples/tile_filters.c
@@ -1,37 +1,46 @@
 /*
-	Demonstrates CF's draw filter modes on a tilemap under subpixel camera motion.
+	Demonstrates CF's sprite edge modes and draw filter modes on a tilemap under subpixel
+	camera motion.
 
 	Adjacent 16x16 tiles are drawn as individual sprites while the camera slowly pans by
 	fractions of a pixel. Each tile is its own atlas entry, and the atlas pads every entry
-	with a 1px transparent ring to keep neighboring images from bleeding into each other.
-	A sprite's quad covers exactly its own 16x16 pixels, so quads meet edge to edge -- but
-	any filter that samples past the sprite's uv rect reaches that ring, pulls in
-	transparency, and opens a seam the background shows through:
+	with a 1px transparent ring so neighboring images can't bleed into each other. Seams
+	open up when a tile's rendering reaches into that ring and pulls in transparency, which
+	two independent settings control:
 
-	  NEAREST  Takes the texel the sample lands in, which is always one of the sprite's
-	           own: no seams, but interiors shimmer as texel rows pop in and out while the
-	           camera slides across subpixel positions.
-	  LINEAR   Samples raw uvs, so any tap within half a texel of a tile edge blends with
-	           the ring. Tile edges go semi-transparent and seams open at subpixel offsets.
-	  SMOOTH   Snaps to texel centers with a sub-pixel ramp at texel seams, then clamps the
-	           uv into the sprite's own rect so the ring is unreachable. Stable interiors
-	           and closed seams at any camera offset or zoom. The tradeoff: silhouettes no
-	           longer fade out through the ring, so a rotated sprite's outline is a hard
-	           quad edge rather than an antialiased one.
+	  Sprite edge -- cf_draw_push_sprite_edge
+	    SOFT     The quad extends over the ring, so the sprite fades out across it. Rotated
+	             outlines turn smooth, but adjacent tiles overlap and the background shows
+	             through their shared edge.
+	    HARD     The quad covers exactly the tile, so neighbors meet edge to edge with
+	             nothing to blend. Rotated outlines are hard and aliased.
+
+	  Filter -- cf_draw_push_filter
+	    NEAREST  Lands on whole texels, so it never produces a partial alpha to leak
+	             through; interiors shimmer instead, as texel rows pop in and out while the
+	             camera slides across subpixel positions.
+	    LINEAR   Samples raw uvs, so any tap within half a texel of a tile edge blends with
+	             whatever is beyond it -- the widest, softest seams of the three.
+	    SMOOTH   Snaps to texel centers with a sub-pixel ramp at texel seams, then clamps
+	             the uv into the sprite's own rect. Crisp interiors, and the transition at
+	             an edge is about a screen pixel wide instead of a whole texel.
+
+	SMOOTH + HARD is the combination that stays seamless at any camera offset or zoom.
 
 	Controls:
 	  SPACE    cycle filter mode
+	  E        toggle sprite edge mode
 	  P        pause/resume the camera pan
 	  UP/DOWN  zoom in/out
-	  S        save one png per filter mode (current camera offset)
+	  S        save one png per filter mode (current camera offset and edge mode)
 
-	A 5x3 tile block slowly rotates in the sky: under SMOOTH its interior pixels should
-	stay stable (no shimmering crawl like NEAREST) and its seams stay closed even though
-	the shared tile edges are not axis-aligned.
+	A 5x3 tile block slowly rotates in the sky. Under HARD its shared tile edges should
+	stay closed even though they are not axis-aligned, while its outer silhouette goes
+	hard; SOFT is where that silhouette turns smooth, at the cost of those seams.
 
 	Run `tilefilters screenshot <prefix> [offset_px] [zoom] [angle_deg]` to save
-	deterministic pngs of every filter mode at the given subpixel camera offset (default
-	0.5, worst case for seams) plus a zero-offset control, then exit.
+	deterministic pngs of every edge/filter combination at the given subpixel camera offset
+	(default 0.5, worst case for seams) plus a zero-offset control, then exit.
 */
 
 #include <cute.h>
@@ -119,12 +128,13 @@ static void s_draw_rotated_block(float angle)
 	}
 }
 
-static void s_draw_scene(CF_DrawFilterMode mode, float zoom, float offx, float offy, float angle)
+static void s_draw_scene(CF_DrawFilterMode mode, CF_SpriteEdge edge, float zoom, float offx, float offy, float angle)
 {
 	cf_draw_push();
 	cf_draw_scale(zoom, zoom);
 	cf_draw_translate(offx, offy);
 	cf_draw_push_filter(mode);
+	cf_draw_push_sprite_edge(edge);
 	for (int y = 0; y < MAP_H; ++y) {
 		for (int x = 0; x < MAP_W; ++x) {
 			TileKind kind = s_map[y][x];
@@ -135,6 +145,7 @@ static void s_draw_scene(CF_DrawFilterMode mode, float zoom, float offx, float o
 		}
 	}
 	s_draw_rotated_block(angle);
+	cf_draw_pop_sprite_edge();
 	cf_draw_pop_filter();
 	cf_draw_pop();
 }
@@ -145,6 +156,15 @@ static const char* s_mode_name(CF_DrawFilterMode mode)
 	case CF_DRAW_FILTER_NEAREST: return "NEAREST";
 	case CF_DRAW_FILTER_LINEAR: return "LINEAR";
 	case CF_DRAW_FILTER_SMOOTH: return "SMOOTH";
+	default: return "???";
+	}
+}
+
+static const char* s_edge_name(CF_SpriteEdge edge)
+{
+	switch (edge) {
+	case CF_SPRITE_EDGE_SOFT: return "SOFT";
+	case CF_SPRITE_EDGE_HARD: return "HARD";
 	default: return "???";
 	}
 }
@@ -203,7 +223,13 @@ int main(int argc, char* argv[])
 		CF_DRAW_FILTER_SMOOTH,
 	};
 	int mode_count = CF_ARRAY_SIZE(modes);
-	int mode = 0;
+	CF_SpriteEdge edges[] = {
+		CF_SPRITE_EDGE_SOFT,
+		CF_SPRITE_EDGE_HARD,
+	};
+	int edge_count = CF_ARRAY_SIZE(edges);
+	int mode = CF_DRAW_FILTER_SMOOTH;
+	int edge = CF_SPRITE_EDGE_HARD;
 	float zoom = 3.0f;
 	float t = 0;
 	bool paused = false;
@@ -217,17 +243,19 @@ int main(int argc, char* argv[])
 		cf_app_update(NULL);
 
 		if (screenshot) {
-			// One frame per capture: every mode at a half-pixel offset (worst case for
-			// seams) plus a zero-offset control. Skip frame 0 so the window settles.
+			// One frame per capture: every edge/filter combination at a half-pixel offset
+			// (worst case for seams) plus a zero-offset control. Skip frame 0 so the
+			// window settles.
 			if (shot_frame > 0) {
 				int idx = shot_frame - 1;
-				if (idx >= mode_count * 2) break;
-				int m = idx / 2;
+				if (idx >= edge_count * mode_count * 2) break;
 				bool half = (idx % 2) == 0;
+				int m = (idx / 2) % mode_count;
+				int e = idx / (2 * mode_count);
 				float off = half ? shot_off_px / shot_zoom : 0;
-				s_draw_scene(modes[m], shot_zoom, off, off, shot_angle);
+				s_draw_scene(modes[m], edges[e], shot_zoom, off, off, shot_angle);
 				char path[256];
-				snprintf(path, sizeof(path), "%s_%s_%s.png", prefix, s_mode_name(modes[m]), half ? "half" : "zero");
+				snprintf(path, sizeof(path), "%s_%s_%s_%s.png", prefix, s_edge_name(edges[e]), s_mode_name(modes[m]), half ? "half" : "zero");
 				for (char* c = path; *c; ++c) if (*c == ' ' || *c == '(' || *c == ')') *c = '-';
 				s_save_png(path);
 				shot_frame++;
@@ -241,9 +269,9 @@ int main(int argc, char* argv[])
 		// One capture per frame while an S-key screenshot burst is in flight.
 		if (interactive_shot >= 0) {
 			if (interactive_shot < mode_count) {
-				s_draw_scene(modes[interactive_shot], zoom, shot_offx, shot_offy, t * 0.25f);
+				s_draw_scene(modes[interactive_shot], edges[edge], zoom, shot_offx, shot_offy, t * 0.25f);
 				char path[256];
-				snprintf(path, sizeof(path), "%s_%s.png", prefix, s_mode_name(modes[interactive_shot]));
+				snprintf(path, sizeof(path), "%s_%s_%s.png", prefix, s_edge_name(edges[edge]), s_mode_name(modes[interactive_shot]));
 				for (char* c = path; *c; ++c) if (*c == ' ' || *c == '(' || *c == ')') *c = '-';
 				s_save_png(path);
 				interactive_shot++;
@@ -253,6 +281,7 @@ int main(int argc, char* argv[])
 		}
 
 		if (cf_key_just_pressed(CF_KEY_SPACE)) mode = (mode + 1) % mode_count;
+		if (cf_key_just_pressed(CF_KEY_E)) edge = (edge + 1) % edge_count;
 		if (cf_key_just_pressed(CF_KEY_P)) paused = !paused;
 		if (cf_key_just_pressed(CF_KEY_UP)) zoom += 0.25f;
 		if (cf_key_just_pressed(CF_KEY_DOWN)) zoom = cf_max(0.5f, zoom - 0.25f);
@@ -268,12 +297,12 @@ int main(int argc, char* argv[])
 			shot_offy = offy;
 		}
 
-		s_draw_scene(modes[mode], zoom, offx, offy, t * 0.25f);
+		s_draw_scene(modes[mode], edges[edge], zoom, offx, offy, t * 0.25f);
 
 		cf_draw_push_color(cf_color_white());
 		cf_push_font_size(20);
 		char label[256];
-		snprintf(label, sizeof(label), "Filter: %s  --  SPACE cycle, P pause, UP/DOWN zoom (%.2fx), S screenshots", s_mode_name(modes[mode]), zoom);
+		snprintf(label, sizeof(label), "Filter: %s  Edge: %s  --  SPACE filter, E edge, P pause, UP/DOWN zoom (%.2fx), S screenshots", s_mode_name(modes[mode]), s_edge_name(edges[edge]), zoom);
 		cf_draw_text(label, cf_v2(-CANVAS_W * 0.5f + 10, CANVAS_H * 0.5f - 10), -1);
 		cf_pop_font_size();
 		cf_draw_pop_color();

--- a/samples/tile_filters.c
+++ b/samples/tile_filters.c
@@ -2,10 +2,22 @@
 	Demonstrates CF's draw filter modes on a tilemap under subpixel camera motion.
 
 	Adjacent 16x16 tiles are drawn as individual sprites while the camera slowly pans by
-	fractions of a pixel. This exposes seam artifacts between tiles: with SMOOTH/LINEAR the
-	tile edges go semi-transparent at subpixel offsets and the background bleeds through.
-	PIXELART (a port of SDL's SDL_SCALEMODE_PIXELART box-filter) uses hard sprite edges and
-	clamp-to-edge sampling instead, so tiles stay gap-free at any camera offset or zoom.
+	fractions of a pixel. Each tile is its own atlas entry, and the atlas pads every entry
+	with a 1px transparent ring to keep neighboring images from bleeding into each other.
+	A sprite's quad covers exactly its own 16x16 pixels, so quads meet edge to edge -- but
+	any filter that samples past the sprite's uv rect reaches that ring, pulls in
+	transparency, and opens a seam the background shows through:
+
+	  NEAREST  Takes the texel the sample lands in, which is always one of the sprite's
+	           own: no seams, but interiors shimmer as texel rows pop in and out while the
+	           camera slides across subpixel positions.
+	  LINEAR   Samples raw uvs, so any tap within half a texel of a tile edge blends with
+	           the ring. Tile edges go semi-transparent and seams open at subpixel offsets.
+	  SMOOTH   Snaps to texel centers with a sub-pixel ramp at texel seams, then clamps the
+	           uv into the sprite's own rect so the ring is unreachable. Stable interiors
+	           and closed seams at any camera offset or zoom. The tradeoff: silhouettes no
+	           longer fade out through the ring, so a rotated sprite's outline is a hard
+	           quad edge rather than an antialiased one.
 
 	Controls:
 	  SPACE    cycle filter mode
@@ -13,9 +25,9 @@
 	  UP/DOWN  zoom in/out
 	  S        save one png per filter mode (current camera offset)
 
-	A 5x3 tile block slowly rotates in the sky: the pixel art filters should keep its
-	interior pixels stable (no shimmering crawl like NEAREST) and its seams closed even
-	though the shared tile edges are not axis-aligned.
+	A 5x3 tile block slowly rotates in the sky: under SMOOTH its interior pixels should
+	stay stable (no shimmering crawl like NEAREST) and its seams stay closed even though
+	the shared tile edges are not axis-aligned.
 
 	Run `tilefilters screenshot <prefix> [offset_px] [zoom] [angle_deg]` to save
 	deterministic pngs of every filter mode at the given subpixel camera offset (default
@@ -52,7 +64,8 @@ void mount_content_directory_as(const char* dir)
 }
 
 // Cut one 16x16 tile out of the sheet as its own easy sprite. Each tile becomes a separate
-// atlas entry, which is how a real tilemap hits the atlas border-pixel behavior.
+// atlas entry, with its own transparent ring around it -- which is how a real tilemap runs
+// into the seam behavior described above.
 static CF_Sprite s_cut_tile(const CF_Image* sheet, int col, int row)
 {
 	CF_Pixel px[TILE * TILE];
@@ -84,8 +97,8 @@ static void s_build_map(void)
 }
 
 // A 5x3 tile block rotating about its center. Verifies two things under rotation: the
-// interior stays pixel-stable (the point of the pixel art filters), and adjacent tiles
-// stay seam-free even when the shared edges are not axis-aligned.
+// interior stays pixel-stable (the point of SMOOTH), and adjacent tiles stay seam-free
+// even when the shared edges are not axis-aligned.
 static void s_draw_rotated_block(float angle)
 {
 	static const TileKind block[3][5] = {

--- a/samples/tile_filters.c
+++ b/samples/tile_filters.c
@@ -1,0 +1,273 @@
+/*
+	Demonstrates CF's draw filter modes on a tilemap under subpixel camera motion.
+
+	Adjacent 16x16 tiles are drawn as individual sprites while the camera slowly pans by
+	fractions of a pixel. This exposes seam artifacts between tiles: with SMOOTH/LINEAR the
+	tile edges go semi-transparent at subpixel offsets and the background bleeds through.
+	PIXELART (a port of SDL's SDL_SCALEMODE_PIXELART box-filter) uses hard sprite edges and
+	clamp-to-edge sampling instead, so tiles stay gap-free at any camera offset or zoom.
+
+	Controls:
+	  SPACE    cycle filter mode
+	  P        pause/resume the camera pan
+	  UP/DOWN  zoom in/out
+	  S        save one png per filter mode (current camera offset)
+
+	A 5x3 tile block slowly rotates in the sky: the pixel art filters should keep its
+	interior pixels stable (no shimmering crawl like NEAREST) and its seams closed even
+	though the shared tile edges are not axis-aligned.
+
+	Run `tilefilters screenshot <prefix> [offset_px] [zoom] [angle_deg]` to save
+	deterministic pngs of every filter mode at the given subpixel camera offset (default
+	0.5, worst case for seams) plus a zero-offset control, then exit.
+*/
+
+#include <cute.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TILE 16
+#define MAP_W 32
+#define MAP_H 12
+#define CANVAS_W 1280
+#define CANVAS_H 720
+
+typedef enum TileKind
+{
+	TILE_NONE,
+	TILE_GRASS_L,
+	TILE_GRASS_M,
+	TILE_GRASS_R,
+	TILE_DIRT,
+	TILE_KIND_COUNT,
+} TileKind;
+
+void mount_content_directory_as(const char* dir)
+{
+	// cf_string_append reassigns the dynamic string in place: one allocation, one free.
+	char* path = cf_path_normalize(cf_fs_get_base_directory());
+	cf_string_append(path, "/import_spritesheet_data");
+	cf_fs_mount(path, dir, false);
+	cf_string_free(path);
+}
+
+// Cut one 16x16 tile out of the sheet as its own easy sprite. Each tile becomes a separate
+// atlas entry, which is how a real tilemap hits the atlas border-pixel behavior.
+static CF_Sprite s_cut_tile(const CF_Image* sheet, int col, int row)
+{
+	CF_Pixel px[TILE * TILE];
+	for (int y = 0; y < TILE; ++y) {
+		for (int x = 0; x < TILE; ++x) {
+			px[y * TILE + x] = sheet->pix[(row * TILE + y) * sheet->w + (col * TILE + x)];
+		}
+	}
+	return cf_make_easy_sprite_from_pixels(px, TILE, TILE);
+}
+
+static CF_Sprite s_tiles[TILE_KIND_COUNT];
+static TileKind s_map[MAP_H][MAP_W];
+
+static void s_build_map(void)
+{
+	for (int y = 0; y < MAP_H; ++y) {
+		for (int x = 0; x < MAP_W; ++x) {
+			if (y == 4) s_map[y][x] = TILE_GRASS_M;
+			else if (y > 4) s_map[y][x] = TILE_DIRT;
+			else s_map[y][x] = TILE_NONE;
+		}
+	}
+	// A floating platform so isolated caps (transparent rounded corners) are visible too.
+	s_map[1][10] = TILE_GRASS_L;
+	s_map[1][11] = TILE_GRASS_M;
+	s_map[1][12] = TILE_GRASS_M;
+	s_map[1][13] = TILE_GRASS_R;
+}
+
+// A 5x3 tile block rotating about its center. Verifies two things under rotation: the
+// interior stays pixel-stable (the point of the pixel art filters), and adjacent tiles
+// stay seam-free even when the shared edges are not axis-aligned.
+static void s_draw_rotated_block(float angle)
+{
+	static const TileKind block[3][5] = {
+		{ TILE_GRASS_L, TILE_GRASS_M, TILE_GRASS_M, TILE_GRASS_M, TILE_GRASS_R },
+		{ TILE_DIRT, TILE_DIRT, TILE_DIRT, TILE_DIRT, TILE_DIRT },
+		{ TILE_DIRT, TILE_DIRT, TILE_DIRT, TILE_DIRT, TILE_DIRT },
+	};
+	CF_V2 center = cf_v2(120, 56);
+	CF_SinCos r = cf_sincos(angle);
+	for (int y = 0; y < 3; ++y) {
+		for (int x = 0; x < 5; ++x) {
+			CF_Sprite s = s_tiles[block[y][x]];
+			CF_V2 local = cf_v2((x - 2) * (float)TILE, (1 - y) * (float)TILE);
+			s.transform.r = r;
+			s.transform.p = cf_add_v2(center, cf_mul_sc_v2(r, local));
+			cf_draw_sprite(&s);
+		}
+	}
+}
+
+static void s_draw_scene(CF_DrawFilterMode mode, float zoom, float offx, float offy, float angle)
+{
+	cf_draw_push();
+	cf_draw_scale(zoom, zoom);
+	cf_draw_translate(offx, offy);
+	cf_draw_push_filter(mode);
+	for (int y = 0; y < MAP_H; ++y) {
+		for (int x = 0; x < MAP_W; ++x) {
+			TileKind kind = s_map[y][x];
+			if (kind == TILE_NONE) continue;
+			CF_Sprite s = s_tiles[kind];
+			s.transform.p = cf_v2((x - MAP_W / 2) * (float)TILE, (MAP_H / 2 - y) * (float)TILE);
+			cf_draw_sprite(&s);
+		}
+	}
+	s_draw_rotated_block(angle);
+	cf_draw_pop_filter();
+	cf_draw_pop();
+}
+
+static const char* s_mode_name(CF_DrawFilterMode mode)
+{
+	switch (mode) {
+	case CF_DRAW_FILTER_NEAREST: return "NEAREST";
+	case CF_DRAW_FILTER_LINEAR: return "LINEAR";
+	case CF_DRAW_FILTER_SMOOTH: return "SMOOTH";
+	default: return "???";
+	}
+}
+
+// Renders the queued draw commands into an offscreen canvas and saves it as a png.
+static void s_save_png(const char* path)
+{
+	CF_Canvas canvas = cf_make_canvas(cf_canvas_defaults(CANVAS_W, CANVAS_H));
+	cf_render_to(canvas, true);
+	cf_app_draw_onto_screen(false);
+	CF_Readback rb = cf_canvas_readback(canvas);
+	while (!cf_readback_ready(rb)) {}
+	CF_Image img;
+	img.w = CANVAS_W;
+	img.h = CANVAS_H;
+	img.pix = (CF_Pixel*)cf_alloc(CANVAS_W * CANVAS_H * sizeof(CF_Pixel));
+	cf_readback_data(rb, img.pix, CANVAS_W * CANVAS_H * (int)sizeof(CF_Pixel));
+	cf_destroy_readback(rb);
+	cf_destroy_canvas(canvas);
+	cf_image_save_png(path, &img);
+	cf_free(img.pix);
+	printf("saved %s\n", path);
+}
+
+int main(int argc, char* argv[])
+{
+	bool screenshot = argc > 1 && CF_STRCMP(argv[1], "screenshot") == 0;
+	const char* prefix = argc > 2 ? argv[2] : "tile_filters";
+	float shot_off_px = argc > 3 ? (float)atof(argv[3]) : 0.5f;
+	float shot_zoom = argc > 4 ? (float)atof(argv[4]) : 3.0f;
+	float shot_angle = (argc > 5 ? (float)atof(argv[5]) : 22.5f) * (CF_PI / 180.0f);
+	// Screenshot mode disables HiDPI so one draw unit is exactly one canvas pixel,
+	// making the half-pixel camera offset land on true half-pixel screen positions.
+	int options = CF_APP_OPTIONS_WINDOW_POS_CENTERED_BIT | (screenshot ? CF_APP_OPTIONS_HIDDEN_BIT | CF_APP_OPTIONS_NO_HIGH_DPI_BIT : CF_APP_OPTIONS_RESIZABLE_BIT);
+	CF_Result result = cf_make_app("Tile Filters", 0, 0, 0, CANVAS_W, CANVAS_H, options, argv[0]);
+	if (cf_is_error(result)) return -1;
+	mount_content_directory_as("/");
+	cf_fs_set_write_directory(cf_fs_get_base_directory());
+
+	CF_Image sheet;
+	result = cf_image_load_png("/tiles.png", &sheet);
+	if (cf_is_error(result)) {
+		printf("Failed to load /tiles.png\n");
+		return -1;
+	}
+	s_tiles[TILE_GRASS_L] = s_cut_tile(&sheet, 0, 0);
+	s_tiles[TILE_GRASS_M] = s_cut_tile(&sheet, 1, 0);
+	s_tiles[TILE_GRASS_R] = s_cut_tile(&sheet, 2, 0);
+	s_tiles[TILE_DIRT] = s_cut_tile(&sheet, 1, 1);
+	cf_image_free(&sheet);
+	s_build_map();
+
+	CF_DrawFilterMode modes[] = {
+		CF_DRAW_FILTER_NEAREST,
+		CF_DRAW_FILTER_LINEAR,
+		CF_DRAW_FILTER_SMOOTH,
+	};
+	int mode_count = CF_ARRAY_SIZE(modes);
+	int mode = 0;
+	float zoom = 3.0f;
+	float t = 0;
+	bool paused = false;
+	int shot_frame = 0;
+	int interactive_shot = -1;
+	float shot_offx = 0, shot_offy = 0;
+
+	cf_clear_color(0.35f, 0.60f, 0.95f, 1.0f);
+
+	while (cf_app_is_running()) {
+		cf_app_update(NULL);
+
+		if (screenshot) {
+			// One frame per capture: every mode at a half-pixel offset (worst case for
+			// seams) plus a zero-offset control. Skip frame 0 so the window settles.
+			if (shot_frame > 0) {
+				int idx = shot_frame - 1;
+				if (idx >= mode_count * 2) break;
+				int m = idx / 2;
+				bool half = (idx % 2) == 0;
+				float off = half ? shot_off_px / shot_zoom : 0;
+				s_draw_scene(modes[m], shot_zoom, off, off, shot_angle);
+				char path[256];
+				snprintf(path, sizeof(path), "%s_%s_%s.png", prefix, s_mode_name(modes[m]), half ? "half" : "zero");
+				for (char* c = path; *c; ++c) if (*c == ' ' || *c == '(' || *c == ')') *c = '-';
+				s_save_png(path);
+				shot_frame++;
+				continue;
+			}
+			shot_frame++;
+			cf_app_draw_onto_screen(true);
+			continue;
+		}
+
+		// One capture per frame while an S-key screenshot burst is in flight.
+		if (interactive_shot >= 0) {
+			if (interactive_shot < mode_count) {
+				s_draw_scene(modes[interactive_shot], zoom, shot_offx, shot_offy, t * 0.25f);
+				char path[256];
+				snprintf(path, sizeof(path), "%s_%s.png", prefix, s_mode_name(modes[interactive_shot]));
+				for (char* c = path; *c; ++c) if (*c == ' ' || *c == '(' || *c == ')') *c = '-';
+				s_save_png(path);
+				interactive_shot++;
+				continue;
+			}
+			interactive_shot = -1;
+		}
+
+		if (cf_key_just_pressed(CF_KEY_SPACE)) mode = (mode + 1) % mode_count;
+		if (cf_key_just_pressed(CF_KEY_P)) paused = !paused;
+		if (cf_key_just_pressed(CF_KEY_UP)) zoom += 0.25f;
+		if (cf_key_just_pressed(CF_KEY_DOWN)) zoom = cf_max(0.5f, zoom - 0.25f);
+		if (!paused) t += CF_DELTA_TIME;
+
+		// Slow sinusoidal pan; tile edges continuously cross subpixel screen positions.
+		float offx = sinf(t * 0.30f) * 2.0f;
+		float offy = cosf(t * 0.23f) * 1.5f;
+
+		if (cf_key_just_pressed(CF_KEY_S)) {
+			interactive_shot = 0;
+			shot_offx = offx;
+			shot_offy = offy;
+		}
+
+		s_draw_scene(modes[mode], zoom, offx, offy, t * 0.25f);
+
+		cf_draw_push_color(cf_color_white());
+		cf_push_font_size(20);
+		char label[256];
+		snprintf(label, sizeof(label), "Filter: %s  --  SPACE cycle, P pause, UP/DOWN zoom (%.2fx), S screenshots", s_mode_name(modes[mode]), zoom);
+		cf_draw_text(label, cf_v2(-CANVAS_W * 0.5f + 10, CANVAS_H * 0.5f - 10), -1);
+		cf_pop_font_size();
+		cf_draw_pop_color();
+
+		cf_app_draw_onto_screen(true);
+	}
+
+	cf_destroy_app();
+	return 0;
+}

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -1105,6 +1105,7 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	s.maxx = 1;
 	s.maxy = 1;
 
+	bool is_premade = false;
 	if (sprite->id != CF_SPRITE_ID_INVALID) {
 		if (sprite->blend_index > 0) {
 			CF_SpriteAsset* asset = cf_sprite_get_asset(sprite->id);
@@ -1123,6 +1124,7 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 		s.maxy = sub_image.maxy;
 		s.image_id = sprite->easy_sprite_id;
 		s.texture_id = sub_image.image_id; // @JANK - Hijacked to store texture_id and avoid an extra hashtable lookup.
+		is_premade = true;
 	} else {
 		s.image_id = sprite->easy_sprite_id;
 	}
@@ -1130,10 +1132,22 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	s.h = sprite->h;
 	g.type = BATCH_GEOMETRY_TYPE_SPRITE;
 
+	// CF_SPRITE_EDGE_SOFT: grow the quad one pixel past the image on every side, and run the uvs
+	// one texel past it to match, so that extra ring of geometry samples the atlas's transparent
+	// border, creating a soft edge.
+	bool soft_edge = !is_premade && s_draw->sprite_edges.last() == CF_SPRITE_EDGE_SOFT;
+	float border = soft_edge ? 1.0f : 0.0f;
+	if (soft_edge) {
+		float du = border / (float)s.w;
+		float dv = border / (float)s.h;
+		s.minx -= du; s.maxx += du;
+		s.miny -= dv; s.maxy += dv;
+	}
+
 	v2 offset = sprite->offset - (sprite->id != CF_SPRITE_ID_INVALID ? sprite->_pivot : V2(0,0));
 	v2 p = cf_add(sprite->transform.p, cf_mul(offset, sprite->scale));
 
-	v2 scale = V2(sprite->scale.x * s.w, sprite->scale.y * s.h);
+	v2 scale = V2(sprite->scale.x * (s.w + border * 2.0f), sprite->scale.y * (s.h + border * 2.0f));
 
 	CF_V2 quad[] = {
 		{ -0.5f,  0.5f },
@@ -1240,36 +1254,46 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 	float strip_from_max_y = sprite->h - max_y;
 	float strip_from_min_y = min_y;
 
+	// CF_SPRITE_EDGE_SOFT: grow the quad's outer edges one texel past the image, over the
+	// atlas's transparent border, so the silhouette fades out across it.
+	bool soft_edge = !is_premade && s_draw->sprite_edges.last() == CF_SPRITE_EDGE_SOFT;
+	float du = soft_edge ? 1.0f / (float)sprite->w : 0;
+	float dv = soft_edge ? 1.0f / (float)sprite->h : 0;
+	float uv_left   = 0.0f - du;
+	float uv_right  = 1.0f + du;
+	float uv_bottom = 0.0f - dv;
+	float uv_top    = 1.0f + dv;
+
 	CF_V2 uvs0[] = {
 		// top row
-		cf_v2(0           , center_uv1.y),
-		cf_v2(center_uv0.x, center_uv1.y),
-		cf_v2(center_uv1.x, center_uv1.y),
+		cf_v2(uv_left      , center_uv1.y),
+		cf_v2(center_uv0.x , center_uv1.y),
+		cf_v2(center_uv1.x , center_uv1.y),
 		// middle row
-		cf_v2(0           , center_uv0.y),
-		cf_v2(center_uv0.x, center_uv0.y),
-		cf_v2(center_uv1.x, center_uv0.y),
+		cf_v2(uv_left      , center_uv0.y),
+		cf_v2(center_uv0.x , center_uv0.y),
+		cf_v2(center_uv1.x , center_uv0.y),
 		// bottom row
-		cf_v2(0           , 0.0f),
-		cf_v2(center_uv0.x, 0.0f),
-		cf_v2(center_uv1.x, 0.0f),
+		cf_v2(uv_left      , uv_bottom),
+		cf_v2(center_uv0.x , uv_bottom),
+		cf_v2(center_uv1.x , uv_bottom),
 	};
 
 	CF_V2 uvs1[] = {
 		// top row
-		cf_v2(center_uv0.x, 1.0f),
-		cf_v2(center_uv1.x, 1.0f),
-		cf_v2(1.0f        , 1.0f),
+		cf_v2(center_uv0.x , uv_top),
+		cf_v2(center_uv1.x , uv_top),
+		cf_v2(uv_right     , uv_top),
 
 		// middle row
-		cf_v2(center_uv0.x, center_uv1.y),
-		cf_v2(center_uv1.x, center_uv1.y),
-		cf_v2(1.0f        , center_uv1.y),
+		cf_v2(center_uv0.x , center_uv1.y),
+		cf_v2(center_uv1.x , center_uv1.y),
+		cf_v2(uv_right     , center_uv1.y),
 
 		// bottom row
-		cf_v2(center_uv0.x, center_uv0.y),
-		cf_v2(center_uv1.x, center_uv0.y),
-		cf_v2(1.0f        , center_uv0.y),
+		cf_v2(center_uv0.x , center_uv0.y),
+		cf_v2(center_uv1.x , center_uv0.y),
+		cf_v2(uv_right     , center_uv0.y),
 	};
 
 	if (is_premade) {
@@ -1285,63 +1309,71 @@ void cf_draw_sprite_9_slice(const CF_Sprite* sprite)
 	float inner_top    = strip_from_max_y / full_height;
 	float inner_bottom = strip_from_min_y / full_height;
 
+	// CF_SPRITE_EDGE_SOFT: grow the outer edge of the quads to match the inflated UV
+	float pixel_x = (soft_edge && full_width  > 0) ? 1.0f / full_width : 0;
+	float pixel_y = (soft_edge && full_height > 0) ? 1.0f / full_height : 0;
+	float outer_left   = -0.5f - pixel_x;
+	float outer_right  =  0.5f + pixel_x;
+	float outer_bottom = -0.5f - pixel_y;
+	float outer_top    =  0.5f + pixel_y;
+
 	CF_V2 quads[9][4] = {
 		// top row
 		{
-			{ -0.5f             ,  0.5f                },
-			{ -0.5f + inner_left,  0.5f                },
-			{ -0.5f + inner_left,  0.5f - inner_top    },
-			{ -0.5f             ,  0.5f - inner_top    },
+			{ outer_left           , outer_top             },
+			{ -0.5f + inner_left   , outer_top             },
+			{ -0.5f + inner_left   , 0.5f - inner_top      },
+			{ outer_left           , 0.5f - inner_top      },
 		},
 		{
-			{ -0.5f + inner_left ,  0.5f               },
-			{  0.5f - inner_right,  0.5f               },
-			{  0.5f - inner_right,  0.5f - inner_top   },
-			{ -0.5f + inner_left ,  0.5f - inner_top   },
+			{ -0.5f + inner_left   , outer_top             },
+			{  0.5f - inner_right  , outer_top             },
+			{  0.5f - inner_right  , 0.5f - inner_top      },
+			{ -0.5f + inner_left   , 0.5f - inner_top      },
 		},
 		{
-			{  0.5f - inner_right,  0.5f               },
-			{  0.5f              ,  0.5f               },
-			{  0.5f              ,  0.5f - inner_top   },
-			{  0.5f - inner_right,  0.5f - inner_top   },
+			{ 0.5f - inner_right   , outer_top             },
+			{ outer_right          , outer_top             },
+			{ outer_right          , 0.5f - inner_top      },
+			{ 0.5f - inner_right   , 0.5f - inner_top      },
 		},
 		// middle row
 		{
-			{ -0.5f              ,  0.5f - inner_top    },
-			{ -0.5f + inner_left ,  0.5f - inner_top    },
-			{ -0.5f + inner_left , -0.5f + inner_bottom },
-			{ -0.5f              , -0.5f + inner_bottom },
+			{ outer_left           ,  0.5f - inner_top     },
+			{ -0.5f + inner_left   ,  0.5f - inner_top     },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{ outer_left           , -0.5f + inner_bottom  },
 		},
 		{
-			{ -0.5f + inner_left ,  0.5f - inner_top    },
-			{  0.5f - inner_right,  0.5f - inner_top    },
-			{  0.5f - inner_right, -0.5f + inner_bottom },
-			{ -0.5f + inner_left , -0.5f + inner_bottom },
+			{ -0.5f + inner_left   ,  0.5f - inner_top     },
+			{  0.5f - inner_right  ,  0.5f - inner_top     },
+			{  0.5f - inner_right  , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
 		},
 		{
-			{  0.5f - inner_right,  0.5f - inner_top    },
-			{  0.5f              ,  0.5f - inner_top    },
-			{  0.5f              , -0.5f + inner_bottom },
-			{  0.5f - inner_right, -0.5f + inner_bottom },
+			{ 0.5f - inner_right   ,  0.5f - inner_top     },
+			{ outer_right          ,  0.5f - inner_top     },
+			{ outer_right          , -0.5f + inner_bottom  },
+			{ 0.5f - inner_right   , -0.5f + inner_bottom  },
 		},
 		// bottom row
 		{
-			{ -0.5f              , -0.5f + inner_bottom },
-			{ -0.5f + inner_left , -0.5f + inner_bottom },
-			{ -0.5f + inner_left , -0.5f                },
-			{ -0.5f              , -0.5f                },
+			{ outer_left           , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , outer_bottom          },
+			{ outer_left           , outer_bottom          },
 		},
 		{
-			{ -0.5f + inner_left , -0.5f + inner_bottom },
-			{  0.5f - inner_right, -0.5f + inner_bottom },
-			{  0.5f - inner_right, -0.5f                },
-			{ -0.5f + inner_left , -0.5f                },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{  0.5f - inner_right  , -0.5f + inner_bottom  },
+			{  0.5f - inner_right  , outer_bottom          },
+			{ -0.5f + inner_left   , outer_bottom          },
 		},
 		{
-			{  0.5f - inner_right, -0.5f + inner_bottom },
-			{  0.5f              , -0.5f + inner_bottom },
-			{  0.5f              , -0.5f                },
-			{  0.5f - inner_right, -0.5f                },
+			{ 0.5f - inner_right   , -0.5f + inner_bottom  },
+			{ outer_right          , -0.5f + inner_bottom  },
+			{ outer_right          , outer_bottom          },
+			{ 0.5f - inner_right   , outer_bottom          },
 		},
 	};
 
@@ -1438,34 +1470,44 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 	float strip_from_max_y = sprite->h - max_y;
 	float strip_from_min_y = min_y;
 
+	// CF_SPRITE_EDGE_SOFT: grow the quad's outer edges one texel past the image, over the
+	// atlas's transparent border, so the silhouette fades out across it.
+	bool soft_edge = !is_premade && s_draw->sprite_edges.last() == CF_SPRITE_EDGE_SOFT;
+	float du = soft_edge ? 1.0f / (float)sprite->w : 0;
+	float dv = soft_edge ? 1.0f / (float)sprite->h : 0;
+	float uv_left   = 0.0f - du;
+	float uv_right  = 1.0f + du;
+	float uv_bottom = 0.0f - dv;
+	float uv_top    = 1.0f + dv;
+
 	CF_V2 uvs0[] = {
 		// top row
-		cf_v2(0           , center_uv1.y),
-		cf_v2(center_uv0.x, center_uv1.y),
-		cf_v2(center_uv1.x, center_uv1.y),
+		cf_v2(uv_left      , center_uv1.y),
+		cf_v2(center_uv0.x , center_uv1.y),
+		cf_v2(center_uv1.x , center_uv1.y),
 		// middle row
-		cf_v2(0           , center_uv0.y),
-		cf_v2(center_uv0.x, center_uv0.y),
-		cf_v2(center_uv1.x, center_uv0.y),
+		cf_v2(uv_left      , center_uv0.y),
+		cf_v2(center_uv0.x , center_uv0.y),
+		cf_v2(center_uv1.x , center_uv0.y),
 		// bottom row
-		cf_v2(0           , 0.0f),
-		cf_v2(center_uv0.x, 0.0f),
-		cf_v2(center_uv1.x, 0.0f),
+		cf_v2(uv_left      , uv_bottom),
+		cf_v2(center_uv0.x , uv_bottom),
+		cf_v2(center_uv1.x , uv_bottom),
 	};
 
 	CF_V2 uvs1[] = {
 		// top row
-		cf_v2(center_uv0.x, 1.0f),
-		cf_v2(center_uv1.x, 1.0f),
-		cf_v2(1.0f        , 1.0f),
+		cf_v2(center_uv0.x , uv_top),
+		cf_v2(center_uv1.x , uv_top),
+		cf_v2(uv_right     , uv_top),
 		// middle row
-		cf_v2(center_uv0.x, center_uv1.y),
-		cf_v2(center_uv1.x, center_uv1.y),
-		cf_v2(1.0f        , center_uv1.y),
+		cf_v2(center_uv0.x , center_uv1.y),
+		cf_v2(center_uv1.x , center_uv1.y),
+		cf_v2(uv_right     , center_uv1.y),
 		// bottom row
-		cf_v2(center_uv0.x, center_uv0.y),
-		cf_v2(center_uv1.x, center_uv0.y),
-		cf_v2(1.0f        , center_uv0.y),
+		cf_v2(center_uv0.x , center_uv0.y),
+		cf_v2(center_uv1.x , center_uv0.y),
+		cf_v2(uv_right     , center_uv0.y),
 	};
 
 	if (is_premade) {
@@ -1485,63 +1527,71 @@ void cf_draw_sprite_9_slice_tiled(const CF_Sprite* sprite)
 	CF_V2 side_tiled_size = V2(	(center_patch.max.x - center_patch.min.x) / full_width,
 								(center_patch.max.y - center_patch.min.y) / full_height);
 
+	// CF_SPRITE_EDGE_SOFT: grow the outer edge of the quads to match the inflated UV
+	float pixel_x = soft_edge ? 1.0f / full_width : 0;
+	float pixel_y = soft_edge ? 1.0f / full_height : 0;
+	float outer_left   = -0.5f - pixel_x;
+	float outer_right  =  0.5f + pixel_x;
+	float outer_bottom = -0.5f - pixel_y;
+	float outer_top    =  0.5f + pixel_y;
+
 	CF_V2 quads[9][4] = {
 		// top row
 		{
-			{ -0.5f             ,  0.5f               },
-			{ -0.5f + inner_left,  0.5f               },
-			{ -0.5f + inner_left,  0.5f - inner_top   },
-			{ -0.5f             ,  0.5f - inner_top   },
+			{ outer_left           , outer_top             },
+			{ -0.5f + inner_left   , outer_top             },
+			{ -0.5f + inner_left   , 0.5f - inner_top      },
+			{ outer_left           , 0.5f - inner_top      },
 		},
 		{
-			{ -0.5f + inner_left ,  0.5f              },
-			{  0.5f - inner_right,  0.5f              },
-			{  0.5f - inner_right,  0.5f - inner_top  },
-			{ -0.5f + inner_left ,  0.5f - inner_top  },
+			{ -0.5f + inner_left   , outer_top             },
+			{  0.5f - inner_right  , outer_top             },
+			{  0.5f - inner_right  , 0.5f - inner_top      },
+			{ -0.5f + inner_left   , 0.5f - inner_top      },
 		},
 		{
-			{  0.5f - inner_right,  0.5f              },
-			{  0.5f              ,  0.5f              },
-			{  0.5f              ,  0.5f - inner_top  },
-			{  0.5f - inner_right,  0.5f - inner_top  },
+			{ 0.5f - inner_right   , outer_top             },
+			{ outer_right          , outer_top             },
+			{ outer_right          , 0.5f - inner_top      },
+			{ 0.5f - inner_right   , 0.5f - inner_top      },
 		},
 		// middle row
 		{
-			{ -0.5f              ,  0.5f - inner_top   },
-			{ -0.5f + inner_left ,  0.5f - inner_top   },
-			{ -0.5f + inner_left , -0.5f + inner_bottom},
-			{ -0.5f              , -0.5f + inner_bottom},
+			{ outer_left           ,  0.5f - inner_top     },
+			{ -0.5f + inner_left   ,  0.5f - inner_top     },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{ outer_left           , -0.5f + inner_bottom  },
 		},
 		{
-			{ -0.5f + inner_left ,  0.5f - inner_top   },
-			{  0.5f - inner_right,  0.5f - inner_top   },
-			{  0.5f - inner_right, -0.5f + inner_bottom},
-			{ -0.5f + inner_left , -0.5f + inner_bottom},
+			{ -0.5f + inner_left   ,  0.5f - inner_top     },
+			{  0.5f - inner_right  ,  0.5f - inner_top     },
+			{  0.5f - inner_right  , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
 		},
 		{
-			{  0.5f - inner_right,  0.5f - inner_top   },
-			{  0.5f              ,  0.5f - inner_top   },
-			{  0.5f              , -0.5f + inner_bottom},
-			{  0.5f - inner_right, -0.5f + inner_bottom},
+			{ 0.5f - inner_right   ,  0.5f - inner_top     },
+			{ outer_right          ,  0.5f - inner_top     },
+			{ outer_right          , -0.5f + inner_bottom  },
+			{ 0.5f - inner_right   , -0.5f + inner_bottom  },
 		},
 		// bottom row
 		{
-			{ -0.5f              , -0.5f + inner_bottom},
-			{ -0.5f + inner_left , -0.5f + inner_bottom},
-			{ -0.5f + inner_left , -0.5f               },
-			{ -0.5f              , -0.5f               },
+			{ outer_left           , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{ -0.5f + inner_left   , outer_bottom          },
+			{ outer_left           , outer_bottom          },
 		},
 		{
-			{ -0.5f + inner_left , -0.5f + inner_bottom},
-			{  0.5f - inner_right, -0.5f + inner_bottom},
-			{  0.5f - inner_right, -0.5f               },
-			{ -0.5f + inner_left , -0.5f               },
+			{ -0.5f + inner_left   , -0.5f + inner_bottom  },
+			{  0.5f - inner_right  , -0.5f + inner_bottom  },
+			{  0.5f - inner_right  , outer_bottom          },
+			{ -0.5f + inner_left   , outer_bottom          },
 		},
 		{
-			{  0.5f - inner_right, -0.5f + inner_bottom},
-			{  0.5f              , -0.5f + inner_bottom},
-			{  0.5f              , -0.5f               },
-			{  0.5f - inner_right, -0.5f               },
+			{ 0.5f - inner_right   , -0.5f + inner_bottom  },
+			{ outer_right          , -0.5f + inner_bottom  },
+			{ outer_right          , outer_bottom          },
+			{ 0.5f - inner_right   , outer_bottom          },
 		},
 	};
 
@@ -4773,6 +4823,21 @@ CF_DrawFilterMode cf_draw_pop_filter()
 CF_DrawFilterMode cf_draw_peek_filter()
 {
 	return s_draw->filter_modes.last();
+}
+
+void cf_draw_push_sprite_edge(CF_SpriteEdge sprite_edge)
+{
+	PUSH_DRAW_VAR(sprite_edge);
+}
+
+CF_SpriteEdge cf_draw_pop_sprite_edge()
+{
+	POP_DRAW_VAR(sprite_edge);
+}
+
+CF_SpriteEdge cf_draw_peek_sprite_edge()
+{
+	return s_draw->sprite_edges.last();
 }
 
 // Blend modes are recorded per drawable (no command split at record time); the flush

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -564,13 +564,13 @@ static void s_draw_report_tiled(const BatchGeometry* geoms, const CF_PendingUV* 
 			tc.payload = (uint32_t)pay.count();
 			pay.add({ q0.x, q0.y, e1.x, e1.y });
 			pay.add({ e2.x, e2.y, 1.0f / dot(e1, e1), 1.0f / dot(e2, e2) });
-			// The reported uv rect spans the entry's padded rect (atlas_use_border_pixels);
-			// +1 steps past the 1px border onto the block's first content texel, and the
-			// content width (padded minus borders) drives row wrapping for multi-row
-			// path blocks (glyph strips are single-row and never wrap).
-			float bx = CF_ROUNDF(cf_min(s->minx, s->maxx) * (float)texture_w) + 1.0f;
-			float by = CF_ROUNDF(cf_min(s->miny, s->maxy) * (float)texture_h) + 1.0f;
-			float bw = CF_ROUNDF(fabsf(s->maxx - s->minx) * (float)texture_w) - 2.0f;
+			// The reported uv rect spans the block's content (any atlas border ring is
+			// already excluded), so it lands directly on the first content texel, and its
+			// width drives row wrapping for multi-row path blocks (glyph strips are
+			// single-row and never wrap).
+			float bx = CF_ROUNDF(cf_min(s->minx, s->maxx) * (float)texture_w);
+			float by = CF_ROUNDF(cf_min(s->miny, s->maxy) * (float)texture_h);
+			float bw = CF_ROUNDF(fabsf(s->maxx - s->minx) * (float)texture_w);
 			pay.add({ bx, by, cf_max(bw, 1.0f), 0 });
 			// Per-corner colors (TL,TR,BR,BL), bilerped in the shader by box fraction so
 			// text-effect color gradients carry over to the curve path.
@@ -1105,7 +1105,6 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	s.maxx = 1;
 	s.maxy = 1;
 
-	bool apply_border_scale = true;
 	if (sprite->id != CF_SPRITE_ID_INVALID) {
 		if (sprite->blend_index > 0) {
 			CF_SpriteAsset* asset = cf_sprite_get_asset(sprite->id);
@@ -1124,7 +1123,6 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 		s.maxy = sub_image.maxy;
 		s.image_id = sprite->easy_sprite_id;
 		s.texture_id = sub_image.image_id; // @JANK - Hijacked to store texture_id and avoid an extra hashtable lookup.
-		apply_border_scale = false;
 	} else {
 		s.image_id = sprite->easy_sprite_id;
 	}
@@ -1136,11 +1134,6 @@ void cf_draw_sprite(const CF_Sprite* sprite)
 	v2 p = cf_add(sprite->transform.p, cf_mul(offset, sprite->scale));
 
 	v2 scale = V2(sprite->scale.x * s.w, sprite->scale.y * s.h);
-	if (apply_border_scale) {
-		// Expand sprite's scale to account for border pixels in the atlas.
-		scale.x = scale.x + (scale.x / (float)sprite->w) * 2.0f;
-		scale.y = scale.y + (scale.y / (float)sprite->h) * 2.0f;
-	}
 
 	CF_V2 quad[] = {
 		{ -0.5f,  0.5f },
@@ -4215,13 +4208,8 @@ static v2 s_draw_text(const char* text, CF_V2 position, int text_length, bool re
 			g.alpha = 1.0f;
 			CF_Color color = s_draw->colors.last();
 
-			// Account for atlas_cache's 1-pixel atlas border. The border is 1 *device*
-			// pixel (glyph bitmaps are rasterized at pixel_scale resolution), but q0/q1
-			// are in logical units, so the pad must shrink by pixel_scale to match --
-			// otherwise on HiDPI the quad is stretched past the glyph's actual coverage.
-			v2 pad = V2(1,1) / app->pixel_scale;
-			v2 q0 = glyph->q0 + V2(x,baseline_y) - pad;
-			v2 q1 = glyph->q1 + V2(x,baseline_y) + pad;
+			v2 q0 = glyph->q0 + V2(x,baseline_y);
+			v2 q1 = glyph->q1 + V2(x,baseline_y);
 
 			// Curve text path (the default; a pushed stroke also forces it): fetch the
 			// outline strip up front so layout stays identical (metrics still come from
@@ -5463,11 +5451,6 @@ CF_TemporaryImage cf_fetch_image(const CF_Sprite* sprite)
 		image.tex = { s.texture_id };
 		image.w = sprite->w;
 		image.h = sprite->h;
-		v2 inv_dims = V2(1.0f / s_draw->atlas_dims.x, 1.0f / s_draw->atlas_dims.y);
-		s.minx += inv_dims.x;
-		s.maxx -= inv_dims.x;
-		s.miny -= inv_dims.y;
-		s.maxy += inv_dims.y;
 		image.u = cf_v2(s.minx, s.miny);
 		image.v = cf_v2(s.maxx, s.maxy);
 		return image;

--- a/src/cute_draw3d.cpp
+++ b/src/cute_draw3d.cpp
@@ -74,16 +74,6 @@ struct CF_TextureBinding3d
 	bool ambient;
 };
 
-// One instance's sprite image, captured at submission (cf_draw3d_push_texture). The entry is
-// the atlas-cache template (image id, dimensions, local uv sub-rect); resolution to a page
-// texture + atlas uv rect happens per flush in cf_draw3d_process, which is also the usage
-// signal the atlas compiler packs by.
-struct CF_ImageRef3d
-{
-	atlas_cache_entry_t entry;
-	bool bordered; // Atlased images carry a 1px border (inset one texel); premade rects don't.
-};
-
 // One sub-mesh draw record within a coalesced command (see CF_MeshCmd3d::runs).
 struct CF_MeshRun3d
 {
@@ -118,8 +108,8 @@ struct CF_MeshCmd3d
 	// `instances`. Presence splits coalescing (it changes what the shader samples); the
 	// images themselves vary freely across instances.
 	bool sprite_textured = false;
-	Cute::Array<CF_ImageRef3d> image_refs;
-	const Cute::Array<CF_ImageRef3d>* image_refs_ref = NULL;
+	Cute::Array<atlas_cache_entry_t> image_refs;
+	const Cute::Array<atlas_cache_entry_t>* image_refs_ref = NULL;
 	Cute::Array<CF_Uniform3d> uniforms; // data points into uniform_block.
 	void* uniform_block = NULL;         // One allocation holding every captured uniform's bytes.
 	                                    // NULL when the bytes are borrowed (replay payloads).
@@ -545,15 +535,13 @@ static CF_MeshInstance3d s_instance()
 
 // Captures a sprite's current frame as an atlas entry template, mirroring cf_draw_sprite's
 // image-id resolution (asset sprites, blend layers, easy sprites, premade sub-images).
-static CF_ImageRef3d s_image_ref(const CF_Sprite* sprite)
+static atlas_cache_entry_t s_image_ref(const CF_Sprite* sprite)
 {
-	CF_ImageRef3d ref = { };
-	atlas_cache_entry_t& s = ref.entry;
+	atlas_cache_entry_t s = { };
 	s.minx = 0;
 	s.miny = 0;
 	s.maxx = 1;
 	s.maxy = 1;
-	ref.bordered = true;
 	if (sprite->id != CF_SPRITE_ID_INVALID) {
 		if (sprite->blend_index > 0) {
 			CF_SpriteAsset* asset = cf_sprite_get_asset(sprite->id);
@@ -572,13 +560,12 @@ static CF_ImageRef3d s_image_ref(const CF_Sprite* sprite)
 		s.maxy = sub_image.maxy;
 		s.image_id = sprite->easy_sprite_id;
 		s.texture_id = sub_image.image_id; // @JANK - Hijacked to store texture_id, matching cf_draw_sprite.
-		ref.bordered = false;
 	} else {
 		s.image_id = sprite->easy_sprite_id;
 	}
 	s.w = sprite->w;
 	s.h = sprite->h;
-	return ref;
+	return s;
 }
 
 // Routes atlas uv results to the mesh command being resolved in cf_draw3d_process (the 2d
@@ -1984,7 +1971,7 @@ void cf_draw3d_process(CF_Command* cmd, CF_Canvas canvas, bool clear)
 		// Resolve every instance's image through the atlas. Pushing entries per flush is both
 		// the uv lookup and the usage signal: images drawn together pack into shared pages,
 		// so page splits (extra draws below) converge away as the atlas learns the scene.
-		const Cute::Array<CF_ImageRef3d>& image_refs = mc->image_refs_ref ? *mc->image_refs_ref : mc->image_refs;
+		const Cute::Array<atlas_cache_entry_t>& image_refs = mc->image_refs_ref ? *mc->image_refs_ref : mc->image_refs;
 		CF_ASSERT(image_refs.count() == instances.count());
 		s_draw3d->resolve_uvs.clear();
 		s_draw3d->resolve_uvs.set_count(instances.count());
@@ -1994,10 +1981,10 @@ void cf_draw3d_process(CF_Command* cmd, CF_Canvas canvas, bool clear)
 		// image per flush is still the atlas's usage signal.
 		s_draw3d->resolve_dedupe.clear();
 		for (int i = 0; i < instances.count(); ++i) {
-			uint64_t image_id = image_refs[i].entry.image_id;
+			uint64_t image_id = image_refs[i].image_id;
 			if (s_draw3d->resolve_dedupe.try_find(image_id)) continue;
 			s_draw3d->resolve_dedupe.add(image_id, i);
-			atlas_cache_entry_t e = image_refs[i].entry;
+			atlas_cache_entry_t e = image_refs[i];
 			e.udata = (ATLAS_CACHE_U64)i;
 			atlas_cache_push(&s_draw->atlas_cache, e);
 		}
@@ -2006,20 +1993,18 @@ void cf_draw3d_process(CF_Command* cmd, CF_Canvas canvas, bool clear)
 		atlas_cache_flush(&s_draw->atlas_cache);
 		s_draw3d->resolving = false;
 		for (int i = 0; i < instances.count(); ++i) {
-			int rep = s_draw3d->resolve_dedupe.find(image_refs[i].entry.image_id);
+			int rep = s_draw3d->resolve_dedupe.find(image_refs[i].image_id);
 			if (rep != i) s_draw3d->resolve_uvs[i] = s_draw3d->resolve_uvs[rep];
 		}
 
 		// Stage uv-filled instance copies. The rect packs as (minx, maxy, maxx, miny) so mesh
-		// uv (0, 0) samples the image's top-left, matching 2d sprites; atlased images inset
-		// one texel to skip the 1px border ring.
+		// uv (0, 0) samples the image's top-left, matching 2d sprites. Reported uvs already
+		// exclude the atlas border ring, so they map straight onto the mesh.
 		s_draw3d->staged.clear();
 		for (int i = 0; i < instances.count(); ++i) {
 			const CF_PendingUV& uv = s_draw3d->resolve_uvs[i];
 			CF_MeshInstance3d inst = instances[i];
-			float du = image_refs[i].bordered && uv.tex_w ? 1.0f / (float)uv.tex_w : 0;
-			float dv = image_refs[i].bordered && uv.tex_h ? 1.0f / (float)uv.tex_h : 0;
-			inst.uv_rect = cf_v4(uv.minx + du, uv.maxy + dv, uv.maxx - du, uv.miny - dv);
+			inst.uv_rect = cf_v4(uv.minx, uv.maxy, uv.maxx, uv.miny);
 			s_draw3d->staged.add(inst);
 		}
 	}

--- a/src/internal/cute_draw_internal.h
+++ b/src/internal/cute_draw_internal.h
@@ -329,6 +329,7 @@ struct CF_Draw
 	CF_Arena uniform_arena;
 	Cute::Array<float> alpha_discards = { 1.0f };
 	Cute::Array<CF_DrawFilterMode> filter_modes = { CF_DRAW_FILTER_SMOOTH };
+	Cute::Array<CF_SpriteEdge> sprite_edges = { CF_SPRITE_EDGE_SOFT };
 	Cute::Array<int> blends = { 0 }; // CF_DrawBlend stack (cf_draw_push_blend).
 	Cute::Array<CF_Color> colors = { cf_color_white() };
 	Cute::Array<CF_DrawDash> dashes = { { 0, 0, 0 } }; // cf_draw_push_dash stack; on = 0 means solid.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CF_TEST_SRCS
 	test_json.cpp
 	test_markups.cpp
 	test_draw_tiled.cpp
+	test_atlas_uvs.cpp
 	test_graphics_3d.cpp
 	test_shader_reload.cpp
 	test_shader_directory.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -45,6 +45,7 @@ TEST_SUITE(test_string);
 TEST_SUITE(test_json);
 TEST_SUITE(test_markups);
 TEST_SUITE(test_draw_tiled);
+TEST_SUITE(test_atlas_uvs);
 TEST_SUITE(test_graphics_3d);
 TEST_SUITE(test_shader_reload);
 TEST_SUITE(test_shader_directory);
@@ -117,6 +118,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_json);
 	RUN_TRACED(test_markups);
 	RUN_TRACED(test_draw_tiled);
+	RUN_TRACED(test_atlas_uvs);
 	RUN_TRACED(test_graphics_3d);
 	RUN_TRACED(test_shader_reload);
 	RUN_TRACED(test_shader_directory);

--- a/test/test_atlas_uvs.cpp
+++ b/test/test_atlas_uvs.cpp
@@ -1,0 +1,184 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute.h>
+#include <internal/cute_draw_internal.h>
+
+#include <math.h>
+#include <string.h>
+
+// The atlas cache pads each image with a 1px border ring so a bilinear tap at an image's
+// edge cannot reach into the neighboring image. That ring is an implementation detail:
+// reported uvs must span the image's *content*, and local uvs pushed on an entry are
+// fractions of the image. Renderers rely on this to map one texel per sprite pixel without
+// inflating their geometry, and 9-slice relies on it to cut patches where it says it does.
+//
+// Pure CPU -- no app, no GPU, so this runs headless.
+
+#define UV_ATLAS_W 64
+#define UV_ATLAS_H 64
+#define UV_IMG_W   16
+#define UV_IMG_H   8
+
+struct UvHarness
+{
+	atlas_cache_t cache;
+	atlas_cache_entry_t reported[8];
+	int reported_count;
+	uint64_t next_texture_id;
+};
+
+static UvHarness* s_uv;
+
+static ATLAS_CACHE_U64 s_uv_generate_texture(void* pixels, int w, int h, void* udata)
+{
+	CF_UNUSED(pixels); CF_UNUSED(w); CF_UNUSED(h); CF_UNUSED(udata);
+	return s_uv->next_texture_id++;
+}
+
+static void s_uv_destroy_texture(ATLAS_CACHE_U64 texture_id, void* udata)
+{
+	CF_UNUSED(texture_id); CF_UNUSED(udata);
+}
+
+static void s_uv_get_pixels(ATLAS_CACHE_U64 image_id, void* buffer, int bytes, void* udata)
+{
+	CF_UNUSED(image_id); CF_UNUSED(udata);
+	CF_MEMSET(buffer, 0xFF, bytes);
+}
+
+static void s_uv_report(atlas_cache_entry_t* entries, int count, int texture_w, int texture_h, void* udata)
+{
+	CF_UNUSED(texture_w); CF_UNUSED(texture_h); CF_UNUSED(udata);
+	for (int i = 0; i < count && s_uv->reported_count < 8; ++i) {
+		s_uv->reported[s_uv->reported_count++] = entries[i];
+	}
+}
+
+static void s_uv_init(UvHarness* h)
+{
+	CF_MEMSET(h, 0, sizeof(*h));
+	h->next_texture_id = 1;
+	s_uv = h;
+
+	atlas_cache_config_t config;
+	atlas_cache_set_default_config(&config);
+	config.atlas_use_border_pixels = 1;
+	config.atlas_width_in_pixels = UV_ATLAS_W;
+	config.atlas_height_in_pixels = UV_ATLAS_H;
+	config.lonely_buffer_count_till_flush = 0;
+	config.ticks_to_decay_texture = 100000;
+	config.batch_callback = s_uv_report;
+	config.get_pixels_callback = s_uv_get_pixels;
+	config.generate_texture_callback = s_uv_generate_texture;
+	config.delete_texture_callback = s_uv_destroy_texture;
+	atlas_cache_init(&h->cache, &config, NULL);
+}
+
+// Push one entry carrying a local uv sub-rect, flush, and hand back what was reported.
+static atlas_cache_entry_t s_uv_submit(UvHarness* h, uint64_t image_id, float u0, float v0, float u1, float v1)
+{
+	atlas_cache_entry_t e;
+	CF_MEMSET(&e, 0, sizeof(e));
+	e.image_id = image_id;
+	e.w = UV_IMG_W;
+	e.h = UV_IMG_H;
+	e.minx = u0; e.miny = v0;
+	e.maxx = u1; e.maxy = v1;
+	h->reported_count = 0;
+	atlas_cache_push(&h->cache, e);
+	atlas_cache_flush(&h->cache);
+	CF_MEMSET(&e, 0, sizeof(e));
+	return h->reported_count == 1 ? h->reported[0] : e;
+}
+
+static bool s_uv_near(float a, float b) { return fabsf(a - b) < 1e-5f; }
+
+TEST_CASE(test_atlas_uvs_exclude_border_ring)
+{
+	UvHarness h;
+	s_uv_init(&h);
+
+	// Before any defrag the image is "lonely": it owns a texture that is exactly one
+	// padded slot, so the content rect is the texture minus one texel per edge.
+	float iw = 1.0f / (float)(UV_IMG_W + 2);
+	float ih = 1.0f / (float)(UV_IMG_H + 2);
+	atlas_cache_entry_t lonely = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	REQUIRE(s_uv_near(lonely.minx, iw));
+	REQUIRE(s_uv_near(lonely.maxx, 1.0f - iw));
+	// v is reported flipped, so miny holds the larger coordinate.
+	REQUIRE(s_uv_near(lonely.miny, 1.0f - ih));
+	REQUIRE(s_uv_near(lonely.maxy, ih));
+	// Dimensions describe the image, not its padded slot.
+	REQUIRE(lonely.w == UV_IMG_W);
+	REQUIRE(lonely.h == UV_IMG_H);
+
+	// Once packed into a page, the rect must still be exactly the image: a whole number of
+	// texels wide and tall, landing on texel edges, with the ring between it and the page.
+	atlas_cache_defrag(&h.cache);
+	atlas_cache_entry_t atlased = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	float x0 = atlased.minx * UV_ATLAS_W;
+	float y0 = atlased.maxy * UV_ATLAS_H;
+	REQUIRE(s_uv_near((atlased.maxx - atlased.minx) * UV_ATLAS_W, (float)UV_IMG_W));
+	REQUIRE(s_uv_near((atlased.miny - atlased.maxy) * UV_ATLAS_H, (float)UV_IMG_H));
+	REQUIRE(s_uv_near(x0, floorf(x0)));
+	REQUIRE(s_uv_near(y0, floorf(y0)));
+	REQUIRE(x0 >= 1.0f); // Ring sits between the content and the page edge.
+	REQUIRE(y0 >= 1.0f);
+	REQUIRE(atlased.w == UV_IMG_W);
+	REQUIRE(atlased.h == UV_IMG_H);
+
+	// atlas_cache_fetch reports the same rect as a flush does.
+	atlas_cache_entry_t fetched = atlas_cache_fetch(&h.cache, 100, UV_IMG_W, UV_IMG_H);
+	REQUIRE(s_uv_near(fetched.minx, atlased.minx));
+	REQUIRE(s_uv_near(fetched.maxx, atlased.maxx));
+	REQUIRE(s_uv_near(fetched.miny, atlased.miny));
+	REQUIRE(s_uv_near(fetched.maxy, atlased.maxy));
+
+	atlas_cache_term(&h.cache);
+	s_uv = NULL;
+	return true;
+}
+
+TEST_CASE(test_atlas_uvs_partial_rect_matches_residency)
+{
+	UvHarness h;
+	s_uv_init(&h);
+
+	// The 9-slice case: a local sub-rect must select that same fraction of the image, and
+	// must not shift or flip when the image moves from its own texture into an atlas page.
+	atlas_cache_entry_t lonely_full = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	atlas_cache_entry_t lonely_half = s_uv_submit(&h, 100, 0, 0, 0.5f, 0.5f);
+
+	atlas_cache_defrag(&h.cache);
+	atlas_cache_entry_t atlas_full = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	atlas_cache_entry_t atlas_half = s_uv_submit(&h, 100, 0, 0, 0.5f, 0.5f);
+
+	// Both halves start at the image's origin.
+	REQUIRE(s_uv_near(lonely_half.minx, lonely_full.minx));
+	REQUIRE(s_uv_near(lonely_half.miny, lonely_full.miny));
+	REQUIRE(s_uv_near(atlas_half.minx, atlas_full.minx));
+	REQUIRE(s_uv_near(atlas_half.miny, atlas_full.miny));
+
+	// ...and cover half of it, in the same direction, in both residencies.
+	REQUIRE(s_uv_near((lonely_half.maxx - lonely_full.minx) / (lonely_full.maxx - lonely_full.minx), 0.5f));
+	REQUIRE(s_uv_near((lonely_half.maxy - lonely_full.miny) / (lonely_full.maxy - lonely_full.miny), 0.5f));
+	REQUIRE(s_uv_near((atlas_half.maxx - atlas_full.minx) / (atlas_full.maxx - atlas_full.minx), 0.5f));
+	REQUIRE(s_uv_near((atlas_half.maxy - atlas_full.miny) / (atlas_full.maxy - atlas_full.miny), 0.5f));
+
+	atlas_cache_term(&h.cache);
+	s_uv = NULL;
+	return true;
+}
+
+TEST_SUITE(test_atlas_uvs)
+{
+	RUN_TEST_CASE(test_atlas_uvs_exclude_border_ring);
+	RUN_TEST_CASE(test_atlas_uvs_partial_rect_matches_residency);
+}

--- a/test/test_atlas_uvs.cpp
+++ b/test/test_atlas_uvs.cpp
@@ -5,10 +5,18 @@
 	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
 */
 
+// libcute compiles the atlas cache into cute_draw.cpp, where its symbols carry no CF_API
+// export decoration -- invisible to anything linking against the DLL on Windows, even though
+// they resolve fine against an ELF shared object. Compile a private copy into this test with
+// internal linkage instead. The cache keeps all of its state in the atlas_cache_t the caller
+// owns, so a second copy shares nothing with libcute's and cannot interfere with it.
+#define ATLAS_CACHE_API static inline
+#define ATLAS_CACHE_IMPLEMENTATION
+#include <cute/cute_atlas_cache.h>
+
 #include "test_harness.h"
 
 #include <cute.h>
-#include <internal/cute_draw_internal.h>
 
 #include <math.h>
 #include <string.h>

--- a/tools/builtin_shaders.h
+++ b/tools/builtin_shaders.h
@@ -637,6 +637,28 @@ vec2 smooth_uv(vec2 uv, vec2 texture_size)
 	pixel = seam + clamp((pixel - seam) / fwidth(pixel), -0.5, 0.5);
 	return pixel / texture_size;
 }
+
+vec2 smooth_uv_fw(vec2 uv, vec4 uv_bounds, vec2 texture_size, vec2 fw)
+{
+	vec2 pixel = uv * texture_size;
+	vec2 seam  = floor(pixel + 0.5);
+	pixel = seam + clamp((pixel - seam) / fw, -0.5, 0.5);
+	uv = pixel / texture_size;
+
+	vec2 half_texel = 0.5 / texture_size;
+	return clamp(uv, uv_bounds.xy + half_texel, uv_bounds.zw - half_texel);
+}
+
+vec2 smooth_uv(vec2 uv, vec4 uv_bounds, vec2 texture_size)
+{
+	vec2 pixel = uv * texture_size;
+	vec2 seam  = floor(pixel + 0.5);
+	pixel = seam + clamp((pixel - seam) / fwidth(pixel), -0.5, 0.5);
+	uv = pixel / texture_size;
+
+	vec2 half_texel = 0.5 / texture_size;
+	return clamp(uv, uv_bounds.xy + half_texel, uv_bounds.zw - half_texel);
+}
 )";
 
 // Stub function. This gets replaced by injected user-shader code via #include.
@@ -771,7 +793,7 @@ void main()
 
 	// Traditional sprite/text/tri cases.
 	vec4 c = vec4(0);
-	vec2 uv = u_use_smooth_uv == 0 ? smooth_uv(v_uv, u_texture_size) : v_uv;
+	vec2 uv = u_use_smooth_uv == 0 ? smooth_uv(v_uv, v_uv_bounds, u_texture_size) : v_uv;
 	vec4 tex_c = de_gamma(texture(u_image, uv));
 	c = is_sprite ? gamma(tex_c) : c;
 	c = is_text ? v_col * tex_c.a : c;
@@ -1050,10 +1072,10 @@ void main()
 			float gds = (abs(dot(gdx, e1)) + abs(dot(gdy, e1))) * P1.z;
 			float gdt = (abs(dot(gdx, e2)) + abs(dot(gdy, e2))) * P1.w;
 			vec2 fw = vec2(gds * abs(uvb.z - uvb.x), gdt * abs(uvb.w - uvb.y)) * u_texture_size;
-			vec2 uv_final = u_use_smooth_uv == 0 ? smooth_uv_fw(uv, u_texture_size, fw) : uv;
+			vec2 uv_final = u_use_smooth_uv == 0 ? smooth_uv_fw(uv, uvb, u_texture_size, fw) : uv;
 			vec4 tex_c = textureLod(u_image, uv_final, 0.0);
 #else
-			vec2 uv_final = u_use_smooth_uv == 0 ? smooth_uv(uv, u_texture_size) : uv;
+			vec2 uv_final = u_use_smooth_uv == 0 ? smooth_uv(uv, uvb, u_texture_size) : uv;
 			vec4 tex_c = texture(u_image, uv_final);
 #endif
 			float quad_cov = step(0.0, s) * step(s, 1.0) * step(0.0, t) * step(t, 1.0);


### PR DESCRIPTION
Alternative approach to: https://github.com/RandyGaul/cute_framework/pull/574

The crux of it is a [`smooth_uv` function](https://github.com/RandyGaul/cute_framework/compare/master...bullno1:cute_framework:seamless-tiles?expand=1#diff-2681c6e8fa99495385a20147638ed3d1504767ff22237a518b1c0fff08e791cbR652) that is UV-bound-aware so it will not sample the 1 pixel padding ring around a sprite.
This function would also be useful when using pixel-art textures in a 3D environment.

However, for this to work, a few changes have to be made:

* `cute_atlas_cache` will now report the actual *content* UV bound for a sprite. This will exclude the border.
* The tile has to be drawn without being inflated.

But this gives a hard edge to rotated sprites because the transparent border is gone.
To preserve the existing behaviour, `cf_draw_push_sprite_edge` is introduced with the following values:

* `CF_SPRITE_EDGE_SOFT`: Pad the quad and its UV by 1 pixel and texel accordingly. This is the default and the edge is smooth when rotated.
* `CF_SPRITE_EDGE_HARD`: Do no padding. This allows sprites drawn next to each other to be seamless.

For 9 patches, only the outer edges are inflated when drawn with `CF_SPRITE_EDGE_SOFT`.
This can be verified in the 9_slice sample: rotate the 9 slice and the edge still looks smooth.

An added benefit of making `cute_atlas_cache` report the actual content UV is that in the 3D path, there is no longer a need to check whether a texture is bordered: https://github.com/RandyGaul/cute_framework/compare/master...bullno1:cute_framework:seamless-tiles?expand=1#diff-9b0035c01f94f7a18d4eb0e9887e96651f9dc2906247c1de180a737965b8e6d2L2020

Several parts no longer have to account for padding:

* https://github.com/RandyGaul/cute_framework/pull/578/changes#diff-57b30c86d874918121c5ae3ce35035a60cb2db799fb6e23457fefcd13682bdbaL4218
* https://github.com/RandyGaul/cute_framework/pull/578/changes#diff-57b30c86d874918121c5ae3ce35035a60cb2db799fb6e23457fefcd13682bdbaL5466