### PR TITLE
samples/hidpi: add live mouse coordinate readout

### DIFF
--- a/samples/hidpi.c
+++ b/samples/hidpi.c
@@ -20,6 +20,9 @@
 	  - A live readout of `cf_app_get_pixel_scale()` alongside the physical
 	    canvas size, so the current display's HiDPI scale factor is visible
 	    at a glance.
+	  - A live readout of the mouse position in both raw screen coordinates
+	    and `cf_screen_to_world`'s translation, so the HiDPI mouse mapping
+	    can be eyeballed against known shape positions.
 
 	No interactivity beyond closing the window; no external assets needed.
 */
@@ -90,6 +93,23 @@ int main(int argc, char* argv[])
 		);
 		cf_push_font_size(12);
 		draw_text_centered(pixel_scale_buf, cf_v2(0, 300));
+		cf_pop_font_size();
+
+		// -- Live mouse-coordinate readout -- screen space is raw, top-left-origin,
+		// y-down input; world space is what cf_screen_to_world hands back, matching
+		// the space cf_draw_text etc. draw into. If HiDPI translation is correct, the
+		// world coordinate should track the cursor 1:1 over the canvas regardless of
+		// pixel_scale.
+		char mouse_buf[128];
+		CF_V2 mouse_screen = cf_v2(cf_mouse_x(), cf_mouse_y());
+		CF_V2 mouse_world = cf_screen_to_world(mouse_screen);
+		snprintf(
+			mouse_buf, sizeof(mouse_buf),
+			"mouse: screen (%.0f, %.0f) -> world (%.0f, %.0f)",
+			mouse_screen.x, mouse_screen.y, mouse_world.x, mouse_world.y
+		);
+		cf_push_font_size(12);
+		draw_text_centered(mouse_buf, cf_v2(0, 300 - 18));
 		cf_pop_font_size();
 
 		cf_draw_pop_color();


### PR DESCRIPTION
Adds a `mouse: screen (x, y) -> world (x, y)` readout line to the hidpi sample, next to the existing `pixel_scale` line -- so HiDPI mouse-coordinate mapping can be eyeballed against known shape positions at any pixel scale, not just glyph/shape crispness.

Second slice of the #579 split -- pure sample addition, no engine changes.

**Note**: The scale of the rendered content is incorrect, which will be fixed in the upcoming PRs.

<img width="1280" height="832" alt="hidpi_after" src="https://github.com/user-attachments/assets/ac71510f-662a-4073-97ce-013421c0ba8d" />
