### PR TITLE
Mipmapped sprite atlas: cf_draw3d_mips + cf_draw3d_anisotropy

### DIFF
--- a/docs/topics/drawing_3d.md
+++ b/docs/topics/drawing_3d.md
@@ -151,6 +151,8 @@ cf_draw3d_pop_texture();
 
 The image lives wherever the texture atlas compiler decides, the sub-rect arrives on the `in_uv_rect` instance lane, and the shader samples `texture(u_image, mix(in_uv_rect.xy, in_uv_rect.zw, in_uv))`. There is no atlas API to hold correctly -- and because drawing meshes together is itself the packing signal, many meshes with many different images still converge toward a single instanced draw. Mesh uvs must lie in [0, 1] (hardware wrap can't tile inside an atlas sub-rect); meshes with tiling uvs bind a standalone `CF_Texture` via `cf_draw3d_set_texture` instead. Mesh uv (0,0) samples the image's top-left, matching 2D sprites.
 
+Sprites viewed at a distance or a steep angle in 3D shimmer with swimming pixels unless the atlas carries mipmaps -- flip them on once at init with `cf_draw3d_mips(4)`, and pair it with `cf_draw3d_anisotropy(4)` so oblique views (floor decals, tilted standees) keep their sharpness. Every atlased sprite benefits, and the atlas compiler handles the rest: pages pack with wide enough gutters that coarse mip levels never blend neighboring images, and every page rebuild regenerates its chain automatically.
+
 ## Draw Lists and Baking
 
 `CF_DrawList` records 3D submissions just like 2D drawing, and adds a bake: at `cf_draw_list_end`, submissions group by their full state *regardless of submission order*, each group's instances write out once, and replay issues one instanced draw per group. The city sample records 10,000 buildings plus ground into one list -- that's **one instanced draw per pass**, at four-digit framerates in a Debug build, with zero per-building CPU cost at replay.

--- a/docs/topics/shipping_3d.md
+++ b/docs/topics/shipping_3d.md
@@ -77,6 +77,13 @@ cf_generate_mipmaps(tex);
 
 Anisotropic filtering (`max_anisotropy` on `CF_TextureParams`) is the difference between smeared and readable ground textures at grazing angles; it's cheap on everything modern.
 
+**Sprites go through the atlas, and the atlas has its own switch.** Everything above covers textures you create yourself; sprites drawn through `cf_draw3d_sprite`, `cf_draw3d_billboard`, or `cf_draw3d_push_texture` sample atlas pages the compiler owns. One call each at init mips and aniso-filters every one of them:
+
+```cpp
+cf_draw3d_mips(4);        // Pages carry a 4-level chain; gutters widen so levels never bleed.
+cf_draw3d_anisotropy(4);  // Oblique sprites (decals, standees) stay sharp.
+```
+
 ## Recipe: Culling Baked Draw Lists
 
 A baked `CF_DrawList` replays as one instanced draw -- which also makes it all-or-nothing: there is no per-instance culling inside a bake. The pattern is to make the *list* the culling granularity:
@@ -104,6 +111,7 @@ When frustum granularity isn't enough -- dense cities, per-instance occlusion --
 - [ ] Windows/D3D12 run tested -- especially anything shadow-cube shaped
 - [ ] Web build tested early if browsers are a target (compute/indirect/MSAA/BC gaps designed out, not ported out)
 - [ ] Textures block-compressed with mips on native; mipped PNG fallback on web; anisotropy on
+- [ ] Sprite atlas mipped if sprites render in 3D (`cf_draw3d_mips` + `cf_draw3d_anisotropy`)
 - [ ] MSAA only on single-target canvases, or post AA
 - [ ] Draw lists chunked for frustum culling
 - [ ] `cf_draw3d_stats` near zero avoidable splits; `cf_push_gpu_label` regions in place for GPU captures

--- a/include/cute_draw3d.h
+++ b/include/cute_draw3d.h
@@ -803,6 +803,53 @@ CF_API void CF_CALL cf_draw3d_sprite(const CF_Sprite* sprite, CF_V3 position);
  */
 CF_API void CF_CALL cf_draw3d_billboard(const CF_Sprite* sprite, CF_V3 position);
 
+/**
+ * @function cf_draw3d_mips
+ * @category draw3d
+ * @brief    Gives the sprite atlas a mipmap chain, killing the pixel swimming of minified sprites.
+ * @param    mip_count  Total mip levels including the base image. 1 (the default) disables mips;
+ *                      4 is the recommended chain. Clamped to [1, 6].
+ * @remarks  Without mips a sprite drawn smaller than its image -- at distance or at a steep angle
+ *           in 3d -- point-samples a texel lattice denser than the screen grid, and every camera
+ *           move re-rolls which texels win: the classic swimming-pixels shimmer. A mip chain gives
+ *           the GPU pre-filtered smaller versions to sample instead. Flip it on once at init
+ *           (`cf_draw3d_mips(4)`) and every atlased sprite benefits, in 3d and in zoomed-out 2d
+ *           alike; pair it with `cf_draw3d_anisotropy` so oblique viewing angles keep their
+ *           sharpness. Sprites at 1:1 scale are untouched -- mip level 0 is the original image.
+ *
+ *           Each level `k` is half the resolution of level `k - 1`, so `mip_count` of 4 covers
+ *           minification cleanly down to 1/8 scale; past the chain's end the last level is reused
+ *           (slight aliasing returns on far-off sprites, which are tiny by then). Deeper chains
+ *           cost atlas space: images pack with a ring of `2^(mip_count - 2)` transparent pixels so
+ *           coarse mip texels never blend neighboring images together -- 4 pixels at the
+ *           recommended 4 levels, doubling per extra level, which is why the count clamps at 6.
+ *
+ *           Calling this rebuilds the atlas from scratch, so call it at init (or at least between
+ *           frames, never mid-draw). Premade atlases (`cf_register_premade_atlas`) registered
+ *           while mips are on get a chain too, but pack no rings -- bake your own gutters between
+ *           sub-images or their mips bleed into one another.
+ * @related  cf_draw3d_anisotropy cf_draw3d_sprite cf_draw3d_billboard cf_draw3d_push_texture cf_draw_set_atlas_dimensions
+ */
+CF_API void CF_CALL cf_draw3d_mips(int mip_count);
+
+/**
+ * @function cf_draw3d_anisotropy
+ * @category draw3d
+ * @brief    Sets anisotropic filtering for sprite atlas textures.
+ * @param    max_anisotropy  Maximum anisotropy ratio. 1 (the default) disables it; 4 is a good
+ *                           choice. Clamped to [1, 16].
+ * @remarks  Mip selection alone is isotropic: it picks the level for the *steepest* screen-space
+ *           uv derivative, so a sprite viewed edge-on in 3d -- a floor decal, a tilted standee --
+ *           blurs along the axis that never needed the coarser level. Anisotropic filtering takes
+ *           several samples along the squashed axis instead, keeping oblique views sharp. It only
+ *           has levels to choose from when `cf_draw3d_mips` is on -- enable both for sprites
+ *           viewed at an angle. Costs proportionally more texture bandwidth; 4 captures most of
+ *           the win. Calling this rebuilds the atlas, so call it at init alongside
+ *           `cf_draw3d_mips`.
+ * @related  cf_draw3d_mips cf_draw3d_sprite cf_draw3d_billboard cf_draw3d_push_texture
+ */
+CF_API void CF_CALL cf_draw3d_anisotropy(int max_anisotropy);
+
 //--------------------------------------------------------------------------------------------------
 // Shapes. The 3d analog of `cute_draw.h`'s shape drawing: debug lines, gizmos, and simple solid
 // primitives with no shader or mesh setup required. Strokes (lines, circles, arcs) render as
@@ -1339,6 +1386,8 @@ CF_INLINE void draw3d_mesh(CF_Mesh mesh) { cf_draw3d_mesh(mesh); }
 CF_INLINE void draw3d_mesh_range(CF_Mesh mesh, int first_element, int element_count) { cf_draw3d_mesh_range(mesh, first_element, element_count); }
 CF_INLINE void draw3d_sprite(const CF_Sprite* sprite, CF_V3 position) { cf_draw3d_sprite(sprite, position); }
 CF_INLINE void draw3d_billboard(const CF_Sprite* sprite, CF_V3 position) { cf_draw3d_billboard(sprite, position); }
+CF_INLINE void draw3d_mips(int mip_count) { cf_draw3d_mips(mip_count); }
+CF_INLINE void draw3d_anisotropy(int max_anisotropy) { cf_draw3d_anisotropy(max_anisotropy); }
 CF_INLINE void draw3d_push_color(CF_Color c) { cf_draw3d_push_color(c); }
 CF_INLINE CF_Color draw3d_pop_color() { return cf_draw3d_pop_color(); }
 CF_INLINE CF_Color draw3d_peek_color() { return cf_draw3d_peek_color(); }

--- a/libraries/cute/cute_atlas_cache.h
+++ b/libraries/cute/cute_atlas_cache.h
@@ -3,7 +3,7 @@
 		Licensing information can be found at the end of the file.
 	------------------------------------------------------------------------------
 
-	cute_atlas_cache.h - v1.14
+	cute_atlas_cache.h - v1.15
 
 	To create implementation (the function definitions)
 		#define ATLAS_CACHE_IMPLEMENTATION
@@ -205,6 +205,16 @@
 		1.14 (08/13/2026) Added ATLAS_CACHE_API to control the linkage of the public API.
 		                  Define it as `static inline` to compile a private copy into one
 		                  translation unit.
+		1.15 (08/16/2026) `atlas_use_border_pixels` is now a ring width in pixels rather
+		                  than a boolean (0 and 1 behave exactly as before). Wider rings
+		                  exist for mipmapped atlas pages: a mip-level-k texel spans 2^k
+		                  base pixels, so sampling level k near an image's edge needs
+		                  2*ring >= 2^k of empty space before the neighboring image --
+		                  ring = 2^(k-1) keeps k levels bleed-free. Added the optional
+		                  `texture_assembled_callback`, invoked each time the cache
+		                  finishes producing a texture's contents (a new atlas page or
+		                  lonely texture, on both the CPU and GPU repack paths) -- the
+		                  natural hook for post-processing such as mipmap generation.
 */
 
 /*
@@ -365,10 +375,11 @@ typedef void (destroy_texture_handle_fn)(ATLAS_CACHE_U64 texture_id, void* udata
 // at all (brand new content) still go through `get_pixels_fn`, and they upload just the region they
 // land in via `upload_subimage_fn`. If any of the three is NULL the CPU path runs, unchanged.
 //
-// Note on the 1-pixel border (`atlas_use_border_pixels`): the CPU path pads each image with a ring of
-// *zero* pixels (not edge replication). Lonely textures and old atlas slots already contain that zero
-// ring baked in, so whole-slot copies reproduce the CPU path's result exactly. The ring is invisible
-// to callers: reported uvs span the image's content, never the ring.
+// Note on the border ring (`atlas_use_border_pixels`, a ring width in pixels): the CPU path pads
+// each image with a ring of *zero* pixels (not edge replication). Lonely textures and old atlas
+// slots already contain that zero ring baked in, so whole-slot copies reproduce the CPU path's
+// result exactly. The ring is invisible to callers: reported uvs span the image's content, never
+// the ring.
 
 // Create an atlas page texture of w by h pixels with no particular contents, *cleared to the same
 // empty color the CPU path uses* (see ATLAS_CACHE_ATLAS_EMPTY_COLOR, transparent-zero by default).
@@ -384,6 +395,14 @@ typedef void (copy_texture_fn)(ATLAS_CACHE_U64 dst, int dst_x, int dst_y, ATLAS_
 // `dst` at pixel offset (x, y).
 typedef void (upload_subimage_fn)(ATLAS_CACHE_U64 dst, int x, int y, int w, int h, const void* pixels, void* udata);
 
+// OPTIONAL. Called each time the cache finishes producing a texture's contents: a lonely texture
+// right after `generate_texture_handle_fn`, a CPU-path atlas page right after its assembled pixels
+// are handed to `generate_texture_handle_fn`, and a GPU-repack-path atlas page after its last
+// region copy/upload. Textures are immutable once assembled (changes always produce a new texture),
+// so this fires exactly once per texture handle -- the natural hook for one-shot post-processing
+// such as mipmap generation.
+typedef void (texture_assembled_fn)(ATLAS_CACHE_U64 texture_id, void* udata);
+
 // Initializes a set of good default paramaters. The users must still set
 // the four callbacks inside of `config`.
 ATLAS_CACHE_API void atlas_cache_set_default_config(atlas_cache_config_t* config);
@@ -393,7 +412,9 @@ struct atlas_cache_config_t
 	int pixel_stride;
 	int atlas_width_in_pixels;
 	int atlas_height_in_pixels;
-	int atlas_use_border_pixels;
+	int atlas_use_border_pixels;        // Width in pixels of the zeroed ring padded around each image (0 = none). More than 1 is
+	                                    // only useful when pages get mipmaps: ring = 2^(k-1) keeps k mip levels free of neighbor
+	                                    // bleed. Reported uvs always span an image's content; the ring is never visible to callers.
 	int ticks_to_decay_texture;         // number of ticks it takes for a texture handle to be destroyed via `destroy_texture_handle_fn`
 	int lonely_buffer_count_till_flush; // Number of unique textures allowed to persist that are not a part of an atlas yet, each one allowed is another draw call.
 	                                    // These are called "lonely textures", since they don't belong to any atlas yet. Set this to 0 if you want all textures to be
@@ -413,6 +434,9 @@ struct atlas_cache_config_t
 	generate_empty_texture_fn* generate_empty_texture_callback;
 	copy_texture_fn* copy_texture_callback;
 	upload_subimage_fn* upload_subimage_callback;
+	// Optional (default NULL) -- fires whenever a texture's contents are complete (see the
+	// typedef comment for the exact timing on each path).
+	texture_assembled_fn* texture_assembled_callback;
 	void* allocator_context;
 };
 
@@ -542,6 +566,7 @@ struct atlas_cache_t
 	generate_empty_texture_fn* generate_empty_texture_callback;
 	copy_texture_fn* copy_texture_callback;
 	upload_subimage_fn* upload_subimage_callback;
+	texture_assembled_fn* texture_assembled_callback;
 	void* mem_ctx;
 	void* udata;
 };
@@ -874,6 +899,7 @@ int atlas_cache_init(atlas_cache_t* cache, atlas_cache_config_t* config, void* u
 	cache->generate_empty_texture_callback = config->generate_empty_texture_callback;
 	cache->copy_texture_callback = config->copy_texture_callback;
 	cache->upload_subimage_callback = config->upload_subimage_callback;
+	cache->texture_assembled_callback = config->texture_assembled_callback;
 	cache->mem_ctx = config->allocator_context;
 	cache->udata = udata;
 
@@ -984,6 +1010,7 @@ void atlas_cache_set_default_config(atlas_cache_config_t* config)
 	config->generate_empty_texture_callback = 0;
 	config->copy_texture_callback = 0;
 	config->upload_subimage_callback = 0;
+	config->texture_assembled_callback = 0;
 	config->allocator_context = 0;
 }
 
@@ -1145,7 +1172,8 @@ static void atlas_cache_internal_sort_entries(atlas_cache_t* cache)
 
 static inline void atlas_cache_internal_get_pixels(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h)
 {
-	int size = cache->atlas_use_border_pixels ? cache->pixel_stride * (w + 2) * (h + 2) : cache->pixel_stride * w * h;
+	int b = cache->atlas_use_border_pixels;
+	int size = b ? cache->pixel_stride * (w + b * 2) * (h + b * 2) : cache->pixel_stride * w * h;
 	if (size > cache->pixel_buffer_size)
 	{
 		ATLAS_CACHE_FREE(cache->pixel_buffer, cache->mem_ctx);
@@ -1158,32 +1186,33 @@ static inline void atlas_cache_internal_get_pixels(atlas_cache_t* cache, ATLAS_C
 	int size_from_user = cache->pixel_stride * w * h;
 	cache->get_pixels_callback(image_id, cache->pixel_buffer, size_from_user, cache->udata);
 
-	if (cache->atlas_use_border_pixels) {
-		// Expand image from top-left corner, offset by (1, 1).
+	if (b) {
+		// Expand the image in-place from packed w by h rows into the padded slot, offset by
+		// (b, b). Walking rows bottom-up keeps every destination past the rows still waiting
+		// to move (the destination of row r starts beyond (r + 1) source rows for any b >= 1).
 		int w0 = w;
 		int h0 = h;
-		w += 2;
-		h += 2;
+		w += b * 2;
+		h += b * 2;
 		char* buffer = (char*)cache->pixel_buffer;
 		int dst_row_stride = w * cache->pixel_stride;
 		int src_row_stride = w0 * cache->pixel_stride;
-		int src_row_offset = cache->pixel_stride;
-		for (int i = 0; i < h - 2; ++i)
+		int src_row_offset = b * cache->pixel_stride;
+		for (int r = h0 - 1; r >= 0; --r)
 		{
-			char* src_row = buffer + (h0 - i - 1) * src_row_stride;
-			char* dst_row = buffer + (h - i - 2) * dst_row_stride + src_row_offset;
+			char* src_row = buffer + r * src_row_stride;
+			char* dst_row = buffer + (r + b) * dst_row_stride + src_row_offset;
 			ATLAS_CACHE_MEMMOVE(dst_row, src_row, src_row_stride);
 		}
 
-		// Clear the border pixels.
-		int pixel_stride = cache->pixel_stride;
-		ATLAS_CACHE_MEMSET(buffer, 0, dst_row_stride);
-		for (int i = 1; i < h - 1; ++i)
+		// Clear the ring (the moves leave stale copies of source rows behind).
+		for (int r = 0; r < b; ++r) ATLAS_CACHE_MEMSET(buffer + r * dst_row_stride, 0, dst_row_stride);
+		for (int r = b; r < h - b; ++r)
 		{
-			ATLAS_CACHE_MEMSET(buffer + i * dst_row_stride, 0, pixel_stride);
-			ATLAS_CACHE_MEMSET(buffer + i * dst_row_stride + src_row_stride + src_row_offset, 0, pixel_stride);
+			ATLAS_CACHE_MEMSET(buffer + r * dst_row_stride, 0, src_row_offset);
+			ATLAS_CACHE_MEMSET(buffer + r * dst_row_stride + src_row_offset + src_row_stride, 0, src_row_offset);
 		}
-		ATLAS_CACHE_MEMSET(buffer + (h - 1) * dst_row_stride, 0, dst_row_stride);
+		for (int r = h - b; r < h; ++r) ATLAS_CACHE_MEMSET(buffer + r * dst_row_stride, 0, dst_row_stride);
 	}
 }
 
@@ -1197,12 +1226,11 @@ static inline int atlas_cache_internal_use_gpu_copies(atlas_cache_t* cache)
 static inline ATLAS_CACHE_U64 atlas_cache_internal_generate_texture_handle(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h)
 {
 	atlas_cache_internal_get_pixels(cache, image_id, w, h);
-	if (cache->atlas_use_border_pixels)
-	{
-		w += 2;
-		h += 2;
-	}
-	return cache->generate_texture_callback(cache->pixel_buffer, w, h, cache->udata);
+	w += cache->atlas_use_border_pixels * 2;
+	h += cache->atlas_use_border_pixels * 2;
+	ATLAS_CACHE_U64 texture_id = cache->generate_texture_callback(cache->pixel_buffer, w, h, cache->udata);
+	if (cache->texture_assembled_callback) cache->texture_assembled_callback(texture_id, cache->udata);
+	return texture_id;
 }
 
 static atlas_cache_internal_lonely_texture_t* atlas_cache_internal_lonelybuffer_push(atlas_cache_t* cache, ATLAS_CACHE_U64 image_id, int w, int h, int make_tex)
@@ -1249,10 +1277,11 @@ static int atlas_cache_internal_lonely_entry(atlas_cache_t* cache, ATLAS_CACHE_U
 			float v0 = 0, v1 = 1;
 			if (cache->atlas_use_border_pixels)
 			{
-				float iw = 1.0f / (float)(tex->w + 2);
-				float ih = 1.0f / (float)(tex->h + 2);
-				u0 = iw; u1 = 1.0f - iw;
-				v0 = ih; v1 = 1.0f - ih;
+				int b = cache->atlas_use_border_pixels;
+				float bu = (float)b / (float)(tex->w + b * 2);
+				float bv = (float)b / (float)(tex->h + b * 2);
+				u0 = bu; u1 = 1.0f - bu;
+				v0 = bv; v1 = 1.0f - bv;
 			}
 
 			if (ATLAS_CACHE_LONELY_FLIP_Y_AXIS_FOR_UV)
@@ -1314,8 +1343,8 @@ static int atlas_cache_internal_push_entry(atlas_cache_t* cache, atlas_cache_int
 			ATLAS_CACHE_ASSERT(tex);
 			tex->timestamp = 0;
 			// Slot dims are padded by the border ring; report the image's own dims.
-			entry.w = cache->atlas_use_border_pixels ? tex->w - 2 : tex->w;
-			entry.h = cache->atlas_use_border_pixels ? tex->h - 2 : tex->h;
+			entry.w = tex->w - cache->atlas_use_border_pixels * 2;
+			entry.h = tex->h - cache->atlas_use_border_pixels * 2;
 
 			// Entries are pushed with *local* uvs, remapped here onto the image's content
 			// rect within the atlas (the border ring is excluded -- see the uv math in
@@ -1457,13 +1486,8 @@ int atlas_cache_flush(atlas_cache_t* cache)
 				{
 					atlas_cache_internal_lonely_texture_t* tex = (atlas_cache_internal_lonely_texture_t*)atlas_cache_map_find(&cache->lonely_buffer, image_id);
 					ATLAS_CACHE_ASSERT(tex);
-					w = tex->w;
-					h = tex->h;
-					if (cache->atlas_use_border_pixels)
-					{
-						w += 2;
-						h += 2;
-					}
+					w = tex->w + cache->atlas_use_border_pixels * 2;
+					h = tex->h + cache->atlas_use_border_pixels * 2;
 				}
 			} 
 			else
@@ -1630,7 +1654,7 @@ static void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_at
 		const atlas_cache_internal_lonely_texture_t* img = imgs + i;
 		atlas_cache_internal_integer_image_t* image = images + i;
 		image->fit = 0;
-		image->size = cache->atlas_use_border_pixels ? atlas_cache_v2(img->w + 2, img->h + 2) : atlas_cache_v2(img->w, img->h);
+		image->size = atlas_cache_v2(img->w + cache->atlas_use_border_pixels * 2, img->h + cache->atlas_use_border_pixels * 2);
 		image->img_index = i;
 	}
 
@@ -1759,6 +1783,8 @@ static void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_at
 				}
 			}
 		}
+
+		if (cache->texture_assembled_callback) cache->texture_assembled_callback(atlas_out->texture_id, cache->udata);
 	}
 	else
 	{
@@ -1793,6 +1819,7 @@ static void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_at
 		}
 
 		atlas_out->texture_id = cache->generate_texture_callback(atlas_pixels, atlas_width, atlas_height, cache->udata);
+		if (cache->texture_assembled_callback) cache->texture_assembled_callback(atlas_out->texture_id, cache->udata);
 	}
 
 	iw = 1.0f / (float)(atlas_width);
@@ -1812,7 +1839,7 @@ static void atlas_cache_make_atlas(atlas_cache_t* cache, atlas_cache_internal_at
 			// internal detail (it keeps a bilinear tap at an image's edge from reaching into
 			// the neighboring image), so callers never have to know it is there. The slot
 			// coords below stay padded -- the GPU copy path moves whole slots, ring included.
-			int border = cache->atlas_use_border_pixels ? 1 : 0;
+			int border = cache->atlas_use_border_pixels;
 			float min_x = (float)(min.x + border) * iw;
 			float min_y = (float)(min.y + border) * ih;
 			float max_x = (float)(max.x - border) * iw;
@@ -1939,13 +1966,8 @@ static void atlas_cache_internal_flush_atlas(atlas_cache_t* cache, atlas_cache_i
 		atlas_cache_internal_texture_t* atlas_texture = textures + i;
 		if (atlas_texture->timestamp < ticks_to_decay_texture)
 		{
-			int w = atlas_texture->w;
-			int h = atlas_texture->h;
-			if (cache->atlas_use_border_pixels)
-			{
-				w -= 2;
-				h -= 2;
-			}
+			int w = atlas_texture->w - cache->atlas_use_border_pixels * 2;
+			int h = atlas_texture->h - cache->atlas_use_border_pixels * 2;
 			atlas_cache_internal_lonely_texture_t* lonely_texture = atlas_cache_internal_lonelybuffer_push(cache, atlas_texture->image_id, w, h, 0);
 			lonely_texture->timestamp = atlas_texture->timestamp;
 			if (use_gpu_copies)

--- a/samples/billboards.c
+++ b/samples/billboards.c
@@ -221,6 +221,11 @@ int main(int argc, char* argv[])
 
 	cf_canvas_set_clear_color(cf_app_get_canvas(), cf_make_color_rgb_f(0.05f, 0.06f, 0.12f));
 
+	// Sprites at 3d distances swim without mips; one call gives every atlased sprite a mip
+	// chain, and anisotropy keeps the cylindrical trees sharp when viewed edge-on.
+	cf_draw3d_mips(4);
+	cf_draw3d_anisotropy(4);
+
 	CF_Mesh quad = s_make_quad();
 	CF_Mesh ground = s_make_floor();
 	CF_Shader cutout_shd = cf_make_shader_from_source(s_bill_vs, s_cutout_fs);

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -6,6 +6,7 @@
 */
 
 #include <cute_draw.h>
+#include <cute_draw3d.h> // cf_draw3d_mips / cf_draw3d_anisotropy live here (the atlas cache is this file's).
 #include <cute_alloc.h>
 #include <cute_array.h>
 #include <cute_file_system.h>
@@ -104,12 +105,35 @@ static CF_INLINE uint32_t s_pack_half2(float a, float b)
 static CF_INLINE uint32_t s_pack_half_rg(CF_Color c) { return s_pack_half2(c.r, c.g); }
 static CF_INLINE uint32_t s_pack_half_ba(CF_Color c) { return s_pack_half2(c.b, c.a); }
 
+// Texture params shared by atlas pages, lonely textures, and premade atlas textures. When mips
+// are enabled (cf_draw3d_mips) they carry a partial mip chain plus COLOR_TARGET usage, since
+// cf_generate_mipmaps fills the chain with GPU blits.
+static CF_TextureParams s_atlas_texture_params(int w, int h)
+{
+	CF_TextureParams params = cf_texture_defaults(w, h);
+	params.filter = CF_FILTER_LINEAR;
+	params.max_anisotropy = (float)s_draw->atlas_anisotropy;
+	if (s_draw->atlas_mip_count > 1) {
+		params.allocate_mipmaps = true;
+		params.mip_count = s_draw->atlas_mip_count;
+		params.usage |= CF_TEXTURE_USAGE_COLOR_TARGET_BIT;
+	}
+	return params;
+}
+
+// Ring width that keeps the whole mip chain free of neighbor bleed: a mip-level-k texel spans
+// 2^k base pixels, and adjacent images sit 2*ring apart, so ring = 2^(mip_count - 2) covers the
+// chain's last level. Always at least the 1px ring bilinear filtering needs at mip 0.
+static int s_atlas_border_pixels()
+{
+	int mips = s_draw->atlas_mip_count;
+	return mips > 1 ? cf_max(1, 1 << (mips - 2)) : 1;
+}
+
 ATLAS_CACHE_U64 cf_generate_texture_handle(void* pixels, int w, int h, void* udata)
 {
 	CF_UNUSED(udata);
-	CF_TextureParams params = cf_texture_defaults(w, h);
-	params.filter = CF_FILTER_LINEAR;
-	CF_Texture texture = cf_make_texture(params);
+	CF_Texture texture = cf_make_texture(s_atlas_texture_params(w, h));
 	cf_texture_update(texture, pixels, w * h * sizeof(CF_Pixel));
 	return texture.id;
 }
@@ -129,9 +153,7 @@ void cf_destroy_texture_handle(ATLAS_CACHE_U64 texture_id, void* udata)
 ATLAS_CACHE_U64 cf_generate_empty_texture_handle(int w, int h, void* udata)
 {
 	CF_UNUSED(udata);
-	CF_TextureParams params = cf_texture_defaults(w, h);
-	params.filter = CF_FILTER_LINEAR;
-	CF_Texture texture = cf_make_texture(params);
+	CF_Texture texture = cf_make_texture(s_atlas_texture_params(w, h));
 	// Clear to transparent-zero, matching the CPU path's memset of its atlas buffer: regions
 	// no image lands in are still sampled through the atlas border ring and must not contain
 	// garbage. One zeroed whole-texture upload -- still no per-image producer callbacks.
@@ -157,6 +179,17 @@ void cf_upload_texture_handle_subimage(ATLAS_CACHE_U64 dst, int x, int y, int w,
 	CF_Texture dst_tex;
 	dst_tex.id = dst;
 	cf_texture_update_region(dst_tex, x, y, w, h, (void*)pixels);
+}
+
+// Fires whenever the atlas cache finishes assembling a texture's contents (a new page or lonely
+// texture, on either the CPU or GPU repack path). Assembly writes mip 0; derive the rest.
+void cf_texture_handle_assembled(ATLAS_CACHE_U64 texture_id, void* udata)
+{
+	CF_UNUSED(udata);
+	if (s_draw->atlas_mip_count <= 1) return;
+	CF_Texture tex;
+	tex.id = texture_id;
+	cf_generate_mipmaps(tex);
 }
 
 atlas_cache_t* cf_get_draw_atlas_cache()
@@ -933,7 +966,7 @@ static void s_init_atlas_cache(int w, int h)
 {
 	atlas_cache_config_t config;
 	atlas_cache_set_default_config(&config);
-	config.atlas_use_border_pixels = 1;
+	config.atlas_use_border_pixels = s_atlas_border_pixels();
 	config.ticks_to_decay_texture = 100000;
 	config.batch_callback = s_draw_report;
 	config.get_pixels_callback = cf_get_pixels;
@@ -944,6 +977,7 @@ static void s_init_atlas_cache(int w, int h)
 	config.generate_empty_texture_callback = cf_generate_empty_texture_handle;
 	config.copy_texture_callback = cf_copy_texture_handle_region;
 	config.upload_subimage_callback = cf_upload_texture_handle_subimage;
+	config.texture_assembled_callback = cf_texture_handle_assembled;
 	config.allocator_context = NULL;
 	config.lonely_buffer_count_till_flush = 0;
 	config.atlas_height_in_pixels = h;
@@ -954,6 +988,16 @@ static void s_init_atlas_cache(int w, int h)
 		CF_FREE(s_draw);
 		s_draw = NULL;
 		CF_ASSERT(false);
+		return;
+	}
+
+	// Premade atlas registrations live inside the cache, so a rebuild (atlas dims or mip
+	// settings changing) just dropped them -- re-register from the flattened records.
+	int offset = 0;
+	for (int i = 0; i < s_draw->premade_atlas_records.count(); ++i) {
+		CF_Draw::PremadeRecord r = s_draw->premade_atlas_records[i];
+		atlas_cache_register_premade_atlas(&s_draw->atlas_cache, r.texture_id, r.w, r.h, r.entry_count, s_draw->premade_atlas_entries.data() + offset);
+		offset += r.entry_count;
 	}
 }
 
@@ -4722,6 +4766,30 @@ void cf_draw_set_atlas_dimensions(int width_in_pixels, int height_in_pixels)
 	s_draw->texel_dims.y = 1.0f / s_draw->atlas_dims.y;
 }
 
+void cf_draw3d_mips(int mip_count)
+{
+	if (mip_count < 1) mip_count = 1;
+	// Each extra level doubles the border ring (see s_atlas_border_pixels); past six levels
+	// (16px rings) the padding cost outweighs any anti-aliasing left to gain.
+	if (mip_count > 6) mip_count = 6;
+	if (mip_count == s_draw->atlas_mip_count) return;
+	s_draw->atlas_mip_count = mip_count;
+	// Existing pages carry neither the mip chain nor the wider ring; rebuild from scratch.
+	atlas_cache_term(&s_draw->atlas_cache);
+	s_init_atlas_cache((int)s_draw->atlas_dims.x, (int)s_draw->atlas_dims.y);
+}
+
+void cf_draw3d_anisotropy(int max_anisotropy)
+{
+	if (max_anisotropy < 1) max_anisotropy = 1;
+	if (max_anisotropy > 16) max_anisotropy = 16;
+	if (max_anisotropy == s_draw->atlas_anisotropy) return;
+	s_draw->atlas_anisotropy = max_anisotropy;
+	// Samplers are baked into each page texture at creation; rebuild to apply.
+	atlas_cache_term(&s_draw->atlas_cache);
+	s_init_atlas_cache((int)s_draw->atlas_dims.x, (int)s_draw->atlas_dims.y);
+}
+
 CF_Shader cf_make_draw_shader(const char* path)
 {
 	// Also make an attached blit shader to apply when drawing canvases.
@@ -5527,10 +5595,11 @@ CF_Texture cf_register_premade_atlas(const char* png_path, int sub_image_count, 
 	CF_Image img = { 0 };
 	image_load_png(png_path, &img);
 	CF_ASSERT(img.pix);
-	CF_TextureParams params = cf_texture_defaults(img.w, img.h);
-	params.filter = CF_FILTER_LINEAR;
-	CF_Texture texture = cf_make_texture(params);
+	// Premades share the pages' mip settings (see cf_draw3d_mips), though they carry no border
+	// rings -- a premade atlas drawn with mips should bake its own gutters between sub-images.
+	CF_Texture texture = cf_make_texture(s_atlas_texture_params(img.w, img.h));
 	cf_texture_update(texture, img.pix, img.w * img.h * sizeof(CF_Pixel));
+	if (s_draw->atlas_mip_count > 1) cf_generate_mipmaps(texture);
 	Array<atlas_cache_premade_entry_t> premades;
 	for (int i = 0; i < sub_image_count; ++i) {
 		atlas_cache_premade_entry_t s = { 0 };
@@ -5544,7 +5613,11 @@ CF_Texture cf_register_premade_atlas(const char* png_path, int sub_image_count, 
 		s.maxy = sub_images[i].maxy;
 		premades.add(s);
 		s_draw->premade_sub_image_id_to_sub_image.add(s.image_id, sub_images[i]);
+		s_draw->premade_atlas_entries.add(s);
 	}
+	// Record the registration so atlas cache rebuilds can replay it (see s_init_atlas_cache).
+	CF_Draw::PremadeRecord record = { texture.id, img.w, img.h, sub_image_count };
+	s_draw->premade_atlas_records.add(record);
 	atlas_cache_register_premade_atlas(&s_draw->atlas_cache, texture.id, img.w, img.h, sub_image_count, premades.data());
 	image_free(&img);
 	return texture;

--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -159,6 +159,7 @@ struct CF_GL_Texture
 	GLenum upload_fmt   = GL_NONE;
 	GLenum upload_type  = GL_NONE;
 	bool has_mips = false;
+	int mip_count = 0; // 0 = full chain; otherwise an explicit partial chain length (CF_TextureParams::mip_count).
 	GLint min_filter = GL_LINEAR;
 	GLint mag_filter = GL_LINEAR;
 	GLint wrap_u = GL_REPEAT;
@@ -901,8 +902,11 @@ static inline void s_apply_sampler_state_to_handle(const CF_GL_Texture* t, GLuin
 	glTexParameteri(t->target, GL_TEXTURE_MIN_FILTER, t->min_filter);
 	glTexParameteri(t->target, GL_TEXTURE_MAG_FILTER, t->mag_filter);
 	// Without this, a standalone sampler using a mipmap min-filter would make
-	// a mipless texture incomplete (sampling black).
+	// a mipless texture incomplete (sampling black). Partial chains clamp for the same
+	// completeness reason, and so glGenerateMipmap stops at the last allocated level
+	// (it derives levels base+1 through q, where q honors GL_TEXTURE_MAX_LEVEL).
 	if (!t->has_mips) glTexParameteri(t->target, GL_TEXTURE_MAX_LEVEL, 0);
+	else if (t->mip_count > 0) glTexParameteri(t->target, GL_TEXTURE_MAX_LEVEL, t->mip_count - 1);
 	glTexParameteri(t->target, GL_TEXTURE_WRAP_S, t->wrap_u);
 	glTexParameteri(t->target, GL_TEXTURE_WRAP_T, t->wrap_v);
 	if (t->target == GL_TEXTURE_CUBE_MAP || t->target == GL_TEXTURE_3D) {
@@ -921,6 +925,7 @@ static inline void s_apply_sampler_params(CF_GL_Texture* t, const CF_TexturePara
 	CF_GL_PixelFormatInfo* info = s_find_pixel_format_info(p.pixel_format);
 	uint32_t caps = info ? info->caps : 0;
 	t->has_mips = p.allocate_mipmaps || p.mip_count > 1;
+	t->mip_count = t->has_mips ? p.mip_count : 0;
 	GLenum min_filter = s_wrap(p.mip_filter, t->has_mips);
 	GLenum mag_filter = s_wrap(p.filter);
 	if (!(caps & CF_GL_FMT_CAP_LINEAR)) {
@@ -952,11 +957,12 @@ static inline bool s_texture_allocate_storage(CF_GL_Texture* t, CF_GL_Slot* slot
 		glTexImage2D(GL_TEXTURE_2D, 0, t->internal_fmt, t->w, t->h, 0, t->upload_fmt, t->upload_type, NULL);
 	}
 	if (t->has_mips) {
-		// Allocate the whole chain up front: explicit-mip uploads (cf_texture_update_mip /
+		// Allocate the chain up front: explicit-mip uploads (cf_texture_update_mip /
 		// _layer_mip) glTexSubImage into levels that must already have storage, and
-		// glGenerateMipmap isn't guaranteed to have run first.
+		// glGenerateMipmap isn't guaranteed to have run first. An explicit mip_count
+		// stops the chain early (GL_TEXTURE_MAX_LEVEL clamps sampling to match).
 		int lw = t->w, lh = t->h, ld = t->layers;
-		for (int level = 1; lw > 1 || lh > 1; ++level) {
+		for (int level = 1; (lw > 1 || lh > 1) && !(t->mip_count > 0 && level >= t->mip_count); ++level) {
 			lw = cf_max(lw >> 1, 1);
 			lh = cf_max(lh >> 1, 1);
 			if (t->target == GL_TEXTURE_CUBE_MAP) {

--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -611,6 +611,9 @@ static inline CF_Texture s_make_texture(CF_TextureParams params, CF_SampleCount 
 	if (!s_is_depth(params.pixel_format) || params.compare_enable) {
 		SDL_GPUSamplerCreateInfo sampler_info = SDL_GPUSamplerCreateInfoDefaults();
 		sampler_info.mip_lod_bias = params.mip_lod_bias;
+		// Without the enable flag max_anisotropy is ignored wholesale (it also overrides
+		// mipmap_mode filtering per the SDL_GPU/Vulkan rules, so only enable when asked).
+		sampler_info.enable_anisotropy = params.max_anisotropy > 1;
 		sampler_info.max_anisotropy = params.max_anisotropy;
 		sampler_info.min_filter = s_wrap(params.filter);
 		sampler_info.mag_filter = s_wrap(params.filter);

--- a/src/internal/cute_draw_internal.h
+++ b/src/internal/cute_draw_internal.h
@@ -325,6 +325,16 @@ struct CF_Draw
 	// until the next frame packs them.
 	bool defragged_this_frame = false;
 	atlas_cache_t atlas_cache;
+	// Sprite-atlas mip settings (cf_draw3d_mips / cf_draw3d_anisotropy). A count of 1 means
+	// no mip chain. Changing either rebuilds the atlas cache.
+	int atlas_mip_count = 1;
+	int atlas_anisotropy = 1;
+	// Premade atlas registrations (cf_register_premade_atlas), flattened so atlas cache
+	// rebuilds (atlas dims or mip settings changing) can re-register them: one record per
+	// premade atlas, its entries concatenated in registration order.
+	struct PremadeRecord { uint64_t texture_id; int w, h, entry_count; };
+	Cute::Array<PremadeRecord> premade_atlas_records;
+	Cute::Array<atlas_cache_premade_entry_t> premade_atlas_entries;
 	CF_Material material;
 	CF_Arena uniform_arena;
 	Cute::Array<float> alpha_discards = { 1.0f };

--- a/test/test_atlas_uvs.cpp
+++ b/test/test_atlas_uvs.cpp
@@ -21,8 +21,9 @@
 #include <math.h>
 #include <string.h>
 
-// The atlas cache pads each image with a 1px border ring so a bilinear tap at an image's
-// edge cannot reach into the neighboring image. That ring is an implementation detail:
+// The atlas cache pads each image with a border ring (1px by default, wider when pages carry
+// mipmaps) so a filter tap at an image's edge cannot reach into the neighboring image. That
+// ring is an implementation detail:
 // reported uvs must span the image's *content*, and local uvs pushed on an entry are
 // fractions of the image. Renderers rely on this to map one texel per sprite pixel without
 // inflating their geometry, and 9-slice relies on it to cut patches where it says it does.
@@ -40,14 +41,31 @@ struct UvHarness
 	atlas_cache_entry_t reported[8];
 	int reported_count;
 	uint64_t next_texture_id;
+	// Captured from the most recent generate_texture callback (padded slot or whole page).
+	int generated_w, generated_h;
+	unsigned char generated_pixels[64 * 64 * 4];
+	// texture_assembled_callback log.
+	uint64_t assembled[8];
+	int assembled_count;
 };
 
 static UvHarness* s_uv;
 
 static ATLAS_CACHE_U64 s_uv_generate_texture(void* pixels, int w, int h, void* udata)
 {
-	CF_UNUSED(pixels); CF_UNUSED(w); CF_UNUSED(h); CF_UNUSED(udata);
+	CF_UNUSED(udata);
+	s_uv->generated_w = w;
+	s_uv->generated_h = h;
+	int size = w * h * 4;
+	if (size <= (int)sizeof(s_uv->generated_pixels)) CF_MEMCPY(s_uv->generated_pixels, pixels, size);
 	return s_uv->next_texture_id++;
+}
+
+static void s_uv_texture_assembled(ATLAS_CACHE_U64 texture_id, void* udata)
+{
+	CF_UNUSED(udata);
+	if (s_uv->assembled_count < 8) s_uv->assembled[s_uv->assembled_count] = texture_id;
+	s_uv->assembled_count++;
 }
 
 static void s_uv_destroy_texture(ATLAS_CACHE_U64 texture_id, void* udata)
@@ -69,7 +87,7 @@ static void s_uv_report(atlas_cache_entry_t* entries, int count, int texture_w, 
 	}
 }
 
-static void s_uv_init(UvHarness* h)
+static void s_uv_init_border(UvHarness* h, int border)
 {
 	CF_MEMSET(h, 0, sizeof(*h));
 	h->next_texture_id = 1;
@@ -77,7 +95,7 @@ static void s_uv_init(UvHarness* h)
 
 	atlas_cache_config_t config;
 	atlas_cache_set_default_config(&config);
-	config.atlas_use_border_pixels = 1;
+	config.atlas_use_border_pixels = border;
 	config.atlas_width_in_pixels = UV_ATLAS_W;
 	config.atlas_height_in_pixels = UV_ATLAS_H;
 	config.lonely_buffer_count_till_flush = 0;
@@ -86,7 +104,13 @@ static void s_uv_init(UvHarness* h)
 	config.get_pixels_callback = s_uv_get_pixels;
 	config.generate_texture_callback = s_uv_generate_texture;
 	config.delete_texture_callback = s_uv_destroy_texture;
+	config.texture_assembled_callback = s_uv_texture_assembled;
 	atlas_cache_init(&h->cache, &config, NULL);
+}
+
+static void s_uv_init(UvHarness* h)
+{
+	s_uv_init_border(h, 1);
 }
 
 // Push one entry carrying a local uv sub-rect, flush, and hand back what was reported.
@@ -185,8 +209,107 @@ TEST_CASE(test_atlas_uvs_partial_rect_matches_residency)
 	return true;
 }
 
+// A ring wider than one pixel is what mipmapped pages need (see cf_draw3d_mips): a mip-level-k
+// texel spans 2^k base pixels, so adjacent images must sit 2*ring >= 2^k apart or coarse levels
+// blend them together. The uv contract must hold at any width.
+TEST_CASE(test_atlas_uvs_wide_border_ring)
+{
+	const int B = 4; // cf_draw3d_mips(4)'s ring.
+	UvHarness h;
+	s_uv_init_border(&h, B);
+
+	// Lonely: one padded slot, content inset by B texels per edge.
+	float bu = (float)B / (float)(UV_IMG_W + B * 2);
+	float bv = (float)B / (float)(UV_IMG_H + B * 2);
+	atlas_cache_entry_t lonely = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	REQUIRE(s_uv_near(lonely.minx, bu));
+	REQUIRE(s_uv_near(lonely.maxx, 1.0f - bu));
+	REQUIRE(s_uv_near(lonely.miny, 1.0f - bv));
+	REQUIRE(s_uv_near(lonely.maxy, bv));
+	REQUIRE(lonely.w == UV_IMG_W);
+	REQUIRE(lonely.h == UV_IMG_H);
+
+	// The lonely texture's pixels: content offset by (B, B) into the padded slot, ring zeroed.
+	// This exercises the in-place expansion in atlas_cache_internal_get_pixels at width B.
+	REQUIRE(s_uv->generated_w == UV_IMG_W + B * 2);
+	REQUIRE(s_uv->generated_h == UV_IMG_H + B * 2);
+	for (int y = 0; y < s_uv->generated_h; ++y) {
+		for (int x = 0; x < s_uv->generated_w; ++x) {
+			bool in_content = x >= B && x < B + UV_IMG_W && y >= B && y < B + UV_IMG_H;
+			unsigned char expected = in_content ? 0xFF : 0x00;
+			for (int c = 0; c < 4; ++c) {
+				REQUIRE(s_uv->generated_pixels[(y * s_uv->generated_w + x) * 4 + c] == expected);
+			}
+		}
+	}
+
+	// Packed into a page: content rect still exactly the image, on texel edges, ring-first.
+	atlas_cache_defrag(&h.cache);
+	atlas_cache_entry_t a = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	float x0 = a.minx * UV_ATLAS_W;
+	float y0 = a.maxy * UV_ATLAS_H;
+	REQUIRE(s_uv_near((a.maxx - a.minx) * UV_ATLAS_W, (float)UV_IMG_W));
+	REQUIRE(s_uv_near((a.miny - a.maxy) * UV_ATLAS_H, (float)UV_IMG_H));
+	REQUIRE(s_uv_near(x0, floorf(x0)));
+	REQUIRE(s_uv_near(y0, floorf(y0)));
+	REQUIRE(x0 >= (float)B);
+	REQUIRE(y0 >= (float)B);
+
+	// Two images on one page keep 2*B pixels of ring between their content rects, the
+	// spacing that keeps every allotted mip level from blending them together. Fresh cache
+	// so both are lonely when defrag packs a page (a defrag above already packed image 100).
+	atlas_cache_term(&h.cache);
+	s_uv_init_border(&h, B);
+	s_uv_submit(&h, 100, 0, 0, 1, 1);
+	s_uv_submit(&h, 200, 0, 0, 1, 1);
+	atlas_cache_defrag(&h.cache);
+	atlas_cache_entry_t e0 = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	atlas_cache_entry_t e1 = s_uv_submit(&h, 200, 0, 0, 1, 1);
+	REQUIRE(e0.texture_id == e1.texture_id);
+	float ax0 = e0.minx * UV_ATLAS_W, ax1 = e0.maxx * UV_ATLAS_W;
+	float bx0 = e1.minx * UV_ATLAS_W, bx1 = e1.maxx * UV_ATLAS_W;
+	float ay0 = e0.maxy * UV_ATLAS_H, ay1 = e0.miny * UV_ATLAS_H;
+	float by0 = e1.maxy * UV_ATLAS_H, by1 = e1.miny * UV_ATLAS_H;
+	bool separated_x = bx0 >= ax1 + 2.0f * B - 1e-3f || ax0 >= bx1 + 2.0f * B - 1e-3f;
+	bool separated_y = by0 >= ay1 + 2.0f * B - 1e-3f || ay0 >= by1 + 2.0f * B - 1e-3f;
+	REQUIRE(separated_x || separated_y);
+
+	atlas_cache_term(&h.cache);
+	s_uv = NULL;
+	return true;
+}
+
+// texture_assembled_callback: exactly once per produced texture, after its contents exist --
+// the hook cute_draw.cpp uses to generate atlas mipmaps.
+TEST_CASE(test_atlas_uvs_texture_assembled_callback)
+{
+	UvHarness h;
+	s_uv_init(&h);
+
+	// First flush generates one lonely texture -> one assembled notification for it.
+	atlas_cache_entry_t lonely = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	REQUIRE(h.assembled_count == 1);
+	REQUIRE(h.assembled[0] == lonely.texture_id);
+
+	// Re-drawing an already-resident image assembles nothing new.
+	s_uv_submit(&h, 100, 0, 0, 1, 1);
+	REQUIRE(h.assembled_count == 1);
+
+	// Defrag packs the image into a page (a new texture): one more notification, for the page.
+	atlas_cache_defrag(&h.cache);
+	atlas_cache_entry_t atlased = s_uv_submit(&h, 100, 0, 0, 1, 1);
+	REQUIRE(h.assembled_count == 2);
+	REQUIRE(h.assembled[1] == atlased.texture_id);
+
+	atlas_cache_term(&h.cache);
+	s_uv = NULL;
+	return true;
+}
+
 TEST_SUITE(test_atlas_uvs)
 {
 	RUN_TEST_CASE(test_atlas_uvs_exclude_border_ring);
 	RUN_TEST_CASE(test_atlas_uvs_partial_rect_matches_residency);
+	RUN_TEST_CASE(test_atlas_uvs_wide_border_ring);
+	RUN_TEST_CASE(test_atlas_uvs_texture_assembled_callback);
 }

--- a/test/test_draw3d.cpp
+++ b/test/test_draw3d.cpp
@@ -2088,6 +2088,110 @@ TEST_CASE(test_draw3d_list_ambient_uniforms)
 	return true;
 }
 
+// Fullscreen probe sampling one uv at one explicit lod -- proof the atlas textures carry a
+// real, filled-in mip chain rather than just claiming one.
+static const char* s_mip_probe_vs =
+"layout (location = 0) in vec2 in_pos;\n"
+"void main() { gl_Position = vec4(in_pos, 0, 1); }\n";
+
+static const char* s_mip_probe_fs =
+"layout (location = 0) out vec4 result;\n"
+"layout (set = 2, binding = 0) uniform sampler2D u_tex;\n"
+"layout (set = 3, binding = 0) uniform uniform_block {\n"
+"    vec4 u_probe; // uv.xy, lod, unused\n"
+"};\n"
+"void main() { result = textureLod(u_tex, u_probe.xy, u_probe.z); }\n";
+
+static CF_Mesh s_make_fullscreen_probe_quad()
+{
+	CF_V2 verts[6] = { { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, -1 }, { 1, 1 }, { -1, 1 } };
+	CF_VertexAttribute attr = { };
+	attr.name = "in_pos";
+	attr.format = CF_VERTEX_FORMAT_FLOAT2;
+	attr.offset = 0;
+	CF_Mesh mesh = cf_make_mesh(sizeof(verts), &attr, 1, sizeof(CF_V2));
+	cf_mesh_update_vertex_data(mesh, verts, 6);
+	return mesh;
+}
+
+// Fetches the sprite's image fresh each call: a CF_TemporaryImage is only valid until the next
+// present, and the frame boundary between probes is exactly when the atlas cache repacks the
+// image from its lonely texture into a page (destroying the lonely texture). uv_frac is a
+// fraction of the image's content rect.
+static CF_Pixel s_mip_probe(CF_Canvas canvas, CF_Mesh quad, CF_Shader shader, CF_Material material, const CF_Sprite* sprite, CF_V2 uv_frac, float lod, CF_Pixel* px)
+{
+	cf_app_update(NULL);
+	CF_TemporaryImage img = cf_fetch_image(sprite);
+	if (!img.tex.id) return cf_make_pixel_rgba(0, 0, 0, 0);
+	CF_V2 uv = cf_v2(
+		img.u.x + (img.v.x - img.u.x) * uv_frac.x,
+		img.u.y + (img.v.y - img.u.y) * uv_frac.y);
+	cf_material_set_texture_fs(material, "u_tex", img.tex);
+	CF_V4 probe = cf_v4(uv.x, uv.y, lod, 0);
+	cf_material_set_uniform_fs(material, "u_probe", &probe, CF_UNIFORM_TYPE_FLOAT4, 1);
+	cf_apply_canvas(canvas, true);
+	cf_apply_mesh(quad);
+	cf_apply_shader(shader, material);
+	cf_draw_elements();
+	cf_app_draw_onto_screen(false);
+	test_readback(canvas, px);
+	return px[(H / 2) * W + (W / 2)];
+}
+
+// cf_draw3d_mips end to end: with mips on, atlas textures carry a generated chain -- coarse
+// levels return pre-filtered pixels instead of clamping to the base image.
+TEST_CASE(test_draw3d_atlas_mips)
+{
+	if (!test_make_app(W, H)) return true; // Headless CI: no display/GPU.
+
+	cf_draw3d_mips(4);
+	cf_draw3d_anisotropy(4);
+
+	// A 16x16 per-pixel red/blue checkerboard: every base texel is pure, and every texel of
+	// every coarser mip averages to half red half blue.
+	CF_Pixel checker[16 * 16];
+	for (int y = 0; y < 16; ++y) {
+		for (int x = 0; x < 16; ++x) {
+			checker[y * 16 + x] = ((x + y) & 1) ? cf_make_pixel_rgba(255, 0, 0, 255) : cf_make_pixel_rgba(0, 0, 255, 255);
+		}
+	}
+	CF_Sprite sprite = cf_make_easy_sprite_from_pixels(checker, 16, 16);
+
+	CF_Mesh quad = s_make_fullscreen_probe_quad();
+	CF_Shader shader = cf_make_shader_from_source(s_mip_probe_vs, s_mip_probe_fs);
+	REQUIRE(shader.id);
+	CF_Material material = cf_make_material();
+	CF_Canvas canvas = cf_make_canvas(cf_canvas_defaults(W, H));
+	CF_Pixel* px = (CF_Pixel*)cf_alloc(W * H * (int)sizeof(CF_Pixel));
+
+	// Level 0 at a texel center: the base image, one pure texel.
+	CF_Pixel base = s_mip_probe(canvas, quad, shader, material, &sprite, cf_v2(0.5f / 16.0f, 0.5f / 16.0f), 0, px);
+	bool pure_red = base.colors.r > 200 && base.colors.b < 60;
+	bool pure_blue = base.colors.b > 200 && base.colors.r < 60;
+	REQUIRE(pure_red || pure_blue);
+
+	// Level 2 at the image's center: each texel there averages a 4x4 checker block. Without a
+	// generated chain the fetch clamps to the pure-texel base image and this fails. By this
+	// frame the image has usually graduated from its lonely texture into an atlas page, so
+	// this also proves pages (not just lonely textures) carry a generated chain.
+	CF_Pixel coarse = s_mip_probe(canvas, quad, shader, material, &sprite, cf_v2(0.5f, 0.5f), 2, px);
+	REQUIRE(coarse.colors.r > 90 && coarse.colors.r < 165);
+	REQUIRE(coarse.colors.b > 90 && coarse.colors.b < 165);
+	REQUIRE(coarse.colors.g < 30);
+
+	// Restore the shared app's defaults for the suites that follow.
+	cf_easy_sprite_unload(&sprite);
+	cf_draw3d_mips(1);
+	cf_draw3d_anisotropy(1);
+	cf_free(px);
+	cf_destroy_canvas(canvas);
+	cf_destroy_material(material);
+	cf_destroy_shader(shader);
+	cf_destroy_mesh(quad);
+	test_destroy_app();
+	return true;
+}
+
 TEST_SUITE(test_draw3d)
 {
 	RUN_TEST_CASE(test_draw3d_transforms_and_coalescing);
@@ -2116,5 +2220,6 @@ TEST_SUITE(test_draw3d)
 	RUN_TEST_CASE(test_draw3d_depth_writer_order);
 	RUN_TEST_CASE(test_draw3d_translucent_sort);
 	RUN_TEST_CASE(test_draw3d_mesh_range);
+	RUN_TEST_CASE(test_draw3d_atlas_mips);
 	RUN_TEST_CASE(test_draw3d_bench);
 }


### PR DESCRIPTION
Fixes the swimming-pixels shimmer of sprites drawn at 3d distances and angles (and zoomed-out 2d). Previously no sprite path could get mips at all: atlas pages were created mipless and nothing regenerated chains after assembly.

## Flip it on

```c
cf_draw3d_mips(4);        // pages carry a 4-level chain
cf_draw3d_anisotropy(4);  // oblique views (decals, standees) keep their sharpness
```

Every atlased sprite benefits -- `cf_draw3d_sprite`, `cf_draw3d_billboard`, `cf_draw3d_push_texture`, and 2d drawing when zoomed out. Sprites at 1:1 are untouched (level 0 is the original image).

## Native support in the atlas compiler (cute_atlas_cache v1.15)

- `atlas_use_border_pixels` is now a **ring width in pixels** rather than a boolean (0/1 behave exactly as before). A mip-level-k texel spans 2^k base pixels, so adjacent images need `2*ring >= 2^k` of space before coarse levels blend them together -- ring `2^(mip_count-2)` keeps the whole chain bleed-free (4px at the recommended 4 levels).
- New optional `texture_assembled_callback`: fires exactly once whenever the cache finishes producing a texture's contents -- lonely textures, CPU-path pages, and GPU-repack pages (after the last region copy). The draw layer hooks it to run `cf_generate_mipmaps`, so every page rebuild re-derives its chain automatically.
- v1.13's content-rect uv semantics mean the wider ring needs **zero consumer changes** -- the draw layers, 9-slice, text, and `CF_SPRITE_EDGE_SOFT` are all ring-width agnostic already.

## Draw layer

Pages, lonely textures, and premade atlas textures share mip-aware params (partial chain + `COLOR_TARGET` usage for blit-based generation). Toggling rebuilds the cache through the same term/re-init path as `cf_draw_set_atlas_dimensions`, and premade registrations are now recorded and re-registered across rebuilds -- fixing a latent bug where `cf_draw_set_atlas_dimensions` silently dropped premades.

## Backend fixes this depends on

- **SDL_GPU**: per-texture samplers copied `max_anisotropy` but never set `enable_anisotropy` -- texture-level aniso was silently inert.
- **GLES**: an explicit partial `mip_count` was ignored -- the full chain was allocated and generated with no `GL_TEXTURE_MAX_LEVEL` clamp, which would have sampled bleed-y deep mips on atlas pages.

## Tests

- `test_atlas_uvs`: wide-ring content-uv math (lonely + atlased), the in-place B-wide pixel padding verified texel-by-texel, 2B content spacing on shared pages, and assembled-callback timing (once per texture, none on re-draws).
- `test_draw3d_atlas_mips`: end-to-end GPU probe -- an atlased checkerboard sampled at explicit lods proves level 0 is pure and level 2 is the pre-filtered average, including after the frame boundary where the image repacks from its lonely texture into a page (i.e. the GPU-repack path regenerates too).
- 342/342 on SDL_GPU and GLES.

The billboards sample flips both on, and drawing_3d.md / shipping_3d.md document the calls.