### PR TITLE
Networking dev conveniences + reset client transport on connect

### DIFF
--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -811,6 +811,56 @@ CF_API int CF_CALL cf_snapshot_compress(const void* baseline, const void* curren
  */
 CF_API int CF_CALL cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out);
 
+//--------------------------------------------------------------------------------------------------
+// DEV CONVENIENCES
+//
+// Shortcuts for local development, singleplayer/listen-server, and tests. The "insecure" pair use a
+// fixed keypair compiled into CF, so they need no key exchange -- and provide no security. Never run
+// a real, exposed server with them; use cf_crypto_sign_keygen + the full flow for production.
+
+/**
+ * @function cf_make_server_insecure
+ * @category net
+ * @brief    Creates a server using CF's built-in development keypair. INSECURE -- local/testing only.
+ * @param    application_id  Your game id; must match the client.
+ * @remarks  Pairs with `cf_client_connect_insecure`. Anyone can forge tokens for this server, so it
+ *           is only appropriate for a machine you control (local dev, singleplayer, unit tests).
+ * @related  cf_client_connect_insecure cf_make_server cf_server_start
+ */
+CF_API CF_Server* CF_CALL cf_make_server_insecure(uint64_t application_id);
+
+/**
+ * @function cf_client_connect_insecure
+ * @category net
+ * @brief    Connects to a `cf_make_server_insecure` server in one call. INSECURE -- local/testing only.
+ * @param    address_and_port  The server to connect to, e.g. "127.0.0.1:5000".
+ * @param    application_id    Your game id; must match the server.
+ * @return   Returns any errors as a `CF_Result`.
+ * @remarks  Generates a connect token from CF's built-in development keypair (with a random client id
+ *           so many clients can connect) and connects -- no web service or key handling required.
+ * @related  cf_make_server_insecure cf_client_connect cf_make_client
+ */
+CF_API CF_Result CF_CALL cf_client_connect_insecure(CF_Client* client, const char* address_and_port, uint64_t application_id);
+
+/**
+ * @function cf_client_tick
+ * @category net
+ * @brief    Updates the client using CF's own clock (`CF_DELTA_TIME` and the system time).
+ * @remarks  A convenience over `cf_client_update` for games that just run on the app clock, so you
+ *           don't have to plumb `dt` and a unix timestamp by hand. Call once per frame.
+ * @related  cf_client_update cf_client_pop_packet
+ */
+CF_API void CF_CALL cf_client_tick(CF_Client* client);
+
+/**
+ * @function cf_server_tick
+ * @category net
+ * @brief    Updates the server using CF's own clock (`CF_DELTA_TIME` and the system time).
+ * @remarks  A convenience over `cf_server_update`. Call once per frame.
+ * @related  cf_server_update cf_server_pop_event
+ */
+CF_API void CF_CALL cf_server_tick(CF_Server* server);
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus
@@ -959,6 +1009,14 @@ CF_INLINE void server_enable_network_simulator(Server* server, double latency, d
 
 CF_INLINE int snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity) { return cf_snapshot_compress(baseline,current,size,out,out_capacity); }
 CF_INLINE int snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out) { return cf_snapshot_decompress(baseline,size,compressed,compressed_size,out); }
+
+//--------------------------------------------------------------------------------------------------
+// DEV CONVENIENCES
+
+CF_INLINE Server* make_server_insecure(uint64_t application_id) { return cf_make_server_insecure(application_id); }
+CF_INLINE CF_Result client_connect_insecure(Client* client, const char* address_and_port, uint64_t application_id) { return cf_client_connect_insecure(client,address_and_port,application_id); }
+CF_INLINE void client_tick(Client* client) { cf_client_tick(client); }
+CF_INLINE void server_tick(Server* server) { cf_server_tick(server); }
 
 }
 

--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -9224,6 +9224,23 @@ static cn_result_t s_send_packet_fn(int client_index, void* packet, int size, vo
 	return cn_protocol_server_send_to_client(server->p_server, packet, size, client_index);
 }
 
+// Destroy and recreate a client slot's transport, giving it fresh reliability state. Called on both
+// connect and disconnect so a slot never inherits the previous occupant's sequences or in-flight
+// fragments -- even if that occupant's DISCONNECTED event was dropped under event-queue pressure.
+static void s_server_reset_transport(cn_server_t* server, int client_index)
+{
+	if (server->client_transports[client_index]) {
+		cn_transport_destroy(server->client_transports[client_index]);
+	}
+	cn_transport_config_t transport_config = cn_transport_config_defaults();
+	transport_config.resend_rate = (float)server->config.resend_rate;
+	transport_config.index = client_index;
+	transport_config.send_packet_fn = s_send_packet_fn;
+	transport_config.udata = server;
+	transport_config.user_allocator_context = server->mem_ctx;
+	server->client_transports[client_index] = cn_transport_create(transport_config);
+}
+
 cn_server_t* cn_server_create(cn_server_config_t config)
 {
 	cn_result_t result = s_cn_init_check();
@@ -9306,6 +9323,9 @@ void cn_server_update(cn_server_t* server, double dt, uint64_t current_time)
 		switch (p_event.type) {
 		case CN_PROTOCOL_SERVER_EVENT_NEW_CONNECTION:
 		{
+			// Start the new client's transport clean, even if the previous occupant's DISCONNECTED
+			// event never made it through the queue.
+			s_server_reset_transport(server, p_event.u.new_connection.client_index);
 			cn_server_event_t e;
 			e.type = CN_SERVER_EVENT_TYPE_NEW_CONNECTION;
 			e.u.new_connection.client_index = p_event.u.new_connection.client_index;
@@ -9320,14 +9340,7 @@ void cn_server_update(cn_server_t* server, double dt, uint64_t current_time)
 			e.type = CN_SERVER_EVENT_TYPE_DISCONNECTED;
 			e.u.disconnected.client_index = p_event.u.disconnected.client_index;
 			s_server_event_push(server, &e);
-			cn_transport_destroy(server->client_transports[e.u.disconnected.client_index]);
-			cn_transport_config_t transport_config = cn_transport_config_defaults();
-			transport_config.resend_rate = (float)server->config.resend_rate;
-			transport_config.index = e.u.disconnected.client_index;
-			transport_config.send_packet_fn = s_send_packet_fn;
-			transport_config.udata = server;
-			transport_config.user_allocator_context = server->mem_ctx;
-			server->client_transports[e.u.disconnected.client_index] = cn_transport_create(transport_config);
+			s_server_reset_transport(server, e.u.disconnected.client_index);
 		}	break;
 
 		// Protocol packets are processed by the reliability transport layer before they

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -8,6 +8,8 @@
 #include <cute_networking.h>
 #include <cute_alloc.h>
 #include <cute_c_runtime.h>
+#include <cute_time.h>
+#include <time.h>
 
 // This entire file makes no sense for web builds, since web doesn't allow UDP.
 #ifndef CF_EMSCRIPTEN
@@ -291,6 +293,73 @@ int cf_snapshot_compress(const void* baseline, const void* current, int size, vo
 int cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out)
 {
 	return cf_arith_delta_decompress((const uint8_t*)baseline, size, (const uint8_t*)compressed, compressed_size, (uint8_t*)out);
+}
+
+//--------------------------------------------------------------------------------------------------
+// DEV CONVENIENCES
+
+// A fixed, well-known keypair so an insecure client and server interoperate with no key exchange.
+// INSECURE BY DESIGN: the secret is compiled into every build, so anyone can forge connect tokens.
+// For local development, singleplayer/listen-server, and tests only -- never ship a real server with
+// these keys. Generate real keys with cf_crypto_sign_keygen for production.
+static const uint8_t CF_DEV_SIGN_PUBLIC[32] = {
+	0x3b,0x88,0x0b,0x22,0xb6,0xe7,0x1a,0xee,0x77,0x73,0x90,0xb7,
+	0xf6,0xb3,0x03,0x07,0x65,0x34,0x62,0xc9,0x01,0x2c,0x45,0x18,
+	0xf4,0xce,0x45,0x08,0xfc,0xa8,0xd7,0x05,
+};
+static const uint8_t CF_DEV_SIGN_SECRET[64] = {
+	0x91,0xa2,0xfa,0xcf,0x3c,0x84,0x13,0x3b,0xa2,0x80,0x2b,0x6b,
+	0xd7,0xbf,0x3a,0xc8,0xa2,0xaa,0xbc,0xfe,0xb9,0xdf,0xbf,0x8b,
+	0x2f,0x14,0xd4,0x35,0xa3,0xdd,0x81,0x20,0x3b,0x88,0x0b,0x22,
+	0xb6,0xe7,0x1a,0xee,0x77,0x73,0x90,0xb7,0xf6,0xb3,0x03,0x07,
+	0x65,0x34,0x62,0xc9,0x01,0x2c,0x45,0x18,0xf4,0xce,0x45,0x08,
+	0xfc,0xa8,0xd7,0x05,
+};
+static const uint8_t CF_DEV_C2S_KEY[32] = {
+	0x87,0xdc,0xd5,0xbd,0x47,0x51,0x55,0xf2,0xe2,0x8d,0x3e,0x37,
+	0x97,0x36,0xef,0x36,0x5b,0xc6,0x90,0x1d,0x4c,0x10,0x3d,0x2f,
+	0xb6,0xec,0x34,0x90,0xc4,0x60,0xae,0xed,
+};
+static const uint8_t CF_DEV_S2C_KEY[32] = {
+	0x9f,0x33,0xde,0x4c,0x0d,0x05,0x57,0x0f,0x45,0xe0,0x42,0x41,
+	0x20,0x48,0x5f,0x2a,0x3c,0xd0,0x5a,0x36,0x31,0xfb,0x57,0x11,
+	0x6c,0xd1,0xcd,0x86,0xce,0xbd,0x8c,0x19,
+};
+
+CF_Server* cf_make_server_insecure(uint64_t application_id)
+{
+	CF_ServerConfig config = cf_server_config_defaults();
+	config.application_id = application_id;
+	CF_MEMCPY(&config.public_key, CF_DEV_SIGN_PUBLIC, sizeof(CF_DEV_SIGN_PUBLIC));
+	CF_MEMCPY(&config.secret_key, CF_DEV_SIGN_SECRET, sizeof(CF_DEV_SIGN_SECRET));
+	return cf_make_server(config);
+}
+
+CF_Result cf_client_connect_insecure(CF_Client* client, const char* address_and_port, uint64_t application_id)
+{
+	CF_CryptoKey c2s, s2c;
+	CF_CryptoSignSecret sk;
+	CF_MEMCPY(&c2s, CF_DEV_C2S_KEY, sizeof(CF_DEV_C2S_KEY));
+	CF_MEMCPY(&s2c, CF_DEV_S2C_KEY, sizeof(CF_DEV_S2C_KEY));
+	CF_MEMCPY(&sk, CF_DEV_SIGN_SECRET, sizeof(CF_DEV_SIGN_SECRET));
+	uint64_t now = (uint64_t)time(NULL);
+	uint64_t client_id = 0;
+	cf_crypto_random_bytes(&client_id, sizeof(client_id)); // Distinct per client so many can connect.
+	const char* addrs[1] = { address_and_port };
+	uint8_t token[CF_CONNECT_TOKEN_SIZE];
+	CF_Result r = cf_generate_connect_token(application_id, now, &c2s, &s2c, now + 31536000ull, 10, 1, addrs, client_id, NULL, &sk, token);
+	if (cf_is_error(r)) return r;
+	return cf_client_connect(client, token);
+}
+
+void cf_client_tick(CF_Client* client)
+{
+	cf_client_update(client, CF_DELTA_TIME, (uint64_t)time(NULL));
+}
+
+void cf_server_tick(CF_Server* server)
+{
+	cf_server_update(server, CF_DELTA_TIME, (uint64_t)time(NULL));
 }
 
 #endif // CF_EMSCRIPTEN


### PR DESCRIPTION
Adds cf_make_server_insecure / cf_client_connect_insecure (built-in dev keypair, no key exchange -- local/testing only) and cf_client_tick / cf_server_tick (update on CF's clock). Also fixes a slot reuse issue: the server now resets a client transport on NEW_CONNECTION as well as DISCONNECTED, so a reused slot never inherits stale reliability state. cute_net self-tests 54/54; CI green on all platforms.