### PR TITLE
Rename dpi_scale to display_scale

### DIFF
--- a/docs/topics/hidpi.md
+++ b/docs/topics/hidpi.md
@@ -10,12 +10,12 @@ Under the hood CF sizes its default canvas in *physical* pixels: `logical_size *
 
 Because of this you generally don't need to think about DPI at all. Draw in points; CF renders at native resolution.
 
-## `pixel_scale` vs. `dpi_scale`
+## `pixel_scale` vs. `display_scale`
 
 Two functions report display density, and they're easy to confuse:
 
 - [`cf_app_get_pixel_scale`](../app/function/cf_app_get_pixel_scale.md) — the number of physical pixels per logical point, e.g. `2.0f` on a 2x Retina display. This is the ratio CF actually renders at, and the one to multiply a logical size by to get physical pixels.
-- [`cf_app_get_dpi_scale`](../app/function/cf_app_get_dpi_scale.md) — the OS's *suggested* UI content scale. It is informational only and does **not** describe the rendering ratio. Most games can ignore it.
+- [`cf_app_get_display_scale`](../app/function/cf_app_get_display_scale.md) — the OS's *suggested* UI content scale. It is informational only and does **not** describe the rendering ratio. Most games can ignore it.
 
 When you need to convert between points and physical pixels — for example, sizing an offscreen canvas to match the swapchain — use `cf_app_get_pixel_scale`.
 

--- a/include/cute_app.h
+++ b/include/cute_app.h
@@ -369,7 +369,7 @@ CF_API int CF_CALL cf_app_draw_onto_screen(bool clear);
  * @brief    Gets the size of the window in logical points (called "points" on Retina/HiDPI displays; use `cf_app_get_pixel_scale` to convert to physical pixels).
  * @param    w          The width of the window in logical points.
  * @param    h          The height of the window in logical points.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_display_scale cf_app_get_pixel_scale
  */
 CF_API void CF_CALL cf_app_get_size(int* w, int* h);
 
@@ -377,7 +377,7 @@ CF_API void CF_CALL cf_app_get_size(int* w, int* h);
  * @function cf_app_get_width
  * @category app
  * @brief    Returns the size of the window width in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_display_scale cf_app_get_pixel_scale
  */
 CF_API int CF_CALL cf_app_get_width(void);
 
@@ -385,7 +385,7 @@ CF_API int CF_CALL cf_app_get_width(void);
  * @function cf_app_get_height
  * @category app
  * @brief    Returns the size of the window height in logical points (use `cf_app_get_pixel_scale` to convert to physical pixels).
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_get_pixel_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_display_scale cf_app_get_pixel_scale
  */
 CF_API int CF_CALL cf_app_get_height(void);
 
@@ -393,40 +393,40 @@ CF_API int CF_CALL cf_app_get_height(void);
  * @function cf_app_show_window
  * @category app
  * @brief    Brings the app out of a minimized/hidden state.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_display_scale
  */
 CF_API void CF_CALL cf_app_show_window(void);
 
 /**
- * @function cf_app_get_dpi_scale
+ * @function cf_app_get_display_scale
  * @category app
- * @brief    Returns the scaling factor for the device's intended DPI setting.
+ * @brief    Returns the OS's display scale for the window's current display.
  * @remarks  On some devices (e.g. Apple Retina or iOS) pixels are clustered in 4x4 packs and abstracted as a single pixel
  *           called a "point". The intent is for applications to work in points, and scale their UI elements by a factor of 2x
  *           to aid in readability. These devices have very small pixels. Most of the time you should ignore dpi and let the OS
  *           handle this. CF enables DPI settings by default, but, you can see if this function returns 2.0f to let you know if
  *           pixels are clustered for you under the hood.
- * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
+ * @related  cf_app_set_size cf_app_get_position cf_app_set_position cf_app_get_width cf_app_get_height cf_app_get_display_scale cf_app_display_scale_was_changed
  */
-CF_API float CF_CALL cf_app_get_dpi_scale(void);
+CF_API float CF_CALL cf_app_get_display_scale(void);
 
 /**
- * @function cf_app_dpi_scale_was_changed
+ * @function cf_app_display_scale_was_changed
  * @category app
- * @brief    Returns true if the DPI scaling changed, such as moving from one screen to another.
- * @related  cf_app_get_dpi_scale cf_app_dpi_scale_was_changed
+ * @brief    Returns true if the display scale changed, such as moving from one screen to another.
+ * @related  cf_app_get_display_scale cf_app_display_scale_was_changed
  */
-CF_API bool CF_CALL cf_app_dpi_scale_was_changed(void);
+CF_API bool CF_CALL cf_app_display_scale_was_changed(void);
 
 /**
  * @function cf_app_get_pixel_scale
  * @category app
  * @brief    Returns the number of physical pixels per logical point for the app's window.
  * @remarks  This is the ratio CF actually renders at internally -- e.g. 2.0f on a 2x Retina display. Unlike
- *           `cf_app_get_dpi_scale` (the OS's suggested UI content scale, which is informational only), this value
+ *           `cf_app_get_display_scale` (the OS's suggested UI content scale, which is informational only), this value
  *           directly reflects the backbuffer/canvas pixel density and is what you'd multiply a logical size by to
  *           get physical pixels. Returns 1.0f if `CF_APP_OPTIONS_NO_HIGH_DPI_BIT` was passed to `cf_make_app`.
- * @related  cf_app_get_dpi_scale cf_app_get_size cf_app_get_canvas_width cf_app_get_canvas_height
+ * @related  cf_app_get_display_scale cf_app_get_size cf_app_get_canvas_width cf_app_get_canvas_height
  */
 CF_API float CF_CALL cf_app_get_pixel_scale(void);
 
@@ -970,8 +970,8 @@ CF_INLINE void app_set_position(int x, int y) { return cf_app_set_position(x, y)
 CF_INLINE void app_show_window() { return cf_app_show_window(); }
 CF_INLINE int app_get_width() { return cf_app_get_width(); }
 CF_INLINE int app_get_height() { return cf_app_get_height(); }
-CF_INLINE float app_get_dpi_scale() { return cf_app_get_dpi_scale(); }
-CF_INLINE bool app_dpi_scale_was_changed() { return cf_app_dpi_scale_was_changed(); }
+CF_INLINE float app_get_display_scale() { return cf_app_get_display_scale(); }
+CF_INLINE bool app_display_scale_was_changed() { return cf_app_display_scale_was_changed(); }
 CF_INLINE float app_get_pixel_scale() { return cf_app_get_pixel_scale(); }
 CF_INLINE void app_center_window() { cf_app_center_window(); }
 CF_INLINE bool app_was_resized() { return cf_app_was_resized(); }

--- a/src/cute_app.cpp
+++ b/src/cute_app.cpp
@@ -340,8 +340,7 @@ CF_Result cf_make_app(const char* window_title, CF_DisplayID display_id, int x, 
 	app->h = h;
 	if (window) {
 		SDL_GetWindowPosition(app->window, &app->x, &app->y);
-		app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
-		app->dpi_scale_prev = app->dpi_scale;
+		app->display_scale = SDL_GetWindowDisplayScale(app->window);
 		app->pixel_scale = window ? SDL_GetWindowPixelDensity(app->window) : 1.0f;
 		if (app->pixel_scale <= 0.0f) app->pixel_scale = 1.0f;
 		if (options & CF_APP_OPTIONS_NO_HIGH_DPI_BIT) app->pixel_scale = 1.0f;
@@ -636,14 +635,14 @@ void cf_app_show_window()
 	SDL_ShowWindow(app->window);
 }
 
-float cf_app_get_dpi_scale()
+float cf_app_get_display_scale()
 {
-	return app->dpi_scale;
+	return app->display_scale;
 }
 
-bool cf_app_dpi_scale_was_changed()
+bool cf_app_display_scale_was_changed()
 {
-	return app->dpi_scale_was_changed;
+	return app->display_scale_was_changed;
 }
 
 float cf_app_get_pixel_scale()

--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -476,7 +476,7 @@ void cf_begin_frame_input()
 	app->window_state.moved = false;
 	app->window_state.restored = false;
 	app->window_state.resized = false;
-	app->dpi_scale_was_changed = false;
+	app->display_scale_was_changed = false;
 	cf_joypad_update();
 
 	// Update key durations to simulate "press and hold" style for `key_repeating`.
@@ -576,8 +576,8 @@ void cf_pump_input_msgs()
 			break;
 
 		case SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED:
-			app->dpi_scale = SDL_GetWindowDisplayScale(app->window);
-			app->dpi_scale_was_changed = true;
+			app->display_scale = SDL_GetWindowDisplayScale(app->window);
+			app->display_scale_was_changed = true;
 			s_refresh_pixel_scale();
 			break;
 

--- a/src/internal/cute_app_internal.h
+++ b/src/internal/cute_app_internal.h
@@ -102,9 +102,8 @@ struct CF_App
 	Cute::CF_Path shader_directory;
 	Cute::Map<CF_ShaderFileInfo> shader_file_infos;
 	bool gfx_enabled = false;
-	float dpi_scale = 1.0f;
-	float dpi_scale_prev = 1.0f;
-	bool dpi_scale_was_changed = false;
+	float display_scale = 1.0f;
+	bool display_scale_was_changed = false;
 	float pixel_scale = 1.0f;   // Physical pixels per logical point (from SDL_GetWindowPixelDensity). Drives default-canvas sizing, AA, and glyph rasterization.
 	CF_Filter canvas_blit_filter = CF_FILTER_NEAREST; // Filter used when blitting the app canvas onto the screen, if their sizes differ (e.g. after cf_app_set_canvas_size). Defaults to nearest for a crisp/blocky pixel-art look.
 	bool sync_window = false;


### PR DESCRIPTION
`cf_app_get_dpi_scale` / `cf_app_dpi_scale_was_changed` read like the OS's vague "suggested UI content scale" concept. The value is actually `SDL_GetWindowDisplayScale` -- the OS's points-to-pixels conversion for the window's display -- so this renames it to say that.

**Breaking change:** hard rename, no compat alias.

Also drops `CF_App::dpi_scale_prev`, which was written once at init and never read.

First slice of the #579 split -- pure rename, zero behavior change.