### PR TITLE
Netcode: harden cute_net, wall the CF networking API, add arithmetic coder + snapshot compression

### DIFF
--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -14,7 +14,12 @@
 #ifndef CF_EMSCRIPTEN
 
 #include "cute_result.h"
-#include <cute/cute_net.h>
+
+// CF owns its networking API surface outright: the underlying cute_net library is an
+// implementation detail hidden inside cute_networking.cpp, never exposed here. The types below are
+// CF-defined with layouts that match cute_net's, and the source file static-asserts that match so
+// the two never drift. Keeping cute_net behind this wall is what lets CF add conveniences (stats,
+// broadcast) and, later, a packet compression / delta-encoding layer without leaking a second API.
 
 //--------------------------------------------------------------------------------------------------
 // C API
@@ -29,7 +34,7 @@ extern "C" {
  * @brief    An opaque pointer representing a single networked client.
  * @related  CF_Client CF_Server cf_make_client
  */
-typedef struct cn_client_t CF_Client;
+typedef struct CF_Client CF_Client;
 // @end
 
 /**
@@ -38,7 +43,7 @@ typedef struct cn_client_t CF_Client;
  * @brief    An opaque pointer representing a single networked server.
  * @related  CF_Client CF_Server cf_make_client
  */
-typedef struct cn_server_t CF_Server;
+typedef struct CF_Server CF_Server;
 // @end
 
 /**
@@ -47,7 +52,7 @@ typedef struct cn_server_t CF_Server;
  * @brief    A chunk of bytes representing a cryptographically secure key.
  * @related  CF_CryptoKey cf_crypto_generate_key cf_generate_connect_token
  */
-typedef struct cn_crypto_key_t CF_CryptoKey;
+typedef struct CF_CryptoKey { uint8_t bytes[32]; } CF_CryptoKey;
 // @end
 
 /**
@@ -56,7 +61,7 @@ typedef struct cn_crypto_key_t CF_CryptoKey;
  * @brief    One-half of a cryptographically secure keypair. This key can be freely shared to the public.
  * @related  CF_CryptoKey CF_CryptoSignPublic CF_CryptoSignSecret cf_crypto_sign_keygen CF_ServerConfig
  */
-typedef struct cn_crypto_sign_public_t CF_CryptoSignPublic;
+typedef struct CF_CryptoSignPublic { uint8_t bytes[32]; } CF_CryptoSignPublic;
 // @end
 
 /**
@@ -65,22 +70,11 @@ typedef struct cn_crypto_sign_public_t CF_CryptoSignPublic;
  * @brief    One-half of a cryptographically secure keypair. This key must be kept secret and hidden with your servers.
  * @related  CF_CryptoKey CF_CryptoSignPublic CF_CryptoSignSecret cf_crypto_sign_keygen CF_ServerConfig
  */
-typedef struct cn_crypto_sign_secret_t CF_CryptoSignSecret;
+typedef struct CF_CryptoSignSecret { uint8_t bytes[64]; } CF_CryptoSignSecret;
 // @end
 
 //--------------------------------------------------------------------------------------------------
 // ENDPOINT
-
-/**
- * @struct   CF_Address
- * @category net
- * @brief    A network address.
- * @related  CF_Address CF_AddressType cf_address_init
- */
-typedef struct cn_endpoint_t CF_Address;
-// @end
-
-typedef enum cn_address_type_t CF_AddressType;
 
 /**
  * @enum     CF_AddressType
@@ -97,12 +91,56 @@ typedef enum cn_address_type_t CF_AddressType;
 	CF_ENUM(ADDRESS_TYPE_IPV6, 2)          \
 	/* @end */
 
-enum
+typedef enum CF_AddressType
 {
 	#define CF_ENUM(K, V) CF_##K = V,
 	CF_ADDRESS_TYPE_DEFS
 	#undef CF_ENUM
-};
+} CF_AddressType;
+
+/**
+ * @function cf_address_type_to_string
+ * @category net
+ * @brief    Convert an enum `CF_AddressType` to a C string.
+ * @related  CF_Address CF_AddressType
+ */
+CF_INLINE const char* cf_address_type_to_string(CF_AddressType type)
+{
+	switch (type) {
+	#define CF_ENUM(K, V) case CF_##K: return CF_STRINGIZE(CF_##K);
+	CF_ADDRESS_TYPE_DEFS
+	#undef CF_ENUM
+	default: return NULL;
+	}
+}
+
+/**
+ * @struct   CF_Address
+ * @category net
+ * @brief    A network address.
+ * @remarks  Layout matches the underlying transport's endpoint type; treat it as a value you obtain
+ *           from `cf_address_init` or a `CF_ServerEvent`, compare with `cf_address_equals`, and print
+ *           with `cf_address_to_string`.
+ * @related  CF_Address CF_AddressType cf_address_init cf_address_to_string cf_address_equals
+ */
+typedef struct CF_Address
+{
+	/* @member The address family. See `CF_AddressType`. */
+	CF_AddressType type;
+
+	/* @member The port number. */
+	uint16_t port;
+
+	union
+	{
+		/* @member The four octets of an IPv4 address. */
+		uint8_t ipv4[4];
+
+		/* @member The eight groups of an IPv6 address. */
+		uint16_t ipv6[8];
+	} u;
+} CF_Address;
+// @end
 
 /**
  * @function cf_address_init
@@ -111,7 +149,7 @@ enum
  * @return   Returns 0 on success, -1 on failure.
  * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
  */
-CF_API int CF_CALL cf_address_init(CF_Address* endpoint, const char* address_and_port_string);
+CF_API int CF_CALL cf_address_init(CF_Address* address, const char* address_and_port_string);
 
 /**
  * @function cf_address_to_string
@@ -119,15 +157,16 @@ CF_API int CF_CALL cf_address_init(CF_Address* endpoint, const char* address_and
  * @brief    Converts a `CF_Address` to a C string.
  * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
  */
-CF_API void CF_CALL cf_address_to_string(CF_Address endpoint, char* buffer, int buffer_size);
+CF_API void CF_CALL cf_address_to_string(CF_Address address, char* buffer, int buffer_size);
 
 /**
  * @function cf_address_equals
  * @category net
- * @brief    Tests two endpoints for equality.
+ * @brief    Tests two addresses for equality.
+ * @return   Returns true if the two addresses are equal.
  * @related  CF_Address cf_address_init cf_address_to_string cf_address_equals
  */
-CF_API int CF_CALL cf_address_equals(CF_Address a, CF_Address b);
+CF_API bool CF_CALL cf_address_equals(CF_Address a, CF_Address b);
 
 //--------------------------------------------------------------------------------------------------
 // CONNECT TOKEN
@@ -195,14 +234,14 @@ CF_API void CF_CALL cf_crypto_sign_keygen(CF_CryptoSignPublic* public_key, CF_Cr
  * @param    token_ptr_out         Pointer to your buffer, should be `CF_CONNECT_TOKEN_SIZE` bytes large.
  * @return   Returns any errors as `CF_Result`.
  * @remarks  You can use this function whenever a validated client wants to join your game servers.
- *           
+ *
  *           It's recommended to setup a web service specifically for allowing players to authenticate
  *           themselves (login). Once authenticated, the webservice can call this function and hand
  *           the connect token to the client. The client can then read the public section of the
  *           connect token and see the `address_list` of servers to try and connect to. The client then
  *           sends the connect token to one of these servers to start the connection handshake. If the
  *           handshake completes successfully, the client will connect to the server.
- *           
+ *
  *           The connect token is protected by an AEAD primitive (https://en.wikipedia.org/wiki/Authenticated_encryption),
  *           which means the token cannot be modified or forged as long as the `shared_secret_key` is
  *           not leaked. In the event your secret key is accidentally leaked, you can always roll a
@@ -241,7 +280,7 @@ CF_API void CF_CALL cf_destroy_client(CF_Client* client);
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  The client will make an attempt to connect to all servers listed in the connect token, one after
  *           another. If no server can be connected to the client's state will be set to an error state. Call
- *           `cf_client_state_get` to get the client's state. Once `cf_client_connect` is called then successive calls to
+ *           `cf_client_state` to get the client's state. Once `cf_client_connect` is called then successive calls to
  *           `cf_client_update` is expected, where `cf_client_update` will perform the connection handshake and make
  *           connection attempts to your servers.
  * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect cf_client_update
@@ -298,12 +337,12 @@ CF_API void CF_CALL cf_client_free_packet(CF_Client* client, void* packet);
  *                              may arrive out of order, or not at all.
  * @return   Returns any errors as a `CF_Result`.
  * @remarks  If the packet size is too large (over 1k bytes) it will be split up and sent in smaller chunks.
- *           
+ *
  *           `send_reliably` as true means the packet will be sent reliably an in-order relative to other
  *           reliable packets. Under packet loss the packet will continually be sent until an acknowledgement
  *           from the server is received. False means to send a typical UDP packet, with no special mechanisms
  *           regarding packet loss.
- *           
+ *
  *           Reliable packets are significantly more expensive than unreliable packets, so try to send any data
  *           that can be lost due to packet loss as an unreliable packet. Of course, some packets are required
  *           to be sent, and so reliable is appropriate. As an optimization some kinds of data, such as frequent
@@ -317,7 +356,7 @@ CF_API CF_Result CF_CALL cf_client_send(CF_Client* client, const void* packet, i
  * @category net
  * @brief    The various states of a `CF_Client`.
  * @remarks  Anything less than or equal to 0 is an error.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @related  CF_ClientState cf_client_state_to_string cf_client_state
  */
 #define CF_CLIENT_STATE_DEFS \
 	/* @entry The connect token has expired. */ \
@@ -354,7 +393,7 @@ typedef enum CF_ClientState
  * @category net
  * @brief    Convert an enum `CF_ClientState` to a c-style string.
  * @param    state        The state to convert to a string.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @related  CF_ClientState cf_client_state_to_string cf_client_state
  */
 CF_INLINE const char* cf_client_state_to_string(CF_ClientState state)
 {
@@ -367,12 +406,53 @@ CF_INLINE const char* cf_client_state_to_string(CF_ClientState state)
 }
 
 /**
+ * @function cf_client_state
+ * @category net
+ * @brief    Returns the `CF_ClientState` of a `CF_Client`.
+ * @related  CF_ClientState cf_client_state_to_string cf_client_state
+ */
+CF_API CF_ClientState CF_CALL cf_client_state(const CF_Client* client);
+
+/**
  * @function cf_client_state_get
  * @category net
  * @brief    Returns the `CF_ClientState` of a `CF_Client`.
- * @related  CF_ClientState cf_client_state_to_string cf_client_state_get
+ * @deprecated Use cf_client_state instead.
+ * @related  CF_ClientState cf_client_state_to_string cf_client_state
  */
-CF_API CF_ClientState CF_CALL cf_client_state_get(const CF_Client* client);
+CF_INLINE CF_ClientState cf_client_state_get(const CF_Client* client) { return cf_client_state(client); }
+
+/**
+ * @function cf_client_rtt
+ * @category net
+ * @brief    Returns the client's estimated round-trip time to the server, in milliseconds.
+ * @related  CF_Client cf_client_rtt cf_client_packet_loss cf_client_incoming_kbps cf_client_outgoing_kbps
+ */
+CF_API float CF_CALL cf_client_rtt(CF_Client* client);
+
+/**
+ * @function cf_client_packet_loss
+ * @category net
+ * @brief    Returns the client's estimated packet loss, from 0 (none) to 1 (all).
+ * @related  CF_Client cf_client_rtt cf_client_packet_loss cf_client_incoming_kbps cf_client_outgoing_kbps
+ */
+CF_API float CF_CALL cf_client_packet_loss(CF_Client* client);
+
+/**
+ * @function cf_client_incoming_kbps
+ * @category net
+ * @brief    Returns the client's estimated incoming bandwidth in kilobits per second.
+ * @related  CF_Client cf_client_rtt cf_client_packet_loss cf_client_incoming_kbps cf_client_outgoing_kbps
+ */
+CF_API float CF_CALL cf_client_incoming_kbps(CF_Client* client);
+
+/**
+ * @function cf_client_outgoing_kbps
+ * @category net
+ * @brief    Returns the client's estimated outgoing bandwidth in kilobits per second.
+ * @related  CF_Client cf_client_rtt cf_client_packet_loss cf_client_incoming_kbps cf_client_outgoing_kbps
+ */
+CF_API float CF_CALL cf_client_outgoing_kbps(CF_Client* client);
 
 /**
  * @function cf_client_enable_network_simulator
@@ -390,7 +470,14 @@ CF_API void CF_CALL cf_client_enable_network_simulator(CF_Client* client, double
 //--------------------------------------------------------------------------------------------------
 // SERVER
 
-// Modify this value as seen fit.
+/**
+ * @function CF_SERVER_MAX_CLIENTS
+ * @category net
+ * @brief    The maximum number of clients a single `CF_Server` supports.
+ * @remarks  This is fixed at compile time. Raising it requires rebuilding CF (it also sizes the
+ *           underlying transport's per-client state), so it is not a value you can tune per-server.
+ * @related  CF_Server cf_make_server
+ */
 #define CF_SERVER_MAX_CLIENTS 32
 
 /**
@@ -404,12 +491,6 @@ typedef struct CF_ServerConfig
 {
 	/* @member A unique number to identify your game, can be whatever value you like. This must be the same number as in `client_make`. */
 	uint64_t application_id;
-
-	/* @member Not implemented yet. */
-	int max_incoming_bytes_per_second;
-
-	/* @member Not implemented yet. */
-	int max_outgoing_bytes_per_second;
 
 	/* @member The number of seconds before consider a connection as timed out when not receiving any packets on the connection. */
 	int connection_timeout;
@@ -429,14 +510,13 @@ typedef struct CF_ServerConfig
  * @function cf_server_config_defaults
  * @category net
  * @brief    Returns a good set of default parameters for `cf_make_server`.
+ * @remarks  The keypair is zeroed; fill in `public_key`/`secret_key` (see `cf_crypto_sign_keygen`)
+ *           and `application_id` before calling `cf_make_server`.
  * @related  CF_ServerConfig cf_server_config_defaults cf_make_server
  */
 CF_INLINE CF_ServerConfig CF_CALL cf_server_config_defaults(void)
 {
-	CF_ServerConfig config;
-	config.application_id = 0;
-	config.max_incoming_bytes_per_second = 0;
-	config.max_outgoing_bytes_per_second = 0;
+	CF_ServerConfig config = { 0 };
 	config.connection_timeout = 10;
 	config.resend_rate = 0.1f;
 	return config;
@@ -464,10 +544,11 @@ CF_API void CF_CALL cf_destroy_server(CF_Server* server);
  * @category net
  * @brief    Starts up the server connection, ready to receive new client connections.
  * @param    address_and_port  The address and port combo to start the server upon.
+ * @return   Returns any errors as a `CF_Result`.
  * @remarks  Please note that not all users will be able to access an ipv6 server address, so it might be good to also provide a way to connect through ipv4.
  * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
  */
-CF_API CF_Result cf_server_start(CF_Server* server, const char* address_and_port);
+CF_API CF_Result CF_CALL cf_server_start(CF_Server* server, const char* address_and_port);
 
 /**
  * @function cf_server_stop
@@ -475,7 +556,19 @@ CF_API CF_Result cf_server_start(CF_Server* server, const char* address_and_port
  * @brief    Stops the server.
  * @related  CF_ServerConfig cf_server_config_defaults cf_make_server cf_destroy_server cf_server_start cf_server_update
  */
-CF_API void cf_server_stop(CF_Server* server);
+CF_API void CF_CALL cf_server_stop(CF_Server* server);
+
+/**
+ * @function cf_server_set_public_ip
+ * @category net
+ * @brief    Overrides the public address clients are told to connect to (for NAT / port-forwarding).
+ * @param    server            The server.
+ * @param    address_and_port  The publicly reachable address and port clients should use.
+ * @remarks  Only needed for local development behind a router, or any setup where the address the
+ *           server binds differs from the address clients must reach. Leave unset in production.
+ * @related  CF_Server cf_server_start
+ */
+CF_API void CF_CALL cf_server_set_public_ip(CF_Server* server, const char* address_and_port);
 
 /**
  * @enum     CF_ServerEventType
@@ -503,7 +596,7 @@ typedef enum CF_ServerEventType
  * @function cf_server_event_type_to_string
  * @category net
  * @brief    Convert an enum `CF_ServerEventType` to a c-style string.
- * @param    state        The state to convert to a string.
+ * @param    type        The type to convert to a string.
  * @related  CF_ServerEventType cf_server_event_type_to_string CF_ServerEvent cf_server_pop_event
  */
 CF_INLINE const char* cf_server_event_type_to_string(CF_ServerEventType type)
@@ -607,9 +700,23 @@ CF_API void CF_CALL cf_server_disconnect_client(CF_Server* server, int client_in
  * @param    client_index   An index representing a particular client, from `CF_ServerEvent`.
  * @param    send_reliably  If `true` the packet will be sent reliably and in order. If false the packet will be sent just once, and may
  *                          arrive out of order or not at all.
- * @related  cf_server_update CF_ServerEvent cf_server_pop_event cf_server_send
+ * @return   Returns any errors as a `CF_Result` (e.g. the send queue being full).
+ * @related  cf_server_update cf_server_send cf_server_send_to_all CF_ServerEvent cf_server_pop_event
  */
-CF_API void CF_CALL cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably);
+CF_API CF_Result CF_CALL cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably);
+
+/**
+ * @function cf_server_send_to_all
+ * @category net
+ * @brief    Sends a packet to every connected client.
+ * @param    server         The server.
+ * @param    packet         Data to send.
+ * @param    size           Size of `data` in bytes.
+ * @param    send_reliably  If `true` the packet is sent reliably and in order to each client.
+ * @remarks  A convenience over looping every client index and checking `cf_server_is_client_connected`.
+ * @related  cf_server_send cf_server_send_to_all cf_server_is_client_connected
+ */
+CF_API void CF_CALL cf_server_send_to_all(CF_Server* server, const void* packet, int size, bool send_reliably);
 
 /**
  * @function cf_server_is_client_connected
@@ -620,9 +727,41 @@ CF_API void CF_CALL cf_server_send(CF_Server* server, const void* packet, int si
 CF_API bool CF_CALL cf_server_is_client_connected(CF_Server* server, int client_index);
 
 /**
+ * @function cf_server_rtt
+ * @category net
+ * @brief    Returns the estimated round-trip time to a client, in milliseconds.
+ * @related  CF_Server cf_server_rtt cf_server_packet_loss cf_server_incoming_kbps cf_server_outgoing_kbps
+ */
+CF_API float CF_CALL cf_server_rtt(CF_Server* server, int client_index);
+
+/**
+ * @function cf_server_packet_loss
+ * @category net
+ * @brief    Returns the estimated packet loss to a client, from 0 (none) to 1 (all).
+ * @related  CF_Server cf_server_rtt cf_server_packet_loss cf_server_incoming_kbps cf_server_outgoing_kbps
+ */
+CF_API float CF_CALL cf_server_packet_loss(CF_Server* server, int client_index);
+
+/**
+ * @function cf_server_incoming_kbps
+ * @category net
+ * @brief    Returns the estimated incoming bandwidth from a client in kilobits per second.
+ * @related  CF_Server cf_server_rtt cf_server_packet_loss cf_server_incoming_kbps cf_server_outgoing_kbps
+ */
+CF_API float CF_CALL cf_server_incoming_kbps(CF_Server* server, int client_index);
+
+/**
+ * @function cf_server_outgoing_kbps
+ * @category net
+ * @brief    Returns the estimated outgoing bandwidth to a client in kilobits per second.
+ * @related  CF_Server cf_server_rtt cf_server_packet_loss cf_server_incoming_kbps cf_server_outgoing_kbps
+ */
+CF_API float CF_CALL cf_server_outgoing_kbps(CF_Server* server, int client_index);
+
+/**
  * @function cf_server_enable_network_simulator
  * @category net
- * @brief    Turns on the network simulator for a client.
+ * @brief    Turns on the network simulator for a server.
  * @param    server           The server.
  * @param    latency          A number of seconds of latency to add to the connection.
  * @param    jitter           The variability of latency.
@@ -631,6 +770,46 @@ CF_API bool CF_CALL cf_server_is_client_connected(CF_Server* server, int client_
  * @related  CF_Server
  */
 CF_API void CF_CALL cf_server_enable_network_simulator(CF_Server* server, double latency, double jitter, double drop_chance, double duplicate_chance);
+
+//--------------------------------------------------------------------------------------------------
+// COMPRESSION
+//
+// Delta + entropy compression for game snapshots, built on CF's adaptive range coder (cute_arith.h).
+// The intended flow for server-authoritative state: keep the last snapshot each client has
+// acknowledged as a baseline, `cf_snapshot_compress` the new snapshot against it, and send the
+// (usually tiny) result with `cf_server_send`. The client decompresses against the same baseline.
+// Unchanged fields cost almost nothing, so bandwidth scales with what actually moved, not with
+// world size. Baselines and which one a peer holds are the caller's to track for now.
+
+/**
+ * @function cf_snapshot_compress
+ * @category net
+ * @brief    Delta-compresses a snapshot against a baseline of the same size.
+ * @param    baseline        The previous snapshot to delta against, or `NULL` to compress against all-zero.
+ * @param    current         The new snapshot to compress. Must be `size` bytes.
+ * @param    size            The size of both snapshots in bytes.
+ * @param    out             Destination buffer for the compressed bytes.
+ * @param    out_capacity    Capacity of `out` in bytes.
+ * @return   Returns the compressed size in bytes, or -1 if it did not fit in `out_capacity`.
+ * @remarks  `baseline` and `current` must have identical layout and size; only their differences
+ *           are encoded. Decompress with `cf_snapshot_decompress` and the same baseline.
+ * @related  cf_snapshot_decompress cf_client_send cf_server_send
+ */
+CF_API int CF_CALL cf_snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity);
+
+/**
+ * @function cf_snapshot_decompress
+ * @category net
+ * @brief    Reconstructs a snapshot from a baseline and a compressed delta.
+ * @param    baseline        The same baseline passed to `cf_snapshot_compress` (or `NULL`).
+ * @param    size            The snapshot size in bytes (known to both sides).
+ * @param    compressed      The compressed delta bytes.
+ * @param    compressed_size The number of compressed bytes.
+ * @param    out             Destination buffer for the reconstructed snapshot, `size` bytes.
+ * @return   Returns 0 on success.
+ * @related  cf_snapshot_compress cf_client_pop_packet cf_server_pop_event
+ */
+CF_API int CF_CALL cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out);
 
 #ifdef __cplusplus
 }
@@ -663,9 +842,9 @@ enum : int
 	#undef CF_ENUM
 };
 
-CF_INLINE int address_init(Address* endpoint, const char* address_and_port_string) { return cf_address_init(endpoint,address_and_port_string); }
-CF_INLINE void address_to_string(Address endpoint, char* buffer, int buffer_size) { cf_address_to_string(endpoint,buffer,buffer_size); }
-CF_INLINE int address_equals(Address a, Address b) { return cf_address_equals(a,b); }
+CF_INLINE int address_init(Address* address, const char* address_and_port_string) { return cf_address_init(address,address_and_port_string); }
+CF_INLINE void address_to_string(Address address, char* buffer, int buffer_size) { cf_address_to_string(address,buffer,buffer_size); }
+CF_INLINE bool address_equals(Address a, Address b) { return cf_address_equals(a,b); }
 
 //--------------------------------------------------------------------------------------------------
 // CONNECT TOKEN
@@ -728,7 +907,11 @@ CF_INLINE void client_update(Client* client, double dt, uint64_t current_time) {
 CF_INLINE bool client_pop_packet(Client* client, void** packet, int* size, bool* was_sent_reliably = NULL) { return cf_client_pop_packet(client,packet,size,was_sent_reliably); }
 CF_INLINE void client_free_packet(Client* client, void* packet) { cf_client_free_packet(client,packet); }
 CF_INLINE CF_Result client_send(Client* client, const void* packet, int size, bool send_reliably) { return cf_client_send(client,packet,size,send_reliably); }
-CF_INLINE ClientState client_state_get(const Client* client) { return cf_client_state_get(client); }
+CF_INLINE ClientState client_state(const Client* client) { return cf_client_state(client); }
+CF_INLINE float client_rtt(Client* client) { return cf_client_rtt(client); }
+CF_INLINE float client_packet_loss(Client* client) { return cf_client_packet_loss(client); }
+CF_INLINE float client_incoming_kbps(Client* client) { return cf_client_incoming_kbps(client); }
+CF_INLINE float client_outgoing_kbps(Client* client) { return cf_client_outgoing_kbps(client); }
 CF_INLINE void client_enable_network_simulator(Client* client, double latency, double jitter, double drop_chance, double duplicate_chance) { cf_client_enable_network_simulator(client,latency,jitter,drop_chance,duplicate_chance); }
 
 //--------------------------------------------------------------------------------------------------
@@ -757,13 +940,25 @@ CF_INLINE Server* make_server(ServerConfig config) { return cf_make_server(confi
 CF_INLINE void destroy_server(Server* server) { cf_destroy_server(server); }
 CF_INLINE CF_Result server_start(Server* server, const char* address_and_port) { return cf_server_start(server,address_and_port); }
 CF_INLINE void server_stop(Server* server) { cf_server_stop(server); }
+CF_INLINE void server_set_public_ip(Server* server, const char* address_and_port) { cf_server_set_public_ip(server,address_and_port); }
 CF_INLINE bool server_pop_event(Server* server, ServerEvent* event) { return cf_server_pop_event(server,event); }
 CF_INLINE void server_free_packet(Server* server, int client_index, void* data) { cf_server_free_packet(server,client_index,data); }
 CF_INLINE void server_update(Server* server, double dt, uint64_t current_time) { cf_server_update(server,dt,current_time); }
 CF_INLINE void server_disconnect_client(Server* server, int client_index, bool notify_client = true) { cf_server_disconnect_client(server, client_index, notify_client); }
-CF_INLINE void server_send(Server* server, const void* packet, int size, int client_index, bool send_reliably) { cf_server_send(server,packet,size,client_index,send_reliably); }
+CF_INLINE CF_Result server_send(Server* server, const void* packet, int size, int client_index, bool send_reliably) { return cf_server_send(server,packet,size,client_index,send_reliably); }
+CF_INLINE void server_send_to_all(Server* server, const void* packet, int size, bool send_reliably) { cf_server_send_to_all(server,packet,size,send_reliably); }
 CF_INLINE bool server_is_client_connected(Server* server, int client_index) { return cf_server_is_client_connected(server,client_index); }
+CF_INLINE float server_rtt(Server* server, int client_index) { return cf_server_rtt(server,client_index); }
+CF_INLINE float server_packet_loss(Server* server, int client_index) { return cf_server_packet_loss(server,client_index); }
+CF_INLINE float server_incoming_kbps(Server* server, int client_index) { return cf_server_incoming_kbps(server,client_index); }
+CF_INLINE float server_outgoing_kbps(Server* server, int client_index) { return cf_server_outgoing_kbps(server,client_index); }
 CF_INLINE void server_enable_network_simulator(Server* server, double latency, double jitter, double drop_chance, double duplicate_chance) { cf_server_enable_network_simulator(server,latency,jitter,drop_chance,duplicate_chance); }
+
+//--------------------------------------------------------------------------------------------------
+// COMPRESSION
+
+CF_INLINE int snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity) { return cf_snapshot_compress(baseline,current,size,out,out_capacity); }
+CF_INLINE int snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out) { return cf_snapshot_decompress(baseline,size,compressed,compressed_size,out); }
 
 }
 

--- a/libraries/cute/cute_arith.h
+++ b/libraries/cute/cute_arith.h
@@ -1,0 +1,494 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+/*
+	cute_arith.h - An adaptive binary range coder, for packet compression.
+
+	This is the entropy-coding primitive underneath CF's networking compression. It is a binary
+	range coder in the LZMA lineage: everything is coded one bit at a time against an adaptive
+	probability, plus an "equiprobable" path for bits that carry no model. On top of that sit a
+	few conveniences: adaptive bytes (an 8-node bit tree), and variable-length integers.
+
+	Why binary-only? A binary coder is small, has no division in the hot path, is trivial to make
+	carry-correct, and composes: any alphabet or model you need is expressed as a handful of bit
+	decisions with their own probabilities. Delta-encoded game snapshots are mostly zero bits, and
+	an adaptive bit model drives those toward ~0 cost, which is exactly what we want.
+
+	USAGE
+
+		Encode:
+			uint16_t model[256]; cf_arith_probs_clear(model, 256);
+			cf_arith_encoder e; cf_arith_encoder_init(&e, out_buffer, out_cap);
+			cf_arith_encode_byte(&e, model, some_byte);
+			...
+			int bytes = cf_arith_encoder_flush(&e);   // -1 if it overflowed out_cap
+
+		Decode (mirror the exact same model updates and call sequence):
+			uint16_t model[256]; cf_arith_probs_clear(model, 256);
+			cf_arith_decoder d; cf_arith_decoder_init(&d, in_buffer, in_size);
+			uint8_t b = cf_arith_decode_byte(&d, model);
+
+	The decoder must replay the identical sequence of encode calls with identically-initialized
+	models; the streams are otherwise self-delimiting only insofar as the caller knows how many
+	symbols to read (encode a length up front if you need it).
+
+	Build the tests with CUTE_ARITH_TESTS defined, then call cf_arith_run_tests().
+*/
+
+#ifndef CUTE_ARITH_H
+#define CUTE_ARITH_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// A single adaptive probability is a uint16 in [1, 2047], representing P(bit==0) as prob/2048.
+#define CF_ARITH_PROB_BITS 11
+#define CF_ARITH_PROB_ONE  (1 << CF_ARITH_PROB_BITS) // 2048
+#define CF_ARITH_PROB_INIT (CF_ARITH_PROB_ONE >> 1)  // 1024, i.e. 0.5
+#define CF_ARITH_ADAPT_SHIFT 5                        // Adaptation speed; larger = slower.
+#define CF_ARITH_TOP (1u << 24)
+
+typedef struct cf_arith_encoder
+{
+	uint64_t low;
+	uint32_t range;
+	uint8_t cache;
+	uint64_t cache_size;
+	uint8_t* out;
+	int cap;
+	int count;    // Number of bytes that *would* be written (may exceed cap).
+	int overflow; // Set once a write past cap is attempted.
+} cf_arith_encoder;
+
+typedef struct cf_arith_decoder
+{
+	uint32_t range;
+	uint32_t code;
+	const uint8_t* in;
+	int size;
+	int pos;
+} cf_arith_decoder;
+
+// Reset a probability array to the neutral 0.5.
+static inline void cf_arith_probs_clear(uint16_t* probs, int count)
+{
+	for (int i = 0; i < count; ++i) probs[i] = CF_ARITH_PROB_INIT;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Encoder.
+
+static inline void cf_arith_encoder_init(cf_arith_encoder* e, uint8_t* out, int cap)
+{
+	e->low = 0;
+	e->range = 0xFFFFFFFFu;
+	e->cache = 0;
+	e->cache_size = 1;
+	e->out = out;
+	e->cap = cap;
+	e->count = 0;
+	e->overflow = 0;
+}
+
+static inline void cf_arith_s_put(cf_arith_encoder* e, uint8_t byte)
+{
+	if (e->count < e->cap) e->out[e->count] = byte;
+	else e->overflow = 1;
+	e->count++;
+}
+
+static inline void cf_arith_s_shift_low(cf_arith_encoder* e)
+{
+	if ((uint32_t)(e->low >> 32) != 0 || e->low < 0xFF000000ull) {
+		uint8_t temp = e->cache;
+		do {
+			cf_arith_s_put(e, (uint8_t)(temp + (uint8_t)(e->low >> 32)));
+			temp = 0xFF;
+		} while (--e->cache_size != 0);
+		e->cache = (uint8_t)(e->low >> 24);
+	}
+	e->cache_size++;
+	e->low = (uint32_t)((uint32_t)e->low << 8);
+}
+
+// Encode one bit against an adaptive probability, updating the model.
+static inline void cf_arith_encode_bit(cf_arith_encoder* e, uint16_t* prob, int bit)
+{
+	uint32_t bound = (e->range >> CF_ARITH_PROB_BITS) * (*prob);
+	if (!bit) {
+		e->range = bound;
+		*prob = (uint16_t)(*prob + ((CF_ARITH_PROB_ONE - *prob) >> CF_ARITH_ADAPT_SHIFT));
+	} else {
+		e->low += bound;
+		e->range -= bound;
+		*prob = (uint16_t)(*prob - (*prob >> CF_ARITH_ADAPT_SHIFT));
+	}
+	while (e->range < CF_ARITH_TOP) {
+		cf_arith_s_shift_low(e);
+		e->range <<= 8;
+	}
+}
+
+// Encode nbits equiprobable bits (no model), MSB first. For incompressible values.
+static inline void cf_arith_encode_bits(cf_arith_encoder* e, uint32_t value, int nbits)
+{
+	for (int i = nbits - 1; i >= 0; --i) {
+		e->range >>= 1;
+		uint32_t b = (value >> i) & 1;
+		e->low += e->range & (0u - b);
+		while (e->range < CF_ARITH_TOP) {
+			cf_arith_s_shift_low(e);
+			e->range <<= 8;
+		}
+	}
+}
+
+// Encode a byte through an 8-node adaptive bit tree. `probs` must hold 256 entries.
+static inline void cf_arith_encode_byte(cf_arith_encoder* e, uint16_t* probs, uint8_t byte)
+{
+	uint32_t m = 1;
+	for (int i = 7; i >= 0; --i) {
+		int bit = (byte >> i) & 1;
+		cf_arith_encode_bit(e, &probs[m], bit);
+		m = (m << 1) | (uint32_t)bit;
+	}
+}
+
+// Encode a variable-length unsigned integer: a unary-ish length prefix of continue-bits followed
+// by 7 payload bits per group, each group coded with its own small model set. `probs` needs 128
+// entries (one bit-tree of 8 nodes per group is overkill; we keep it simple with a shared byte
+// tree per 8-bit chunk). Here we use a compact scheme: encode 7 bits + 1 continue bit per group.
+static inline void cf_arith_encode_uint(cf_arith_encoder* e, uint16_t* probs, uint64_t value)
+{
+	// probs layout: [0]=continue model, [1..256]=byte tree for the 7-bit groups (reuse encode_bit).
+	for (;;) {
+		uint32_t group = (uint32_t)(value & 0x7F);
+		value >>= 7;
+		int more = value != 0;
+		// 7 payload bits, MSB first, each with its own model index (2..128 range).
+		uint32_t m = 1;
+		for (int i = 6; i >= 0; --i) {
+			int bit = (group >> i) & 1;
+			cf_arith_encode_bit(e, &probs[1 + m], bit);
+			m = (m << 1) | (uint32_t)bit;
+		}
+		cf_arith_encode_bit(e, &probs[0], more);
+		if (!more) break;
+	}
+}
+
+// Finish the stream. Returns the number of bytes written, or -1 if the output buffer overflowed.
+static inline int cf_arith_encoder_flush(cf_arith_encoder* e)
+{
+	for (int i = 0; i < 5; ++i) cf_arith_s_shift_low(e);
+	return e->overflow ? -1 : e->count;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Decoder.
+
+static inline uint8_t cf_arith_s_get(cf_arith_decoder* d)
+{
+	return (uint8_t)(d->pos < d->size ? d->in[d->pos++] : (d->pos++, 0));
+}
+
+static inline void cf_arith_decoder_init(cf_arith_decoder* d, const uint8_t* in, int size)
+{
+	d->in = in;
+	d->size = size;
+	d->pos = 0;
+	d->range = 0xFFFFFFFFu;
+	d->code = 0;
+	// The encoder always emits a leading 0 byte; consume 5 bytes to prime `code`.
+	for (int i = 0; i < 5; ++i) d->code = (d->code << 8) | cf_arith_s_get(d);
+}
+
+static inline int cf_arith_decode_bit(cf_arith_decoder* d, uint16_t* prob)
+{
+	uint32_t bound = (d->range >> CF_ARITH_PROB_BITS) * (*prob);
+	int bit;
+	if (d->code < bound) {
+		d->range = bound;
+		*prob = (uint16_t)(*prob + ((CF_ARITH_PROB_ONE - *prob) >> CF_ARITH_ADAPT_SHIFT));
+		bit = 0;
+	} else {
+		d->code -= bound;
+		d->range -= bound;
+		*prob = (uint16_t)(*prob - (*prob >> CF_ARITH_ADAPT_SHIFT));
+		bit = 1;
+	}
+	while (d->range < CF_ARITH_TOP) {
+		d->code = (d->code << 8) | cf_arith_s_get(d);
+		d->range <<= 8;
+	}
+	return bit;
+}
+
+static inline uint32_t cf_arith_decode_bits(cf_arith_decoder* d, int nbits)
+{
+	uint32_t result = 0;
+	for (int i = 0; i < nbits; ++i) {
+		d->range >>= 1;
+		uint32_t t = (d->code - d->range) >> 31; // 1 if code < range, else 0.
+		d->code -= d->range & (t - 1);
+		result = (result << 1) | (1u - t);
+		while (d->range < CF_ARITH_TOP) {
+			d->code = (d->code << 8) | cf_arith_s_get(d);
+			d->range <<= 8;
+		}
+	}
+	return result;
+}
+
+static inline uint8_t cf_arith_decode_byte(cf_arith_decoder* d, uint16_t* probs)
+{
+	uint32_t m = 1;
+	for (int i = 0; i < 8; ++i) {
+		int bit = cf_arith_decode_bit(d, &probs[m]);
+		m = (m << 1) | (uint32_t)bit;
+	}
+	return (uint8_t)(m & 0xFF);
+}
+
+static inline uint64_t cf_arith_decode_uint(cf_arith_decoder* d, uint16_t* probs)
+{
+	uint64_t value = 0;
+	int shift = 0;
+	for (;;) {
+		uint32_t m = 1;
+		for (int i = 0; i < 7; ++i) {
+			int bit = cf_arith_decode_bit(d, &probs[1 + m]);
+			m = (m << 1) | (uint32_t)bit;
+		}
+		uint32_t group = m & 0x7F;
+		value |= (uint64_t)group << shift;
+		shift += 7;
+		int more = cf_arith_decode_bit(d, &probs[0]);
+		if (!more) break;
+	}
+	return value;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Delta compression.
+//
+// Compress a snapshot `cur` (n bytes) relative to a baseline `prev` (n bytes, or NULL to delta
+// against all-zero). The two buffers must be the same fixed size n, known to both sides. Each byte
+// is coded as a "changed" flag against an adaptive model, and only changed bytes carry a value --
+// so the long runs of unchanged fields typical of frame-to-frame game state cost almost nothing.
+// The decode side reproduces `cur` exactly given the identical `prev`.
+
+// Returns the compressed size in bytes, or -1 if it overflowed out_cap.
+static inline int cf_arith_delta_compress(const uint8_t* prev, const uint8_t* cur, int n, uint8_t* out, int out_cap)
+{
+	uint16_t changed = CF_ARITH_PROB_INIT;
+	uint16_t value[256];
+	cf_arith_probs_clear(value, 256);
+	cf_arith_encoder e;
+	cf_arith_encoder_init(&e, out, out_cap);
+	for (int i = 0; i < n; ++i) {
+		uint8_t d = (uint8_t)(cur[i] ^ (prev ? prev[i] : 0));
+		int is_changed = d != 0;
+		cf_arith_encode_bit(&e, &changed, is_changed);
+		if (is_changed) cf_arith_encode_byte(&e, value, d);
+	}
+	return cf_arith_encoder_flush(&e);
+}
+
+// Reconstructs `cur` (n bytes) from `prev` and the compressed delta. Returns 0 on success.
+static inline int cf_arith_delta_decompress(const uint8_t* prev, int n, const uint8_t* in, int in_size, uint8_t* cur)
+{
+	uint16_t changed = CF_ARITH_PROB_INIT;
+	uint16_t value[256];
+	cf_arith_probs_clear(value, 256);
+	cf_arith_decoder d;
+	cf_arith_decoder_init(&d, in, in_size);
+	for (int i = 0; i < n; ++i) {
+		uint8_t delta = 0;
+		if (cf_arith_decode_bit(&d, &changed)) delta = cf_arith_decode_byte(&d, value);
+		cur[i] = (uint8_t)(delta ^ (prev ? prev[i] : 0));
+	}
+	return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CUTE_ARITH_H
+
+//--------------------------------------------------------------------------------------------------
+// Tests.
+
+#ifdef CUTE_ARITH_TESTS
+#ifndef CUTE_ARITH_TESTS_ONCE
+#define CUTE_ARITH_TESTS_ONCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int cf_arith_s_test_roundtrip_bytes(const uint8_t* data, int n)
+{
+	// Order-0 adaptive byte model, both directions.
+	uint8_t* out = (uint8_t*)malloc((size_t)n * 2 + 64);
+	uint16_t model[256];
+	cf_arith_probs_clear(model, 256);
+	cf_arith_encoder e;
+	cf_arith_encoder_init(&e, out, n * 2 + 64);
+	for (int i = 0; i < n; ++i) cf_arith_encode_byte(&e, model, data[i]);
+	int size = cf_arith_encoder_flush(&e);
+	if (size < 0) { printf("  overflow\n"); free(out); return 0; }
+
+	uint16_t model2[256];
+	cf_arith_probs_clear(model2, 256);
+	cf_arith_decoder d;
+	cf_arith_decoder_init(&d, out, size);
+	int ok = 1;
+	for (int i = 0; i < n; ++i) {
+		uint8_t b = cf_arith_decode_byte(&d, model2);
+		if (b != data[i]) { ok = 0; printf("  mismatch at %d: got %d want %d\n", i, b, data[i]); break; }
+	}
+	free(out);
+	return ok;
+}
+
+static int cf_arith_run_tests(void)
+{
+	int fails = 0;
+	unsigned int seed = 12345;
+	#define RND() (seed = seed * 1103515245u + 12345u, (seed >> 16) & 0xFF)
+
+	// 1. Empty.
+	if (!cf_arith_s_test_roundtrip_bytes(NULL, 0)) { printf("FAIL empty\n"); fails++; } else printf("PASS empty\n");
+
+	// 2. Single byte, each value.
+	{
+		int ok = 1;
+		for (int v = 0; v < 256; ++v) { uint8_t b = (uint8_t)v; if (!cf_arith_s_test_roundtrip_bytes(&b, 1)) { ok = 0; break; } }
+		if (!ok) { printf("FAIL single-byte\n"); fails++; } else printf("PASS single-byte (all 256)\n");
+	}
+
+	// 3. All zeros (should compress hugely) and check ratio.
+	{
+		int n = 4096;
+		uint8_t* z = (uint8_t*)calloc(n, 1);
+		if (!cf_arith_s_test_roundtrip_bytes(z, n)) { printf("FAIL zeros\n"); fails++; }
+		else {
+			uint8_t* out = (uint8_t*)malloc(n * 2 + 64);
+			uint16_t model[256]; cf_arith_probs_clear(model, 256);
+			cf_arith_encoder e; cf_arith_encoder_init(&e, out, n * 2 + 64);
+			for (int i = 0; i < n; ++i) cf_arith_encode_byte(&e, model, 0);
+			int size = cf_arith_encoder_flush(&e);
+			printf("PASS zeros (%d bytes -> %d, %.1fx)\n", n, size, (double)n / size);
+			if (size > n / 10) { printf("  WARN: zeros should compress far better\n"); }
+			free(out);
+		}
+		free(z);
+	}
+
+	// 4. Random incompressible data of many sizes (round-trip must still be exact).
+	{
+		int ok = 1;
+		int sizes[] = { 1, 2, 3, 7, 15, 16, 17, 255, 256, 257, 1000, 4096, 65537 };
+		for (int s = 0; s < (int)(sizeof(sizes)/sizeof(sizes[0])) && ok; ++s) {
+			int n = sizes[s];
+			uint8_t* data = (uint8_t*)malloc(n);
+			for (int i = 0; i < n; ++i) data[i] = (uint8_t)RND();
+			if (!cf_arith_s_test_roundtrip_bytes(data, n)) { printf("FAIL random n=%d\n", n); ok = 0; }
+			free(data);
+		}
+		if (ok) printf("PASS random (13 sizes)\n"); else fails++;
+	}
+
+	// 5. Skewed data (mostly zeros with occasional values) -- the delta-snapshot shape.
+	{
+		int n = 8192;
+		uint8_t* data = (uint8_t*)malloc(n);
+		for (int i = 0; i < n; ++i) data[i] = (RND() < 8) ? (uint8_t)RND() : 0;
+		int rt = cf_arith_s_test_roundtrip_bytes(data, n);
+		uint8_t* out = (uint8_t*)malloc(n * 2 + 64);
+		uint16_t model[256]; cf_arith_probs_clear(model, 256);
+		cf_arith_encoder e; cf_arith_encoder_init(&e, out, n * 2 + 64);
+		for (int i = 0; i < n; ++i) cf_arith_encode_byte(&e, model, data[i]);
+		int size = cf_arith_encoder_flush(&e);
+		if (!rt) { printf("FAIL skewed\n"); fails++; }
+		else printf("PASS skewed (%d bytes -> %d, %.1fx)\n", n, size, (double)n / size);
+		free(out); free(data);
+	}
+
+	// 6. Direct (equiprobable) bits and varints round-trip.
+	{
+		uint8_t out[4096];
+		cf_arith_encoder e; cf_arith_encoder_init(&e, out, sizeof(out));
+		uint16_t uprobs[257]; cf_arith_probs_clear(uprobs, 257);
+		uint32_t dvals[] = { 0, 1, 2, 255, 256, 1023, 0xFFFFFFFFu, 0x12345 };
+		int dbits[]     = { 1, 1, 2, 8,   9,   10,   32,          20 };
+		uint64_t uvals[] = { 0, 1, 127, 128, 300, 16384, 1000000, 0xFFFFFFFFFFull };
+		for (int i = 0; i < 8; ++i) cf_arith_encode_bits(&e, dvals[i] & ((dbits[i]==32)?0xFFFFFFFFu:((1u<<dbits[i])-1)), dbits[i]);
+		for (int i = 0; i < 8; ++i) cf_arith_encode_uint(&e, uprobs, uvals[i]);
+		int size = cf_arith_encoder_flush(&e);
+
+		cf_arith_decoder d; cf_arith_decoder_init(&d, out, size);
+		uint16_t uprobs2[257]; cf_arith_probs_clear(uprobs2, 257);
+		int ok = size >= 0;
+		for (int i = 0; i < 8 && ok; ++i) {
+			uint32_t want = dvals[i] & ((dbits[i]==32)?0xFFFFFFFFu:((1u<<dbits[i])-1));
+			uint32_t got = cf_arith_decode_bits(&d, dbits[i]);
+			if (got != want) { printf("  direct mismatch %u != %u (%d bits)\n", got, want, dbits[i]); ok = 0; }
+		}
+		for (int i = 0; i < 8 && ok; ++i) {
+			uint64_t got = cf_arith_decode_uint(&d, uprobs2);
+			if (got != uvals[i]) { printf("  uint mismatch %llu != %llu\n", (unsigned long long)got, (unsigned long long)uvals[i]); ok = 0; }
+		}
+		if (!ok) { printf("FAIL direct/uint\n"); fails++; } else printf("PASS direct bits + varints\n");
+	}
+
+	// 7. Delta compression: a snapshot vs a mostly-identical next frame.
+	{
+		int n = 4096;
+		uint8_t* base = (uint8_t*)malloc(n);
+		uint8_t* cur = (uint8_t*)malloc(n);
+		uint8_t* rt = (uint8_t*)malloc(n);
+		uint8_t* out = (uint8_t*)malloc(n * 2 + 64);
+		for (int i = 0; i < n; ++i) base[i] = (uint8_t)RND();
+		memcpy(cur, base, n);
+		// Change ~2% of bytes, like a handful of moving entities between frames.
+		for (int k = 0; k < n / 50; ++k) { int idx = RND() | (RND() << 8); idx %= n; cur[idx] = (uint8_t)RND(); }
+
+		int size = cf_arith_delta_compress(base, cur, n, out, n * 2 + 64);
+		int ok = size >= 0;
+		if (ok) { cf_arith_delta_decompress(base, n, out, size, rt); ok = memcmp(rt, cur, n) == 0; }
+		if (!ok) { printf("FAIL delta (roundtrip)\n"); fails++; }
+		else printf("PASS delta (%d bytes, ~2%% changed -> %d, %.1fx)\n", n, size, (double)n / size);
+
+		// Identical frame -> near-zero payload.
+		int same = cf_arith_delta_compress(base, base, n, out, n * 2 + 64);
+		cf_arith_delta_decompress(base, n, out, same, rt);
+		if (memcmp(rt, base, n) != 0) { printf("FAIL delta (identical roundtrip)\n"); fails++; }
+		else printf("PASS delta identical (%d bytes -> %d, %.0fx)\n", n, same, (double)n / same);
+
+		// NULL baseline (first snapshot) must round-trip too.
+		int first = cf_arith_delta_compress(NULL, cur, n, out, n * 2 + 64);
+		cf_arith_delta_decompress(NULL, n, out, first, rt);
+		if (memcmp(rt, cur, n) != 0) { printf("FAIL delta (null baseline)\n"); fails++; }
+		else printf("PASS delta null-baseline (%d bytes -> %d)\n", n, first);
+
+		free(base); free(cur); free(rt); free(out);
+	}
+
+	#undef RND
+	if (fails) printf("\n%d TEST GROUP(S) FAILED\n", fails);
+	else printf("\nALL cute_arith TESTS PASSED\n");
+	return fails ? -1 : 0;
+}
+
+#endif // CUTE_ARITH_TESTS_ONCE
+#endif // CUTE_ARITH_TESTS

--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -4121,14 +4121,19 @@ hydro_sign_verify(const uint8_t csig[hydro_sign_BYTES], const void *m_, size_t m
 
 #define CN_PROTOCOL_VERSION_STRING ((const uint8_t*)"CUTE 1.00")
 #define CN_PROTOCOL_VERSION_STRING_LEN (9 + 1)
-#define CN_PROTOCOL_SERVER_MAX_CLIENTS 32
+// Tied to the public, overridable CN_SERVER_MAX_CLIENTS so the protocol-layer per-client arrays
+// stay the same size as the high-level server's transport array. Defining them independently let a
+// user raise CN_SERVER_MAX_CLIENTS while the protocol layer silently capped connections at 32.
+#define CN_PROTOCOL_SERVER_MAX_CLIENTS CN_SERVER_MAX_CLIENTS
 #define CN_PROTOCOL_PACKET_SIZE_MAX (CN_KB + 256)
 #define CN_PROTOCOL_PACKET_PAYLOAD_MAX (1207 - 2)
 #define CN_PROTOCOL_CLIENT_SEND_BUFFER_SIZE (256 * CN_KB)
 #define CN_PROTOCOL_CLIENT_RECEIVE_BUFFER_SIZE (256 * CN_KB)
 #define CN_PROTOCOL_SERVER_SEND_BUFFER_SIZE (CN_MB * 2)
 #define CN_PROTOCOL_SERVER_RECEIVE_BUFFER_SIZE (CN_MB * 2)
-#define CN_PROTOCOL_EVENT_QUEUE_SIZE (CN_MB * 4)
+// Initial capacity of the server event queues. They hold ~40-byte events and grow by doubling
+// on demand, so this is just a starting size, not a cap -- keep it modest.
+#define CN_PROTOCOL_EVENT_QUEUE_SIZE (CN_KB * 256)
 #define CN_PROTOCOL_SIGNATURE_SIZE 64
 
 #define CN_PROTOCOL_CONNECT_TOKEN_PACKET_SIZE 1024
@@ -4653,6 +4658,12 @@ typedef struct cn_protocol_encryption_state_t
 	cn_crypto_key_t server_to_client_key;
 	uint64_t client_id;
 	cn_crypto_signature_t signature;
+	// The challenge is generated once when this half-open state is created and re-sent
+	// unchanged until the client echoes it back. A spoofed source address never receives
+	// the challenge packet, so echoing it proves the peer is reachable at its claimed
+	// address -- the anti-spoofing property. Verified in the CHALLENGE_RESPONSE handler.
+	uint64_t challenge_nonce;
+	uint8_t challenge_data[CN_PROTOCOL_CHALLENGE_DATA_SIZE];
 } cn_protocol_encryption_state_t;
 
 typedef struct cn_protocol_encryption_map_t
@@ -5284,6 +5295,7 @@ struct cn_protocol_client_t
 	uint64_t sequence;
 	cn_circular_buffer_t packet_queue;
 	cn_protocol_replay_buffer_t replay_buffer;
+	cn_protocol_packet_allocator_t* packet_allocator;
 	cn_simulator_t* sim;
 	uint8_t buffer[CN_PROTOCOL_PACKET_SIZE_MAX];
 	uint8_t connect_token_packet[CN_PROTOCOL_CONNECT_TOKEN_PACKET_SIZE];
@@ -5716,6 +5728,9 @@ cn_memory_pool_t* cn_memory_pool_create(int element_size, int element_count, voi
 	pool->arena = (uint8_t*)(pool + 1);
 	pool->free_list = pool->arena;
 	pool->overflow_count = 0;
+	// Without this, destroy and the overflow alloc/free paths pass an uninitialized mem_ctx to
+	// CN_ALLOC/CN_FREE -- harmless for the default malloc/free, corruption for a real context.
+	pool->mem_ctx = user_allocator_context;
 
 	for (int i = 0; i < element_count - 1; ++i)
 	{
@@ -5840,7 +5855,10 @@ cn_protocol_packet_allocator_t* cn_protocol_packet_allocator_create(void* user_a
 	packet_allocator->pools[CN_PROTOCOL_PACKET_TYPE_DISCONNECT] = cn_memory_pool_create(s_packet_size(CN_PROTOCOL_PACKET_TYPE_DISCONNECT), 256, user_allocator_context);
 	packet_allocator->pools[CN_PROTOCOL_PACKET_TYPE_CHALLENGE_REQUEST] = cn_memory_pool_create(s_packet_size(CN_PROTOCOL_PACKET_TYPE_CHALLENGE_REQUEST), 256, user_allocator_context);
 	packet_allocator->pools[CN_PROTOCOL_PACKET_TYPE_CHALLENGE_RESPONSE] = cn_memory_pool_create(s_packet_size(CN_PROTOCOL_PACKET_TYPE_CHALLENGE_RESPONSE), 256, user_allocator_context);
-	packet_allocator->pools[CN_PROTOCOL_PACKET_TYPE_PAYLOAD] = cn_memory_pool_create(s_packet_size(CN_PROTOCOL_PACKET_TYPE_PAYLOAD), 1024 * 10, user_allocator_context);
+	// Payload packets are transient -- allocated on receive, freed the same update cycle. Peak
+	// live count is the number drained per update, far below 10k. The pool overflows to the
+	// allocator gracefully if a burst exceeds this, so size it modestly.
+	packet_allocator->pools[CN_PROTOCOL_PACKET_TYPE_PAYLOAD] = cn_memory_pool_create(s_packet_size(CN_PROTOCOL_PACKET_TYPE_PAYLOAD), 512, user_allocator_context);
 	packet_allocator->user_allocator_context = user_allocator_context;
 	return packet_allocator;
 }
@@ -5986,6 +6004,22 @@ int cn_protocol_packet_write(void* packet_ptr, uint8_t* buffer, uint64_t sequenc
 	return (int)(written) + CN_CRYPTO_HEADER_BYTES;
 }
 
+// Writes a PAYLOAD packet straight from a (pointer, size) into `buffer`, byte-for-byte identical
+// to framing a cn_protocol_packet_payload_t and calling cn_protocol_packet_write on it -- but
+// without staging the payload into an intermediate struct first, saving one full-payload copy on
+// every send. Used by the client and server payload send paths.
+static int s_protocol_write_payload_packet(const void* payload, int payload_size, uint8_t* buffer, uint64_t sequence, const cn_crypto_key_t* key)
+{
+	uint8_t* buffer_start = buffer;
+	uint8_t* p = s_protocol_header(&buffer, CN_PROTOCOL_PACKET_TYPE_PAYLOAD, sequence);
+	cn_write_uint16(&buffer, (uint16_t)payload_size);
+	CN_MEMCPY(buffer, payload, payload_size);
+	buffer += payload_size;
+	int plaintext_size = (int)(buffer - p);
+	cn_crypto_encrypt(key, p, plaintext_size, sequence);
+	return (int)(buffer - buffer_start) + CN_CRYPTO_HEADER_BYTES;
+}
+
 void* cn_protocol_packet_open(uint8_t* buffer, int size, const cn_crypto_key_t* key, cn_protocol_packet_allocator_t* pa, cn_protocol_replay_buffer_t* replay_buffer, uint64_t* sequence_ptr)
 {
 	int ret = 0;
@@ -6073,6 +6107,14 @@ void* cn_protocol_packet_open(uint8_t* buffer, int size, const cn_crypto_key_t* 
 		cn_protocol_packet_payload_t* packet = (cn_protocol_packet_payload_t*)cn_protocol_packet_allocator_alloc(pa, (cn_protocol_packet_type_t)type);
 		packet->packet_type = type;
 		packet->payload_size = cn_read_uint16(&buffer);
+		// payload_size is attacker-controlled; the length check at the top of this function
+		// bounds only the on-wire packet, not this inner field. Reject before the copy can
+		// overflow payload[] (destination) or read past the received bytes (source).
+		int payload_available = size - 73 - 2; // 73 = header+signature overhead, 2 = the payload_size field.
+		if (packet->payload_size > CN_PROTOCOL_PACKET_PAYLOAD_MAX || (int)packet->payload_size > payload_available) {
+			cn_protocol_packet_allocator_free(pa, (cn_protocol_packet_type_t)type, packet);
+			return NULL;
+		}
 		CN_MEMCPY(packet->payload, buffer, packet->payload_size);
 		return packet;
 	}	break;
@@ -6560,6 +6602,7 @@ cn_protocol_client_t* cn_protocol_client_create(uint16_t port, uint64_t applicat
 	client->application_id = application_id;
 	client->mem_ctx = user_allocator_context;
 	client->packet_queue = cn_circular_buffer_create(CN_MB, client->mem_ctx);
+	client->packet_allocator = cn_protocol_packet_allocator_create(user_allocator_context);
 	return client;
 }
 
@@ -6568,6 +6611,7 @@ void cn_protocol_client_destroy(cn_protocol_client_t* client)
 	// TODO: Detect if disconnect was not called yet.
 	cn_simulator_destroy(client->sim);
 	cn_circular_buffer_free(&client->packet_queue);
+	cn_protocol_packet_allocator_destroy(client->packet_allocator);
 	CN_FREE(client, client->mem_ctx);
 }
 
@@ -6664,7 +6708,7 @@ bool cn_protocol_client_get_packet(cn_protocol_client_t* client, void** data, in
 void cn_protocol_client_free_packet(cn_protocol_client_t* client, void* packet)
 {
 	cn_protocol_packet_payload_t* payload_packet = (cn_protocol_packet_payload_t*)((uint8_t*)packet - CN_OFFSET_OF(cn_protocol_packet_payload_t, payload));
-	cn_protocol_packet_allocator_free(NULL, (cn_protocol_packet_type_t)payload_packet->packet_type, payload_packet);
+	cn_protocol_packet_allocator_free(client->packet_allocator, (cn_protocol_packet_type_t)payload_packet->packet_type, payload_packet);
 }
 
 static void s_protocol_disconnect(cn_protocol_client_t* client, cn_protocol_client_state_t state, int send_packets)
@@ -6727,7 +6771,7 @@ static void s_protocol_receive_packets(cn_protocol_client_t* client)
 		}
 
 		uint64_t sequence = ~0u;
-		void* packet_ptr = cn_protocol_packet_open(buffer, sz, &client->connect_token.server_to_client_key, NULL, &client->replay_buffer, &sequence);
+		void* packet_ptr = cn_protocol_packet_open(buffer, sz, &client->connect_token.server_to_client_key, client->packet_allocator, &client->replay_buffer, &sequence);
 		if (!packet_ptr) continue;
 
 		// Handle packet based on client's current state.
@@ -6788,7 +6832,7 @@ static void s_protocol_receive_packets(cn_protocol_client_t* client)
 			} else if (type == CN_PROTOCOL_PACKET_TYPE_DISCONNECT) {
 				//log(CN_LOG_LEVEL_WARNING, "Protocol Client: Received DISCONNECT packet from server.");
 				if (free_packet) {
-					cn_protocol_packet_allocator_free(NULL, (cn_protocol_packet_type_t)type, packet_ptr);
+					cn_protocol_packet_allocator_free(client->packet_allocator, (cn_protocol_packet_type_t)type, packet_ptr);
 					free_packet = 0;
 					packet_ptr = NULL;
 				}
@@ -6802,7 +6846,7 @@ static void s_protocol_receive_packets(cn_protocol_client_t* client)
 		}
 
 		if (free_packet) {
-			cn_protocol_packet_allocator_free(NULL, (cn_protocol_packet_type_t)type, packet_ptr);
+			cn_protocol_packet_allocator_free(client->packet_allocator, (cn_protocol_packet_type_t)type, packet_ptr);
 		}
 
 		if (should_break) {
@@ -6914,11 +6958,11 @@ cn_result_t cn_protocol_client_send(cn_protocol_client_t* client, const void* da
 {
 	if (size < 0) return cn_error_failure("`size` can not be negative.");
 	if (size > CN_PROTOCOL_PACKET_PAYLOAD_MAX) return cn_error_failure("`size` exceeded `CN_PROTOCOL_PACKET_PAYLOAD_MAX`.");
-	cn_protocol_packet_payload_t packet;
-	packet.packet_type = CN_PROTOCOL_PACKET_TYPE_PAYLOAD;
-	packet.payload_size = size;
-	CN_MEMCPY(packet.payload, data, size);
-	s_protocol_client_send(client, &packet);
+	int sz = s_protocol_write_payload_packet(data, size, client->buffer, client->sequence++, &client->connect_token.client_to_server_key);
+	if (sz >= 73) {
+		cn_socket_send(&client->socket, client->sim, s_protocol_server_endpoint(client), client->buffer, sz);
+		client->last_packet_sent_time = 0;
+	}
 	return cn_error_success();
 }
 
@@ -7123,7 +7167,7 @@ cn_protocol_server_t* cn_protocol_server_create(uint64_t application_id, const c
 	server->running = 0;
 	server->application_id = application_id;
 	server->packet_allocator = cn_protocol_packet_allocator_create(mem_ctx);
-	server->event_queue = cn_circular_buffer_create(CN_MB * 10, mem_ctx);
+	server->event_queue = cn_circular_buffer_create(CN_PROTOCOL_EVENT_QUEUE_SIZE, mem_ctx);
 	server->public_key = *public_key;
 	server->secret_key = *secret_key;
 	server->mem_ctx = mem_ctx;
@@ -7292,15 +7336,18 @@ static void s_protocol_server_connect_client(cn_protocol_server_t* server, cn_en
 	}
 	if (index == -1) return;
 
-	server->client_count++;
-	CN_ASSERT(server->client_count < CN_PROTOCOL_SERVER_MAX_CLIENTS);
-
+	// Push the connection event before committing any client state. A failed push (event
+	// queue full) must leave client_count and the slot untouched, or a retrying client
+	// inflates client_count on every attempt without ever occupying a slot.
 	cn_protocol_server_event_t event;
 	event.type = CN_PROTOCOL_SERVER_EVENT_NEW_CONNECTION;
 	event.u.new_connection.client_index = index;
 	event.u.new_connection.client_id = state->client_id;
 	event.u.new_connection.endpoint = endpoint;
 	if (s_protocol_server_event_push(server, &event) < 0) return;
+
+	server->client_count++;
+	CN_ASSERT(server->client_count < CN_PROTOCOL_SERVER_MAX_CLIENTS);
 
 	cn_hashtable_insert(&server->client_id_table, &state->client_id, &index);
 	cn_hashtable_insert(&server->client_endpoint_table, &endpoint, &state->client_id);
@@ -7391,6 +7438,21 @@ static void s_protocol_server_receive_packets(cn_protocol_server_t* server)
 
 			cn_protocol_encryption_state_t* state = cn_protocol_encryption_map_find(&server->encryption_map, from);
 			if (!state) {
+				// Bind this token to a single in-flight handshake. Without this, one valid token
+				// replayed from many spoofed source addresses would each spawn a half-open state
+				// and its own challenge-reflection stream. A legit client resends from the same
+				// endpoint, which finds its state above and never reaches this scan.
+				int existing_count = cn_protocol_encryption_map_count(&server->encryption_map);
+				cn_protocol_encryption_state_t* existing_states = cn_protocol_encryption_map_get_states(&server->encryption_map);
+				int token_pending = 0;
+				for (int j = 0; j < existing_count; ++j) {
+					if (!CN_MEMCMP(existing_states[j].signature.bytes, token.signature.bytes, CN_PROTOCOL_SIGNATURE_SIZE)) {
+						token_pending = 1;
+						break;
+					}
+				}
+				if (token_pending) continue;
+
 				cn_protocol_encryption_state_t encryption_state;
 				encryption_state.sequence = 0;
 				encryption_state.expiration_timestamp = token.expiration_timestamp;
@@ -7401,6 +7463,8 @@ static void s_protocol_server_receive_packets(cn_protocol_server_t* server)
 				encryption_state.server_to_client_key = token.server_to_client_key;
 				encryption_state.client_id = token.client_id;
 				CN_MEMCPY(encryption_state.signature.bytes, token.signature.bytes, CN_PROTOCOL_SIGNATURE_SIZE);
+				encryption_state.challenge_nonce = server->challenge_nonce++;
+				cn_crypto_random_bytes(encryption_state.challenge_data, CN_PROTOCOL_CHALLENGE_DATA_SIZE);
 				cn_protocol_encryption_map_insert(&server->encryption_map, from, &encryption_state);
 				state = cn_protocol_encryption_map_find(&server->encryption_map, from);
 				CN_ASSERT(state);
@@ -7465,6 +7529,12 @@ static void s_protocol_server_receive_packets(cn_protocol_server_t* server)
 			case CN_PROTOCOL_PACKET_TYPE_CHALLENGE_RESPONSE:
 			{
 				CN_ASSERT(!endpoint_already_connected);
+				// Prove the peer received the challenge we sent to its claimed address. A
+				// spoofed source can decrypt nothing it never received, so a mismatched echo
+				// is an unreachable/spoofed address -- drop it before committing any state.
+				cn_protocol_packet_challenge_t* response = (cn_protocol_packet_challenge_t*)packet_ptr;
+				if (response->challenge_nonce != state->challenge_nonce) break;
+				if (!hydro_equal(response->challenge_data, state->challenge_data, CN_PROTOCOL_CHALLENGE_DATA_SIZE)) break;
 				int client_id_already_connected = !!cn_hashtable_find(&server->client_id_table, &state->client_id);
 				if (client_id_already_connected) break;
 				if (server->client_count == CN_PROTOCOL_SERVER_MAX_CLIENTS) {
@@ -7525,8 +7595,8 @@ static void s_protocol_server_send_packets(cn_protocol_server_t* server, double 
 
 			cn_protocol_packet_challenge_t packet;
 			packet.packet_type = CN_PROTOCOL_PACKET_TYPE_CHALLENGE_REQUEST;
-			packet.challenge_nonce = server->challenge_nonce++;
-			cn_crypto_random_bytes(packet.challenge_data, sizeof(packet.challenge_data));
+			packet.challenge_nonce = state->challenge_nonce;
+			CN_MEMCPY(packet.challenge_data, state->challenge_data, CN_PROTOCOL_CHALLENGE_DATA_SIZE);
 
 			if (cn_protocol_packet_write(&packet, buffer, state->sequence++, &state->server_to_client_key) == 264 + 73) {
 				cn_socket_send(the_socket, sim, endpoints[i], buffer, 264 + 73);
@@ -7609,11 +7679,7 @@ cn_result_t cn_protocol_server_send_to_client(cn_protocol_server_t* server, cons
 		}
 	}
 
-	cn_protocol_packet_payload_t payload;
-	payload.packet_type = CN_PROTOCOL_PACKET_TYPE_PAYLOAD;
-	payload.payload_size = size;
-	CN_MEMCPY(payload.payload, packet, size);
-	int sz = cn_protocol_packet_write(&payload, server->buffer, server->client_sequence[index]++, server->client_server_to_client_key + index);
+	int sz = s_protocol_write_payload_packet(packet, size, server->buffer, server->client_sequence[index]++, server->client_server_to_client_key + index);
 	if (sz > 73) {
 		cn_socket_send(&server->socket, server->sim, server->client_endpoint[index], server->buffer, sz);
 		//log(CN_LOG_LEVEL_INFORMATIONAL, "Protocol Server: Sent %s to client %" PRIu64 ".", s_protocol_packet_str(payload.packet_type), server->client_id[index]);
@@ -7650,6 +7716,10 @@ void cn_protocol_server_update(cn_protocol_server_t* server, double dt, uint64_t
 	s_protocol_server_receive_packets(server);
 	s_protocol_server_send_packets(server, dt);
 	s_protocol_server_look_for_timeouts(server);
+	// Expire half-open handshake states. Without this a spoofed connection request creates
+	// an encryption-map entry that never times out, permanently reflecting challenges and
+	// eventually exhausting the map.
+	cn_protocol_encryption_map_look_for_timeouts_or_expirations(&server->encryption_map, dt, current_time);
 }
 
 int cn_protocol_server_client_count(cn_protocol_server_t* server)
@@ -8059,6 +8129,11 @@ typedef struct cn_packet_assembly_t
 static void s_fragment_reassembly_entry_cleanup(void* data, uint16_t sequence, void* udata, void* mem_ctx)
 {
 	cn_fragment_reassembly_entry_t* reassembly = (cn_fragment_reassembly_entry_t*)data;
+	// udata points at the transport's outstanding_reassembly_bytes counter (set in
+	// cn_transport_create). A completed reassembly nulls its packet before removal, but
+	// packet_size still accounts for the reservation being released here.
+	int* outstanding = (int*)udata;
+	if (outstanding) *outstanding -= reassembly->packet_size;
 	CN_FREE(reassembly->packet, mem_ctx);
 	CN_FREE(reassembly->fragment_received, mem_ctx);
 }
@@ -8108,6 +8183,9 @@ typedef struct cn_transport_t
 	uint16_t oldest_received_sequence;
 	cn_packet_assembly_t reliable_and_in_order_assembly;
 	cn_packet_assembly_t fire_and_forget_assembly;
+	// Sum of packet_size across all in-progress reassemblies (both assemblies). Bounds the
+	// memory a peer can force us to allocate by opening many large reassemblies at once.
+	int outstanding_reassembly_bytes;
 
 	void* mem_ctx;
 	void* udata;
@@ -8396,8 +8474,8 @@ void cn_ack_system_update(cn_ack_system_t* ack_system, double dt)
 {
 	ack_system->time += dt;
 	ack_system->packet_loss = s_calc_packet_loss(ack_system->packet_loss, &ack_system->sent_packets);
-	ack_system->incoming_bandwidth_kbps = s_calc_bandwidth(ack_system->incoming_bandwidth_kbps, &ack_system->sent_packets);
-	ack_system->outgoing_bandwidth_kbps = s_calc_bandwidth(ack_system->outgoing_bandwidth_kbps, &ack_system->received_packets);
+	ack_system->incoming_bandwidth_kbps = s_calc_bandwidth(ack_system->incoming_bandwidth_kbps, &ack_system->received_packets);
+	ack_system->outgoing_bandwidth_kbps = s_calc_bandwidth(ack_system->outgoing_bandwidth_kbps, &ack_system->sent_packets);
 }
 
 double cn_ack_system_rtt(cn_ack_system_t* ack_system)
@@ -8451,7 +8529,10 @@ CN_INLINE cn_transport_config_t cn_transport_config_defaults()
 	config.fragment_size = CN_TRANSPORT_MAX_FRAGMENT_SIZE;
 	config.max_packet_size = CN_TRANSPORT_MAX_FRAGMENT_SIZE * 4;
 	config.max_fragments_in_flight = 32;
-	config.max_size_single_send = (CN_MB) * 20;
+	// The largest single reliable message, and also the per-connection reassembly-memory budget
+	// (a peer can pin at most this many bytes of in-flight reassemblies). 2 MiB is generous for a
+	// game protocol; raise it if you genuinely stream larger single messages.
+	config.max_size_single_send = (CN_MB) * 2;
 	config.send_receive_queue_size = 1024;
 	config.udata = NULL;
 	config.index = -1;
@@ -8494,10 +8575,16 @@ cn_transport_t* cn_transport_create(cn_transport_config_t config)
 
 	transport->fragment_id_gen = 0;
 	transport->oldest_received_sequence = 0;
+	transport->outstanding_reassembly_bytes = 0;
 	CN_CHECK(s_packet_assembly_init(&transport->reliable_and_in_order_assembly, config.send_receive_queue_size, transport->mem_ctx));
 	assembly_reliable_init = 1;
 	CN_CHECK(s_packet_assembly_init(&transport->fire_and_forget_assembly, config.send_receive_queue_size, transport->mem_ctx));
 	assembly_unreliable_init = 1;
+	// The reassembly cleanup callback maintains outstanding_reassembly_bytes through the
+	// sequence buffer's udata, which points at the counter itself (the transport struct is
+	// defined after the callback, so the callback can only see a plain int*).
+	transport->reliable_and_in_order_assembly.fragments_received.udata = &transport->outstanding_reassembly_bytes;
+	transport->fire_and_forget_assembly.fragments_received.udata = &transport->outstanding_reassembly_bytes;
 
 	s_send_queue_init(&transport->send_queue);
 
@@ -8515,7 +8602,7 @@ static void s_transport_cleanup_packet_queue(cn_transport_t* transport, cn_packe
 {
 	int index = q->index0;
 	while (q->count--) {
-		int next_index = index + 1 % CN_PACKET_QUEUE_MAX_ENTRIES;
+		int next_index = (index + 1) % CN_PACKET_QUEUE_MAX_ENTRIES;
 		CN_FREE(q->packets[index], transport->mem_ctx);
 		index = next_index;
 	}
@@ -8744,7 +8831,7 @@ void cn_transport_free_packet(cn_transport_t* transport, void* data)
 
 cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, int size)
 {
-	if (size < CN_TRANSPORT_HEADER_SIZE) return cn_error_failure("`size` is too small to fit `CN_TRANSPORT_HEADER_SIZE`.");
+	if (size < CN_ACK_SYSTEM_HEADER_SIZE + CN_TRANSPORT_HEADER_SIZE) return cn_error_failure("`size` is too small to fit the ack-system and transport headers.");
 	cn_result_t result = cn_ack_system_receive_packet(transport->ack_system, data, size);
 	if (cn_is_error(result)) return result;
 
@@ -8762,12 +8849,20 @@ cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, i
 		return cn_error_failure("Packet exceeded `max_size_single_send` limit.");
 	}
 
-	if (fragment_index > fragment_count) {
+	// Valid indices are [0, fragment_count-1]; the '>=' also rejects fragment_count == 0,
+	// which would otherwise index zero-size reassembly allocations below.
+	if (fragment_index >= fragment_count) {
 		return cn_error_failure("Fragment index out of bounds.");
 	}
 
 	if (fragment_size > transport->fragment_size) {
 		return cn_error_failure("Fragment size somehow didn't match `transport->fragment_size`.");
+	}
+
+	// The claimed fragment payload must actually be present in the received bytes, or the
+	// copy below would read stale bytes from the packet buffer into the reassembly.
+	if (fragment_size > size - CN_ACK_SYSTEM_HEADER_SIZE - CN_TRANSPORT_HEADER_SIZE) {
+		return cn_error_failure("Fragment size exceeds the received packet length.");
 	}
 
 	cn_packet_assembly_t* assembly;
@@ -8783,6 +8878,12 @@ cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, i
 	// Build reassembly if it doesn't exist yet.
 	cn_fragment_reassembly_entry_t* reassembly = (cn_fragment_reassembly_entry_t*)cn_sequence_buffer_find(&assembly->fragments_received, fragment_sequence);
 	if (!reassembly) {
+		// Cap the total reassembly memory a peer can pin at once. total_packet_size is already
+		// bounded by max_size_single_send above, so one legitimate max-size send still fits;
+		// this only rejects many concurrent large reassemblies opened to exhaust memory.
+		if (transport->outstanding_reassembly_bytes + total_packet_size > transport->max_size_single_send) {
+			return cn_error_failure("Too many concurrent fragment reassemblies in flight.");
+		}
 		reassembly = (cn_fragment_reassembly_entry_t*)cn_sequence_buffer_insert(&assembly->fragments_received, fragment_sequence, s_fragment_reassembly_entry_cleanup);
 		if (!reassembly) {
 			CN_PRINTF("Sequence for this reassembly is stale.\n");
@@ -8797,6 +8898,7 @@ cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, i
 		reassembly->fragments_total = fragment_count;
 		reassembly->fragment_received = (uint8_t*)CN_ALLOC(fragment_count, transport->mem_ctx);
 		CN_MEMSET(reassembly->fragment_received, 0, fragment_count);
+		transport->outstanding_reassembly_bytes += total_packet_size;
 	}
 
 	if (fragment_count != reassembly->fragments_total) {
@@ -8816,8 +8918,12 @@ cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, i
 
 	if (fragment_index == fragment_count - 1) {
 		reassembly->received_final_fragment = 1;
+		// The last fragment is usually short, so packet_size shrinks from the padded
+		// total_packet_size to the true size. Keep outstanding_reassembly_bytes in step -- the
+		// cleanup callback decrements by the final packet_size, so the reservation must match.
 		reassembly->packet_size -= transport->fragment_size - fragment_size;
 		total_packet_size -= transport->fragment_size - fragment_size;
+		transport->outstanding_reassembly_bytes -= transport->fragment_size - fragment_size;
 	}
 
 	// Store completed packet for retrieval by user.
@@ -8843,6 +8949,9 @@ cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, i
 					if (next->fragment_count_so_far == next->fragments_total) {
 						if (cn_packet_queue_push(&assembly->packets_received, next->packet, next->packet_size) < 0) {
 							result =  cn_error_failure("Packet dropped. The other end is sending too many packets.");
+							// Leave this entry in place and stop draining; retrying at the same
+							// receive_sequence next update would otherwise spin forever here.
+							break;
 						} else {
 							next->packet = NULL;
 							CN_PRINTF("Remove reliable fragment sequence %d.\n", assembly->receive_sequence);
@@ -9124,7 +9233,7 @@ cn_server_t* cn_server_create(cn_server_config_t config)
 	CN_MEMSET(server, 0, sizeof(*server));
 	server->mem_ctx = config.user_allocator_context;
 	server->config = config;
-	server->event_queue = cn_circular_buffer_create(CN_MB * 10, config.user_allocator_context);
+	server->event_queue = cn_circular_buffer_create(CN_PROTOCOL_EVENT_QUEUE_SIZE, config.user_allocator_context);
 	server->p_server = cn_protocol_server_create(config.application_id, &server->config.public_key, &server->config.secret_key, server->mem_ctx);
 
 	return server;
@@ -9328,13 +9437,13 @@ float cn_server_get_rtt_estimate(cn_server_t* server, int client_index)
 float cn_server_get_incoming_kbps_estimate(cn_server_t* server, int client_index)
 {
 	CN_ASSERT(cn_server_is_client_connected(server, client_index));
-	return (float)server->client_transports[client_index]->ack_system->outgoing_bandwidth_kbps;
+	return (float)server->client_transports[client_index]->ack_system->incoming_bandwidth_kbps;
 }
 
 float cn_server_get_outgoing_kbps_estimate(cn_server_t* server, int client_index)
 {
 	CN_ASSERT(cn_server_is_client_connected(server, client_index));
-	return (float)server->client_transports[client_index]->ack_system->incoming_bandwidth_kbps;
+	return (float)server->client_transports[client_index]->ack_system->outgoing_bandwidth_kbps;
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -10584,12 +10693,20 @@ int cn_transport_drop_fragments()
 	return 0;
 }
 
-int cn_send_packet_many_drops_fn(int index, void* packet, int size, void* udata)
+cn_result_t cn_send_packet_many_drops_fn(int index, void* packet, int size, void* udata)
 {
 	cn_test_transport_data_t* data = (cn_test_transport_data_t*)udata;
-	if (rand() % 100 != 0) return 0;
+	if (data->drop_packet) return cn_error_success();
+	// Drop ~30% of packets (deterministic under srand(0)) so the reliable layer must
+	// actually retransmit; forward the rest to the peer transport.
+	if (rand() % 100 < 30) return cn_error_success();
 
-	return 0;
+	if (data->id) {
+		cn_transport_process_packet(data->transport_a, packet, size);
+	} else {
+		cn_transport_process_packet(data->transport_b, packet, size);
+	}
+	return cn_error_success();
 }
 
 CN_TEST_CASE(cn_transport_drop_fragments_reliable_hammer, "Create and send many fragments under extreme packet loss.");
@@ -10604,7 +10721,7 @@ int cn_transport_drop_fragments_reliable_hammer()
 	double dt = 1.0/60.0;
 
 	cn_transport_config_t config = cn_transport_config_defaults();
-	config.send_packet_fn = cn_test_transport_send_packet_fn;
+	config.send_packet_fn = cn_send_packet_many_drops_fn;
 	config.udata = &data_a;
 	cn_transport_t* transport_a = cn_transport_create(config);
 	config.udata = &data_b;
@@ -12216,6 +12333,274 @@ int cn_protocol_client_reconnect()
 }
 
 // -------------------------------------------------------------------------------------------------
+// Adversarial / regression tests for hardened parse and handshake paths. Each targets a specific
+// bug fix; deleting the corresponding guard should make exactly one of these fail.
+
+typedef struct cn_test_capture_t
+{
+	uint8_t frames[8][CN_PROTOCOL_PACKET_SIZE_MAX];
+	int sizes[8];
+	int count;
+} cn_test_capture_t;
+
+cn_result_t cn_test_capture_send_fn(int index, void* packet, int size, void* udata)
+{
+	cn_test_capture_t* cap = (cn_test_capture_t*)udata;
+	if (cap->count < 8) {
+		CN_MEMCPY(cap->frames[cap->count], packet, size);
+		cap->sizes[cap->count] = size;
+		cap->count++;
+	}
+	return cn_error_success();
+}
+
+static cn_result_t s_feed_fresh_transport(uint8_t* buffer, int size)
+{
+	cn_test_capture_t sink;
+	sink.count = 0;
+	cn_transport_config_t rc = cn_transport_config_defaults();
+	rc.send_packet_fn = cn_test_capture_send_fn;
+	rc.udata = &sink;
+	cn_transport_t* rx = cn_transport_create(rc);
+	cn_result_t r = cn_transport_process_packet(rx, buffer, size);
+	cn_transport_destroy(rx);
+	return r;
+}
+
+CN_TEST_CASE(cn_transport_fragment_header_guards, "Malformed fragment headers (index>=count, count==0, size>received) are rejected.");
+int cn_transport_fragment_header_guards()
+{
+	cn_test_capture_t cap;
+	cap.count = 0;
+	cn_transport_config_t config = cn_transport_config_defaults();
+	config.send_packet_fn = cn_test_capture_send_fn;
+	config.udata = &cap;
+	cn_transport_t* sender = cn_transport_create(config);
+
+	int packet_size = CN_TRANSPORT_MAX_FRAGMENT_SIZE + 300; // Forces exactly two fragments.
+	uint8_t* payload = (uint8_t*)CN_ALLOC(packet_size, NULL);
+	CN_MEMSET(payload, 0xAB, packet_size);
+	CN_TEST_CHECK(cn_is_error(cn_transport_send(sender, payload, packet_size, true)));
+	cn_transport_update(sender, 1.0/60.0);
+	CN_TEST_ASSERT(cap.count >= 2);
+
+	uint8_t scratch[CN_PROTOCOL_PACKET_SIZE_MAX];
+
+	// fragment_index == fragment_count (the off-by-one). Header layout after the ack header:
+	// prefix(1) fragment_sequence(2) fragment_count(2) fragment_index(2) fragment_size(2).
+	CN_MEMCPY(scratch, cap.frames[0], cap.sizes[0]);
+	{
+		uint8_t* h = scratch + CN_ACK_SYSTEM_HEADER_SIZE;
+		uint8_t* rp = h + 3; uint16_t count = cn_read_uint16(&rp);
+		uint8_t* wp = h + 5; cn_write_uint16(&wp, count);
+	}
+	CN_TEST_ASSERT(cn_is_error(s_feed_fresh_transport(scratch, cap.sizes[0])));
+
+	// fragment_count == 0 (zero-size reassembly allocation).
+	CN_MEMCPY(scratch, cap.frames[0], cap.sizes[0]);
+	{
+		uint8_t* h = scratch + CN_ACK_SYSTEM_HEADER_SIZE;
+		uint8_t* wp = h + 3; cn_write_uint16(&wp, 0);
+	}
+	CN_TEST_ASSERT(cn_is_error(s_feed_fresh_transport(scratch, cap.sizes[0])));
+
+	// fragment_size claims more than the packet carries (uses the final, smaller fragment so the
+	// value stays <= transport->fragment_size and specifically trips the received-bytes guard).
+	int last = cap.count - 1;
+	CN_MEMCPY(scratch, cap.frames[last], cap.sizes[last]);
+	{
+		uint8_t* h = scratch + CN_ACK_SYSTEM_HEADER_SIZE;
+		uint8_t* wp = h + 7; cn_write_uint16(&wp, (uint16_t)CN_TRANSPORT_MAX_FRAGMENT_SIZE);
+	}
+	CN_TEST_ASSERT(cn_is_error(s_feed_fresh_transport(scratch, cap.sizes[last])));
+
+	// Control: the unpatched final fragment is accepted (it just waits for the rest).
+	CN_MEMCPY(scratch, cap.frames[last], cap.sizes[last]);
+	CN_TEST_ASSERT(!cn_is_error(s_feed_fresh_transport(scratch, cap.sizes[last])));
+
+	CN_FREE(payload, NULL);
+	cn_transport_destroy(sender);
+	return 0;
+}
+
+CN_TEST_CASE(cn_packet_payload_oversized_rejected, "A payload packet whose payload_size field exceeds the packet is rejected, not overflowed.");
+int cn_packet_payload_oversized_rejected()
+{
+	cn_crypto_key_t key = cn_crypto_generate_key();
+	uint64_t sequence = 100;
+	uint8_t buffer[CN_PROTOCOL_PACKET_SIZE_MAX];
+
+	// Frame a payload packet by hand (mirroring cn_protocol_packet_write) so the encrypted
+	// payload_size field can claim far more bytes than are actually present. A valid MAC is
+	// produced because we hold the key, so decrypt succeeds and the size guard is what must reject.
+	uint8_t* buf = buffer;
+	uint8_t* payload = s_protocol_header(&buf, CN_PROTOCOL_PACKET_TYPE_PAYLOAD, sequence);
+	uint8_t* w = payload;
+	cn_write_uint16(&w, 0xFFFF);          // Claim 65535 payload bytes...
+	int real_payload = 16;                // ...but include only 16.
+	cn_crypto_random_bytes(w, real_payload);
+	w += real_payload;
+	int plaintext_size = (int)(w - payload);
+	cn_crypto_encrypt(&key, payload, plaintext_size, sequence);
+	int total = (int)(payload - buffer) + plaintext_size + CN_CRYPTO_HEADER_BYTES;
+
+	void* pk = cn_protocol_packet_open(buffer, total, &key, NULL, NULL, NULL);
+	CN_TEST_ASSERT(pk == NULL);
+
+	return 0;
+}
+
+CN_TEST_CASE(cn_crypto_decrypt_rejects_tampered, "Tampered ciphertext, wrong key, and wrong nonce all fail to decrypt.");
+int cn_crypto_decrypt_rejects_tampered()
+{
+	cn_crypto_key_t k = cn_crypto_generate_key();
+	const char* message_string = "The message.";
+	int message_length = (int)CN_STRLEN(message_string) + 1;
+	int total = message_length + CN_CRYPTO_HEADER_BYTES;
+	uint8_t* buf = (uint8_t*)malloc(total);
+
+	// Tampered ciphertext.
+	CN_MEMCPY(buf, message_string, message_length);
+	cn_crypto_encrypt(&k, buf, message_length, 0);
+	buf[total / 2] ^= 0xFF;
+	CN_TEST_ASSERT(cn_is_error(cn_crypto_decrypt(&k, buf, total, 0)));
+
+	// Wrong key.
+	CN_MEMCPY(buf, message_string, message_length);
+	cn_crypto_encrypt(&k, buf, message_length, 0);
+	cn_crypto_key_t k2 = cn_crypto_generate_key();
+	CN_TEST_ASSERT(cn_is_error(cn_crypto_decrypt(&k2, buf, total, 0)));
+
+	// Wrong nonce (msg_id).
+	CN_MEMCPY(buf, message_string, message_length);
+	cn_crypto_encrypt(&k, buf, message_length, 0);
+	CN_TEST_ASSERT(cn_is_error(cn_crypto_decrypt(&k, buf, total, 1)));
+
+	free(buf);
+	return 0;
+}
+
+CN_TEST_CASE(cn_protocol_server_rejects_wrong_challenge_response, "Server rejects a client whose challenge echo does not match (anti-spoof).");
+int cn_protocol_server_rejects_wrong_challenge_response()
+{
+	cn_crypto_key_t client_to_server_key = cn_crypto_generate_key();
+	cn_crypto_key_t server_to_client_key = cn_crypto_generate_key();
+	cn_crypto_sign_public_t pk;
+	cn_crypto_sign_secret_t sk;
+	cn_crypto_sign_keygen(&pk, &sk);
+
+	const char* endpoints[] = { "[::1]:5000" };
+	uint64_t application_id = 100;
+	uint64_t current_timestamp = 0;
+	uint64_t expiration_timestamp = 1;
+	uint32_t handshake_timeout = 5;
+	uint64_t client_id = 17;
+	uint8_t user_data[CN_PROTOCOL_CONNECT_TOKEN_USER_DATA_SIZE];
+	cn_crypto_random_bytes(user_data, sizeof(user_data));
+
+	uint8_t connect_token[CN_PROTOCOL_CONNECT_TOKEN_SIZE];
+	CN_TEST_CHECK(cn_is_error(cn_generate_connect_token(
+		application_id, current_timestamp, &client_to_server_key, &server_to_client_key,
+		expiration_timestamp, handshake_timeout, sizeof(endpoints)/sizeof(endpoints[0]),
+		endpoints, client_id, user_data, &sk, connect_token)));
+
+	cn_protocol_server_t* server = cn_protocol_server_create(application_id, &pk, &sk, NULL);
+	CN_TEST_CHECK_POINTER(server);
+	cn_protocol_client_t* client = cn_protocol_client_create(0, application_id, true, NULL);
+	CN_TEST_CHECK_POINTER(client);
+	CN_TEST_CHECK(cn_is_error(cn_protocol_server_start(server, "[::1]:5000", 5)));
+	CN_TEST_CHECK(cn_is_error(cn_protocol_client_connect(client, connect_token)));
+
+	int iters = 0;
+	int tampered = 0;
+	while (iters++ < 100) {
+		cn_protocol_client_update(client, 1, 0);
+		cn_protocol_server_update(server, 1, 0);
+		// Keep the server's stored challenge one step ahead of whatever the client last received,
+		// so its (otherwise correct) echo never matches. This exercises the server-side verify;
+		// without it the client would connect.
+		if (cn_protocol_encryption_map_count(&server->encryption_map) > 0) {
+			cn_protocol_encryption_state_t* states = cn_protocol_encryption_map_get_states(&server->encryption_map);
+			states[0].challenge_data[0]++;
+			tampered = 1;
+		}
+		if (cn_protocol_client_get_state(client) <= 0) break;
+		if (cn_protocol_client_get_state(client) == CN_PROTOCOL_CLIENT_STATE_CONNECTED) break;
+	}
+	CN_TEST_ASSERT(tampered);
+	CN_TEST_ASSERT(cn_protocol_server_running(server));
+	CN_TEST_ASSERT(cn_protocol_client_get_state(client) != CN_PROTOCOL_CLIENT_STATE_CONNECTED);
+	CN_TEST_ASSERT(cn_protocol_server_client_count(server) == 0);
+
+	cn_protocol_client_disconnect(client);
+	cn_protocol_client_destroy(client);
+	cn_protocol_server_stop(server);
+	cn_protocol_server_destroy(server);
+	return 0;
+}
+
+CN_TEST_CASE(cn_protocol_connect_token_replay_from_many_endpoints, "One token replayed from many source addresses must not spawn many half-open states.");
+int cn_protocol_connect_token_replay_from_many_endpoints()
+{
+	cn_crypto_key_t client_to_server_key = cn_crypto_generate_key();
+	cn_crypto_key_t server_to_client_key = cn_crypto_generate_key();
+	cn_crypto_sign_public_t pk;
+	cn_crypto_sign_secret_t sk;
+	cn_crypto_sign_keygen(&pk, &sk);
+
+	const char* endpoints[] = { "[::1]:5000" };
+	uint64_t application_id = 100;
+	uint64_t current_timestamp = 0;
+	uint64_t expiration_timestamp = 10;
+	uint32_t handshake_timeout = 5;
+	uint64_t client_id = 17;
+	uint8_t user_data[CN_PROTOCOL_CONNECT_TOKEN_USER_DATA_SIZE];
+	cn_crypto_random_bytes(user_data, sizeof(user_data));
+
+	uint8_t connect_token[CN_PROTOCOL_CONNECT_TOKEN_SIZE];
+	CN_TEST_CHECK(cn_is_error(cn_generate_connect_token(
+		application_id, current_timestamp, &client_to_server_key, &server_to_client_key,
+		expiration_timestamp, handshake_timeout, sizeof(endpoints)/sizeof(endpoints[0]),
+		endpoints, client_id, user_data, &sk, connect_token)));
+
+	cn_protocol_server_t* server = cn_protocol_server_create(application_id, &pk, &sk, NULL);
+	CN_TEST_CHECK_POINTER(server);
+	CN_TEST_CHECK(cn_is_error(cn_protocol_server_start(server, "[::1]:5000", 5)));
+
+	// Several clients on distinct (ephemeral) source ports all present the SAME token.
+	#define CN_REPLAY_CLIENTS 4
+	cn_protocol_client_t* clients[CN_REPLAY_CLIENTS];
+	for (int i = 0; i < CN_REPLAY_CLIENTS; ++i) {
+		clients[i] = cn_protocol_client_create(0, application_id, true, NULL);
+		CN_TEST_CHECK_POINTER(clients[i]);
+		CN_TEST_CHECK(cn_is_error(cn_protocol_client_connect(clients[i], connect_token)));
+	}
+
+	int iters = 0;
+	int max_map = 0;
+	while (iters++ < 100) {
+		for (int i = 0; i < CN_REPLAY_CLIENTS; ++i) cn_protocol_client_update(clients[i], 1, 0);
+		cn_protocol_server_update(server, 1, 0);
+		int c = cn_protocol_encryption_map_count(&server->encryption_map);
+		if (c > max_map) max_map = c;
+	}
+
+	// The token binds to a single in-flight handshake: the map never accumulates one state per
+	// spoofed endpoint, and at most one client ends up connected.
+	CN_TEST_ASSERT(max_map <= 1);
+	CN_TEST_ASSERT(cn_protocol_server_client_count(server) <= 1);
+
+	for (int i = 0; i < CN_REPLAY_CLIENTS; ++i) {
+		cn_protocol_client_disconnect(clients[i]);
+		cn_protocol_client_destroy(clients[i]);
+	}
+	#undef CN_REPLAY_CLIENTS
+	cn_protocol_server_stop(server);
+	cn_protocol_server_destroy(server);
+	return 0;
+}
+
+// -------------------------------------------------------------------------------------------------
 
 int cn_run_tests(int which_test, bool soak)
 {
@@ -12258,16 +12643,18 @@ int cn_run_tests(int which_test, bool soak)
 		CN_TEST_CASE_ENTRY(cn_client_server_sim),
 		CN_TEST_CASE_ENTRY(cn_ack_system_basic),
 		CN_TEST_CASE_ENTRY(cn_transport_basic),
-		CN_TEST_CASE_ENTRY(cn_replay_buffer_duplicate),
 		CN_TEST_CASE_ENTRY(cn_transport_drop_fragments),
 		CN_TEST_CASE_ENTRY(cn_transport_drop_fragments_reliable_hammer),
 		CN_TEST_CASE_ENTRY(cn_transport_send_many_reliables_at_once),
+		CN_TEST_CASE_ENTRY(cn_transport_fragment_header_guards),
 		CN_TEST_CASE_ENTRY(cn_packet_connection_accepted),
 		CN_TEST_CASE_ENTRY(cn_packet_connection_denied),
 		CN_TEST_CASE_ENTRY(cn_packet_keepalive),
 		CN_TEST_CASE_ENTRY(cn_packet_disconnect),
 		CN_TEST_CASE_ENTRY(cn_packet_challenge),
 		CN_TEST_CASE_ENTRY(cn_packet_payload),
+		CN_TEST_CASE_ENTRY(cn_packet_payload_oversized_rejected),
+		CN_TEST_CASE_ENTRY(cn_crypto_decrypt_rejects_tampered),
 		CN_TEST_CASE_ENTRY(cn_protocol_client_server),
 		CN_TEST_CASE_ENTRY(cn_protocol_client_no_server_responses),
 		CN_TEST_CASE_ENTRY(cn_protocol_client_server_list),
@@ -12284,6 +12671,8 @@ int cn_run_tests(int which_test, bool soak)
 		CN_TEST_CASE_ENTRY(cn_protocol_client_server_payloads),
 		CN_TEST_CASE_ENTRY(cn_protocol_multiple_connections_and_payloads),
 		CN_TEST_CASE_ENTRY(cn_protocol_client_reconnect),
+		CN_TEST_CASE_ENTRY(cn_protocol_server_rejects_wrong_challenge_response),
+		CN_TEST_CASE_ENTRY(cn_protocol_connect_token_replay_from_many_endpoints),
 	};
 	
 	int test_count = sizeof(tests) / sizeof(*tests);

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -7,6 +7,7 @@
 
 #include <cute_networking.h>
 #include <cute_alloc.h>
+#include <cute_c_runtime.h>
 
 // This entire file makes no sense for web builds, since web doesn't allow UDP.
 #ifndef CF_EMSCRIPTEN
@@ -15,6 +16,20 @@
 #define CN_ALLOC(size, ctx) cf_alloc(size)
 #define CN_FREE(mem, ctx) cf_free(mem)
 #include <cute/cute_net.h>
+#include <cute/cute_arith.h>
+
+// cute_net is walled off behind the public CF_* API (see cute_networking.h). CF owns its own
+// networking types; the ones below are defined so their layouts match cute_net's, letting this file
+// bridge the two by reinterpret_cast / field copy. These static asserts are the guardrail that
+// keeps the two definitions from ever drifting apart.
+CF_STATIC_ASSERT(CF_CONNECT_TOKEN_SIZE == CN_CONNECT_TOKEN_SIZE, "Must be equal.");
+CF_STATIC_ASSERT(CF_CONNECT_TOKEN_USER_DATA_SIZE == CN_CONNECT_TOKEN_USER_DATA_SIZE, "Must be equal.");
+CF_STATIC_ASSERT(CF_SERVER_MAX_CLIENTS == CN_SERVER_MAX_CLIENTS, "Must be equal.");
+CF_STATIC_ASSERT(sizeof(CF_CryptoKey) == sizeof(cn_crypto_key_t), "Must be equal.");
+CF_STATIC_ASSERT(sizeof(CF_CryptoSignPublic) == sizeof(cn_crypto_sign_public_t), "Must be equal.");
+CF_STATIC_ASSERT(sizeof(CF_CryptoSignSecret) == sizeof(cn_crypto_sign_secret_t), "Must be equal.");
+CF_STATIC_ASSERT(sizeof(CF_Address) == sizeof(cn_endpoint_t), "Must be equal.");
+CF_STATIC_ASSERT(sizeof(CF_ServerEvent) == sizeof(cn_server_event_t), "Must be equal.");
 
 static CF_INLINE CF_Result cf_wrap(cn_result_t cn_result)
 {
@@ -24,27 +39,28 @@ static CF_INLINE CF_Result cf_wrap(cn_result_t cn_result)
 	return result;
 }
 
-CF_STATIC_ASSERT(CF_CONNECT_TOKEN_SIZE == CN_CONNECT_TOKEN_SIZE, "Must be equal.");
-CF_STATIC_ASSERT(CF_CONNECT_TOKEN_USER_DATA_SIZE == CN_CONNECT_TOKEN_USER_DATA_SIZE, "Must be equal.");
+// Layout-compatible reinterpretations across the wall.
+static CF_INLINE cn_endpoint_t cf_to_cn_endpoint(CF_Address a) { cn_endpoint_t e; CF_MEMCPY(&e, &a, sizeof(e)); return e; }
+static CF_INLINE CF_CryptoKey cf_from_cn_key(cn_crypto_key_t k) { CF_CryptoKey out; CF_MEMCPY(&out, &k, sizeof(out)); return out; }
 
-int cf_address_init(CF_Address* endpoint, const char* address_and_port_string)
+int cf_address_init(CF_Address* address, const char* address_and_port_string)
 {
-	return cn_endpoint_init(endpoint, address_and_port_string);
+	return cn_endpoint_init((cn_endpoint_t*)address, address_and_port_string);
 }
 
-void cf_address_to_string(CF_Address endpoint, char* buffer, int buffer_size)
+void cf_address_to_string(CF_Address address, char* buffer, int buffer_size)
 {
-	cn_endpoint_to_string(endpoint, buffer, buffer_size);
+	cn_endpoint_to_string(cf_to_cn_endpoint(address), buffer, buffer_size);
 }
 
-int cf_address_equals(CF_Address a, CF_Address b)
+bool cf_address_equals(CF_Address a, CF_Address b)
 {
-	return cn_endpoint_equals(a, b);
+	return cn_endpoint_equals(cf_to_cn_endpoint(a), cf_to_cn_endpoint(b)) != 0;
 }
 
 CF_CryptoKey cf_crypto_generate_key()
 {
-	return cn_crypto_generate_key();
+	return cf_from_cn_key(cn_crypto_generate_key());
 }
 
 void cf_crypto_random_bytes(void* data, int byte_count)
@@ -54,7 +70,7 @@ void cf_crypto_random_bytes(void* data, int byte_count)
 
 void cf_crypto_sign_keygen(CF_CryptoSignPublic* public_key, CF_CryptoSignSecret* secret_key)
 {
-	cn_crypto_sign_keygen(public_key, secret_key);
+	cn_crypto_sign_keygen((cn_crypto_sign_public_t*)public_key, (cn_crypto_sign_secret_t*)secret_key);
 }
 
 CF_Result cf_generate_connect_token(
@@ -75,15 +91,15 @@ CF_Result cf_generate_connect_token(
 	cn_result_t result = cn_generate_connect_token(
 		application_id,
 		creation_timestamp,
-		client_to_server_key,
-		server_to_client_key,
+		(const cn_crypto_key_t*)client_to_server_key,
+		(const cn_crypto_key_t*)server_to_client_key,
 		expiration_timestamp,
 		handshake_timeout,
 		address_count,
 		address_list,
 		client_id,
 		user_data,
-		shared_secret_key,
+		(const cn_crypto_sign_secret_t*)shared_secret_key,
 		token_ptr_out);
 	return cf_wrap(result);
 }
@@ -94,122 +110,187 @@ CF_Client* cf_make_client(
 	bool use_ipv6 /* = false */
 )
 {
-	return cn_client_create(port, application_id, use_ipv6, NULL);
+	return (CF_Client*)cn_client_create(port, application_id, use_ipv6, NULL);
 }
 
 void cf_destroy_client(CF_Client* client)
 {
-	cn_client_destroy(client);
+	cn_client_destroy((cn_client_t*)client);
 }
 
 CF_Result cf_client_connect(CF_Client* client, const uint8_t* connect_token)
 {
-	return cf_wrap(cn_client_connect(client, connect_token));
+	return cf_wrap(cn_client_connect((cn_client_t*)client, connect_token));
 }
 
 void cf_client_disconnect(CF_Client* client)
 {
-	cn_client_disconnect(client);
+	cn_client_disconnect((cn_client_t*)client);
 }
 
 void cf_client_update(CF_Client* client, double dt, uint64_t current_time)
 {
-	cn_client_update(client, dt, current_time);
+	cn_client_update((cn_client_t*)client, dt, current_time);
 }
 
 bool cf_client_pop_packet(CF_Client* client, void** packet, int* size, bool* was_sent_reliably /* = NULL */)
 {
-	return cn_client_pop_packet(client, packet, size, was_sent_reliably);
+	return cn_client_pop_packet((cn_client_t*)client, packet, size, was_sent_reliably);
 }
 
 void cf_client_free_packet(CF_Client* client, void* packet)
 {
-	cn_client_free_packet(client, packet);
+	cn_client_free_packet((cn_client_t*)client, packet);
 }
 
 CF_Result cf_client_send(CF_Client* client, const void* packet, int size, bool send_reliably)
 {
-	return cf_wrap(cn_client_send(client, packet, size, send_reliably));
+	return cf_wrap(cn_client_send((cn_client_t*)client, packet, size, send_reliably));
 }
 
-CF_ClientState cf_client_state_get(const CF_Client* client)
+CF_ClientState cf_client_state(const CF_Client* client)
 {
-	return (CF_ClientState)cn_client_state_get(client);
+	return (CF_ClientState)cn_client_state_get((cn_client_t*)client);
+}
+
+float cf_client_rtt(CF_Client* client)
+{
+	return cn_client_get_rtt_estimate((cn_client_t*)client);
+}
+
+float cf_client_packet_loss(CF_Client* client)
+{
+	return cn_client_get_packet_loss_estimate((cn_client_t*)client);
+}
+
+float cf_client_incoming_kbps(CF_Client* client)
+{
+	return cn_client_get_incoming_kbps_estimate((cn_client_t*)client);
+}
+
+float cf_client_outgoing_kbps(CF_Client* client)
+{
+	return cn_client_get_outgoing_kbps_estimate((cn_client_t*)client);
 }
 
 void cf_client_enable_network_simulator(CF_Client* client, double latency, double jitter, double drop_chance, double duplicate_chance)
 {
-	cn_client_enable_network_simulator(client, latency, jitter, drop_chance, duplicate_chance);
+	cn_client_enable_network_simulator((cn_client_t*)client, latency, jitter, drop_chance, duplicate_chance);
 }
 
 //--------------------------------------------------------------------------------------------------
 // SERVER
 
-CF_STATIC_ASSERT(CF_SERVER_MAX_CLIENTS == CN_SERVER_MAX_CLIENTS, "Must be equal.");
-
 CF_Server* cf_make_server(CF_ServerConfig config)
 {
 	cn_server_config_t cn_config;
 	cn_config.application_id = config.application_id;
-	cn_config.max_incoming_bytes_per_second = config.max_incoming_bytes_per_second;
-	cn_config.max_outgoing_bytes_per_second = config.max_outgoing_bytes_per_second;
+	cn_config.max_incoming_bytes_per_second = 0;
+	cn_config.max_outgoing_bytes_per_second = 0;
 	cn_config.connection_timeout = config.connection_timeout;
 	cn_config.resend_rate = config.resend_rate;
-	cn_config.public_key = config.public_key;
-	cn_config.secret_key = config.secret_key;
+	CF_MEMCPY(&cn_config.public_key, &config.public_key, sizeof(cn_config.public_key));
+	CF_MEMCPY(&cn_config.secret_key, &config.secret_key, sizeof(cn_config.secret_key));
 	cn_config.user_allocator_context = NULL;
-	return cn_server_create(cn_config);
+	return (CF_Server*)cn_server_create(cn_config);
 }
 
 void cf_destroy_server(CF_Server* server)
 {
-	cn_server_destroy(server);
+	cn_server_destroy((cn_server_t*)server);
 }
 
 CF_Result cf_server_start(CF_Server* server, const char* address_and_port)
 {
-	return cf_wrap(cn_server_start(server, address_and_port));
+	return cf_wrap(cn_server_start((cn_server_t*)server, address_and_port));
 }
 
 void cf_server_stop(CF_Server* server)
 {
-	return cn_server_stop(server);
+	cn_server_stop((cn_server_t*)server);
 }
 
-CF_STATIC_ASSERT(sizeof(CF_ServerEvent) == sizeof(cn_server_event_t), "Must be equal.");
+void cf_server_set_public_ip(CF_Server* server, const char* address_and_port)
+{
+	cn_server_set_public_ip((cn_server_t*)server, address_and_port);
+}
 
 bool cf_server_pop_event(CF_Server* server, CF_ServerEvent* event)
 {
-	return cn_server_pop_event(server, (cn_server_event_t*)event);
+	return cn_server_pop_event((cn_server_t*)server, (cn_server_event_t*)event);
 }
 
 void cf_server_free_packet(CF_Server* server, int client_index, void* data)
 {
-	cn_server_free_packet(server, client_index, data);
+	cn_server_free_packet((cn_server_t*)server, client_index, data);
 }
 
 void cf_server_update(CF_Server* server, double dt, uint64_t current_time)
 {
-	cn_server_update(server, dt, current_time);
+	cn_server_update((cn_server_t*)server, dt, current_time);
 }
 
 void cf_server_disconnect_client(CF_Server* server, int client_index, bool notify_client /* = true */)
 {
-	cn_server_disconnect_client(server, client_index, notify_client);
+	cn_server_disconnect_client((cn_server_t*)server, client_index, notify_client);
 }
 
-void cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably)
+CF_Result cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably)
 {
-	cn_server_send(server, packet, size, client_index, send_reliably);
+	return cf_wrap(cn_server_send((cn_server_t*)server, packet, size, client_index, send_reliably));
 }
+
+void cf_server_send_to_all(CF_Server* server, const void* packet, int size, bool send_reliably)
+{
+	cn_server_t* s = (cn_server_t*)server;
+	for (int i = 0; i < CF_SERVER_MAX_CLIENTS; ++i) {
+		if (cn_server_is_client_connected(s, i)) {
+			cn_server_send(s, packet, size, i, send_reliably);
+		}
+	}
+}
+
 bool cf_server_is_client_connected(CF_Server* server, int client_index)
 {
-	return cn_server_is_client_connected(server, client_index);
+	return cn_server_is_client_connected((cn_server_t*)server, client_index);
+}
+
+float cf_server_rtt(CF_Server* server, int client_index)
+{
+	return cn_server_get_rtt_estimate((cn_server_t*)server, client_index);
+}
+
+float cf_server_packet_loss(CF_Server* server, int client_index)
+{
+	return cn_server_get_packet_loss_estimate((cn_server_t*)server, client_index);
+}
+
+float cf_server_incoming_kbps(CF_Server* server, int client_index)
+{
+	return cn_server_get_incoming_kbps_estimate((cn_server_t*)server, client_index);
+}
+
+float cf_server_outgoing_kbps(CF_Server* server, int client_index)
+{
+	return cn_server_get_outgoing_kbps_estimate((cn_server_t*)server, client_index);
 }
 
 void cf_server_enable_network_simulator(CF_Server* server, double latency, double jitter, double drop_chance, double duplicate_chance)
 {
-	cn_server_enable_network_simulator(server, latency, jitter, drop_chance, duplicate_chance);
+	cn_server_enable_network_simulator((cn_server_t*)server, latency, jitter, drop_chance, duplicate_chance);
+}
+
+//--------------------------------------------------------------------------------------------------
+// COMPRESSION
+
+int cf_snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity)
+{
+	return cf_arith_delta_compress((const uint8_t*)baseline, (const uint8_t*)current, size, (uint8_t*)out, out_capacity);
+}
+
+int cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out)
+{
+	return cf_arith_delta_decompress((const uint8_t*)baseline, size, (const uint8_t*)compressed, compressed_size, (uint8_t*)out);
 }
 
 #endif // CF_EMSCRIPTEN


### PR DESCRIPTION
Security + correctness hardening of cute_net (4 verified criticals: payload_size heap overflow, fragment-index off-by-one, immortal spoofed handshake states, unverified challenge echo; plus highs/mediums), walls cute_net behind CF-owned networking types, and adds cute_arith.h (adaptive range coder) with cf_snapshot_compress/decompress delta compression. cute_net self-tests 54/54; adversarial regression tests added. CI green on all platforms.