### PR TITLE
net: prioritized message channels + standalone ack packets

### DIFF
--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -772,6 +772,176 @@ CF_API float CF_CALL cf_server_outgoing_kbps(CF_Server* server, int client_index
 CF_API void CF_CALL cf_server_enable_network_simulator(CF_Server* server, double latency, double jitter, double drop_chance, double duplicate_chance);
 
 //--------------------------------------------------------------------------------------------------
+// MESSAGES + CHANNELS
+//
+// Small user messages routed over prioritized channels, layered above raw packets. Each message
+// carries a user id (a type tag, e.g. "chat" or "jump") and is queued on one of a handful of
+// channels. Every update the queues are pumped into the transport highest-priority channel first,
+// under an optional bytes-per-second budget -- so bulk low-priority traffic (asset blobs, big state
+// dumps) waits its turn locally instead of flooding the send queue and delaying urgent messages.
+// Reliability is per channel: a reliable channel delivers every message in order (per channel,
+// FIFO); an unreliable one may drop messages entirely under loss, but never corrupts or reorders
+// what arrives. Small messages queued together on a channel are coalesced into a single packet.
+//
+// Note the budget only orders and throttles LOCAL queueing. Everything still crosses the wire on
+// the one underlying connection, so a reliable retransmit storm can still delay unreliable packets
+// at the socket -- channels keep your own bulk sends from being the cause of that.
+
+/**
+ * @function CF_NET_MAX_CHANNELS
+ * @category net
+ * @brief    The number of message channels available, indexed 0 to `CF_NET_MAX_CHANNELS - 1`.
+ * @related  cf_client_channel_options cf_client_send_msg cf_server_send_msg
+ */
+#define CF_NET_MAX_CHANNELS 8
+
+/**
+ * @function CF_NET_MAX_MSG_SIZE
+ * @category net
+ * @brief    The largest single message that may be sent on a channel, in bytes.
+ * @remarks  Large messages are fragmented and reassembled by the transport automatically. For bulk
+ *           data, prefer a low-priority channel with a send rate set, so the fragments trickle out
+ *           without starving urgent traffic.
+ * @related  cf_client_send_msg cf_server_send_msg cf_client_set_send_rate
+ */
+#define CF_NET_MAX_MSG_SIZE (1024 * 1024)
+
+/**
+ * @function cf_client_channel_options
+ * @category net
+ * @brief    Configures one of the client's outgoing message channels.
+ * @param    client       The client.
+ * @param    channel      Which channel, from 0 to `CF_NET_MAX_CHANNELS - 1`.
+ * @param    priority     Channels with higher priority are pumped over the wire first each update. Default 0.
+ * @param    reliable     If `true` every message on this channel arrives, in order. If `false` messages
+ *                        may be lost under packet loss (but never corrupted or reordered). Default `false`.
+ * @remarks  Configure channels once, right after creating the client. Changing reliability while
+ *           messages are queued applies to messages not yet sent.
+ * @related  cf_client_send_msg cf_client_set_send_rate cf_server_channel_options
+ */
+CF_API void CF_CALL cf_client_channel_options(CF_Client* client, int channel, int priority, bool reliable);
+
+/**
+ * @function cf_client_set_send_rate
+ * @category net
+ * @brief    Caps how many queued message bytes the client pumps into the transport per second.
+ * @param    client            The client.
+ * @param    bytes_per_second  The budget. 0 (the default) means unlimited.
+ * @remarks  The budget is what makes priorities matter: when messages are queued faster than the
+ *           budget drains them, high-priority channels keep flowing while bulk waits locally. A
+ *           message larger than one second's budget still sends, going into "debt" that throttles
+ *           later sends. Raw `cf_client_send` packets bypass the budget entirely.
+ * @related  cf_client_channel_options cf_client_send_msg cf_server_set_send_rate
+ */
+CF_API void CF_CALL cf_client_set_send_rate(CF_Client* client, int bytes_per_second);
+
+/**
+ * @function cf_client_send_msg
+ * @category net
+ * @brief    Queues a message to the server on a channel.
+ * @param    client   The client.
+ * @param    channel  Which channel carries it, from 0 to `CF_NET_MAX_CHANNELS - 1`.
+ * @param    id       A user-defined type tag delivered along with the bytes (e.g. an enum of your game's message kinds).
+ * @param    data     The message bytes. May be `NULL` when `size` is 0 -- an id alone is a fine message.
+ * @param    size     Size of `data` in bytes, up to `CF_NET_MAX_MSG_SIZE`.
+ * @return   Returns an error if the message is oversized or the channel's local queue is full (the
+ *           queue drains each `cf_client_update`, paced by `cf_client_set_send_rate`).
+ * @remarks  The bytes are copied; `data` may be reused immediately. Messages go over the wire during
+ *           `cf_client_update`, highest-priority channel first. The server receives them with
+ *           `cf_server_pop_msg`.
+ * @related  cf_client_pop_msg cf_client_channel_options cf_client_set_send_rate cf_server_pop_msg
+ */
+CF_API CF_Result CF_CALL cf_client_send_msg(CF_Client* client, int channel, uint32_t id, const void* data, int size);
+
+/**
+ * @function cf_client_pop_msg
+ * @category net
+ * @brief    Pops the next message received from the server, if any.
+ * @param    client   The client.
+ * @param    id       The message's user id.
+ * @param    data     Pointer to the message bytes. Free it with `cf_client_free_msg`.
+ * @param    size     Size of `data` in bytes.
+ * @return   Returns `true` when a message was popped.
+ * @remarks  Incoming messages surface here as `cf_client_pop_packet` drains arriving packets, so
+ *           keep popping packets each update like normal (even if you only ever use messages).
+ * @related  cf_client_free_msg cf_server_send_msg cf_client_send_msg
+ */
+CF_API bool CF_CALL cf_client_pop_msg(CF_Client* client, uint32_t* id, void** data, int* size);
+
+/**
+ * @function cf_client_free_msg
+ * @category net
+ * @brief    Frees a message from `cf_client_pop_msg`.
+ * @related  cf_client_pop_msg cf_server_free_msg
+ */
+CF_API void CF_CALL cf_client_free_msg(CF_Client* client, void* data);
+
+/**
+ * @function cf_server_channel_options
+ * @category net
+ * @brief    Configures one of the server's outgoing message channels (applies to every client).
+ * @param    server       The server.
+ * @param    channel      Which channel, from 0 to `CF_NET_MAX_CHANNELS - 1`.
+ * @param    priority     Channels with higher priority are pumped over the wire first each update. Default 0.
+ * @param    reliable     If `true` every message on this channel arrives, in order. If `false` messages
+ *                        may be lost under packet loss (but never corrupted or reordered). Default `false`.
+ * @related  cf_server_send_msg cf_server_set_send_rate cf_client_channel_options
+ */
+CF_API void CF_CALL cf_server_channel_options(CF_Server* server, int channel, int priority, bool reliable);
+
+/**
+ * @function cf_server_set_send_rate
+ * @category net
+ * @brief    Caps how many queued message bytes the server pumps per second, per client.
+ * @param    server            The server.
+ * @param    bytes_per_second  The budget, applied to each client's queues independently. 0 (the default) means unlimited.
+ * @related  cf_server_channel_options cf_server_send_msg cf_client_set_send_rate
+ */
+CF_API void CF_CALL cf_server_set_send_rate(CF_Server* server, int bytes_per_second);
+
+/**
+ * @function cf_server_send_msg
+ * @category net
+ * @brief    Queues a message to one client on a channel.
+ * @param    server        The server.
+ * @param    client_index  An index representing a particular client, from `CF_ServerEvent`.
+ * @param    channel       Which channel carries it, from 0 to `CF_NET_MAX_CHANNELS - 1`.
+ * @param    id            A user-defined type tag delivered along with the bytes.
+ * @param    data          The message bytes. May be `NULL` when `size` is 0.
+ * @param    size          Size of `data` in bytes, up to `CF_NET_MAX_MSG_SIZE`.
+ * @return   Returns an error if the message is oversized, the client is not connected, or that
+ *           client's channel queue is full (queues drain each `cf_server_update`).
+ * @remarks  The bytes are copied; `data` may be reused immediately. The client receives them with
+ *           `cf_client_pop_msg`.
+ * @related  cf_server_pop_msg cf_server_channel_options cf_server_set_send_rate cf_client_pop_msg
+ */
+CF_API CF_Result CF_CALL cf_server_send_msg(CF_Server* server, int client_index, int channel, uint32_t id, const void* data, int size);
+
+/**
+ * @function cf_server_pop_msg
+ * @category net
+ * @brief    Pops the next message received from any client, if any.
+ * @param    server        The server.
+ * @param    client_index  Which client sent it.
+ * @param    id            The message's user id.
+ * @param    data          Pointer to the message bytes. Free it with `cf_server_free_msg`.
+ * @param    size          Size of `data` in bytes.
+ * @return   Returns `true` when a message was popped.
+ * @remarks  Incoming messages surface here only after `cf_server_pop_event` has drained the events
+ *           carrying them, so keep popping events each update like normal.
+ * @related  cf_server_free_msg cf_client_send_msg cf_server_pop_event
+ */
+CF_API bool CF_CALL cf_server_pop_msg(CF_Server* server, int* client_index, uint32_t* id, void** data, int* size);
+
+/**
+ * @function cf_server_free_msg
+ * @category net
+ * @brief    Frees a message from `cf_server_pop_msg`.
+ * @related  cf_server_pop_msg cf_client_free_msg
+ */
+CF_API void CF_CALL cf_server_free_msg(CF_Server* server, void* data);
+
+//--------------------------------------------------------------------------------------------------
 // COMPRESSION
 //
 // Delta + entropy compression for game snapshots, built on CF's adaptive range coder (cute_arith.h).
@@ -1003,6 +1173,20 @@ CF_INLINE float server_packet_loss(Server* server, int client_index) { return cf
 CF_INLINE float server_incoming_kbps(Server* server, int client_index) { return cf_server_incoming_kbps(server,client_index); }
 CF_INLINE float server_outgoing_kbps(Server* server, int client_index) { return cf_server_outgoing_kbps(server,client_index); }
 CF_INLINE void server_enable_network_simulator(Server* server, double latency, double jitter, double drop_chance, double duplicate_chance) { cf_server_enable_network_simulator(server,latency,jitter,drop_chance,duplicate_chance); }
+
+//--------------------------------------------------------------------------------------------------
+// MESSAGES + CHANNELS
+
+CF_INLINE void client_channel_options(Client* client, int channel, int priority, bool reliable) { cf_client_channel_options(client,channel,priority,reliable); }
+CF_INLINE void client_set_send_rate(Client* client, int bytes_per_second) { cf_client_set_send_rate(client,bytes_per_second); }
+CF_INLINE CF_Result client_send_msg(Client* client, int channel, uint32_t id, const void* data, int size) { return cf_client_send_msg(client,channel,id,data,size); }
+CF_INLINE bool client_pop_msg(Client* client, uint32_t* id, void** data, int* size) { return cf_client_pop_msg(client,id,data,size); }
+CF_INLINE void client_free_msg(Client* client, void* data) { cf_client_free_msg(client,data); }
+CF_INLINE void server_channel_options(Server* server, int channel, int priority, bool reliable) { cf_server_channel_options(server,channel,priority,reliable); }
+CF_INLINE void server_set_send_rate(Server* server, int bytes_per_second) { cf_server_set_send_rate(server,bytes_per_second); }
+CF_INLINE CF_Result server_send_msg(Server* server, int client_index, int channel, uint32_t id, const void* data, int size) { return cf_server_send_msg(server,client_index,channel,id,data,size); }
+CF_INLINE bool server_pop_msg(Server* server, int* client_index, uint32_t* id, void** data, int* size) { return cf_server_pop_msg(server,client_index,id,data,size); }
+CF_INLINE void server_free_msg(Server* server, void* data) { cf_server_free_msg(server,data); }
 
 //--------------------------------------------------------------------------------------------------
 // COMPRESSION

--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -7820,6 +7820,7 @@ typedef struct cn_ack_system_t
 	int acks_count;
 	int acks_capacity;
 	uint16_t* acks;
+	int dirty_acks; // Packets received since we last SENT anything carrying ack bits back.
 	cn_sequence_buffer_t sent_packets;
 	cn_sequence_buffer_t received_packets;
 
@@ -7837,6 +7838,13 @@ typedef struct cn_ack_system_t
 // -------------------------------------------------------------------------------------------------
 
 #define CN_TRANSPORT_HEADER_SIZE (1 + 2 + 2 + 2 + 2)
+
+// The transport header's prefix byte: 0 = fire-and-forget fragment, 1 = reliable fragment, 2 = a
+// standalone ack packet carrying no fragment at all (sent when acks are pending but no outgoing
+// traffic exists to piggyback them on -- without it, a one-directional reliable transfer larger
+// than `max_fragments_in_flight` fragments deadlocks, the sender resending its full window forever
+// while waiting on acks that have no packet to ride).
+#define CN_TRANSPORT_PREFIX_ACKS_ONLY 2
 #define CN_TRANSPORT_MAX_FRAGMENT_SIZE 1100
 #define CN_TRANSPORT_SEND_QUEUE_MAX_ENTRIES (1024)
 #define CN_TRANSPORT_PACKET_PAYLOAD_MAX (1200)
@@ -8230,6 +8238,7 @@ cn_ack_system_t* cn_ack_system_create(cn_ack_system_config_t config)
 
 	ack_system->sequence = 0;
 	ack_system->acks_count = 0;
+	ack_system->dirty_acks = 0;
 	ack_system->acks_capacity = config.initial_ack_capacity;
 	ack_system->acks = (uint16_t*)CN_ALLOC(sizeof(uint16_t) * ack_system->acks_capacity, mem_ctx);
 	CN_CHECK(cn_sequence_buffer_init(&ack_system->sent_packets, config.sent_packets_sequence_buffer_size, sizeof(cn_sent_packet_t), NULL, mem_ctx));
@@ -8325,9 +8334,35 @@ cn_result_t cn_ack_system_send_packet(cn_ack_system_t* ack_system, void* data, i
 		return result;
 	}
 
+	ack_system->dirty_acks = 0; // This packet's header just carried our latest ack bits.
 	ack_system->counters[CN_ACK_SYSTEM_COUNTERS_PACKETS_SENT]++;
 
 	return cn_error_success();
+}
+
+// Sends `data` with a current ack header but WITHOUT consuming a sequence slot or expecting an ack
+// back -- for standalone ack packets, which must not themselves generate more acks (two quiet peers
+// would ack each other's acks forever).
+cn_result_t cn_ack_system_send_acks(cn_ack_system_t* ack_system, void* data, int size)
+{
+	if (size > ack_system->max_packet_size || size > CN_ACK_SYSTEM_MAX_PACKET_SIZE) {
+		return cn_error_failure("Exceeded max packet size in ack system.");
+	}
+
+	uint16_t ack;
+	uint32_t ack_bits;
+	cn_sequence_buffer_generate_ack_bits(&ack_system->received_packets, &ack, &ack_bits);
+
+	uint8_t buffer[CN_TRANSPORT_PACKET_PAYLOAD_MAX];
+	// The sequence field is filler here (not incremented, not tracked); receivers of ack-only
+	// packets never read it.
+	int header_size = s_write_ack_system_header(buffer, ack_system->sequence, ack, ack_bits);
+	CN_ASSERT(header_size == CN_ACK_SYSTEM_HEADER_SIZE);
+	CN_ASSERT(size + header_size < CN_TRANSPORT_PACKET_PAYLOAD_MAX);
+	CN_MEMCPY(buffer + header_size, data, size);
+	cn_result_t result = ack_system->send_packet_fn(ack_system->index, buffer, size + header_size, ack_system->udata);
+	if (!cn_is_error(result)) ack_system->dirty_acks = 0;
+	return result;
 }
 
 uint16_t cn_ack_system_get_sequence(cn_ack_system_t* ack_system)
@@ -8343,6 +8378,45 @@ static int s_read_ack_system_header(uint8_t* buffer, int size, uint16_t* sequenc
 	*ack = cn_read_uint16(&buffer);
 	*ack_bits = cn_read_uint32(&buffer);
 	return (int)(buffer - buffer_start);
+}
+
+// Marks our previously sent packets as acked per the peer's (ack, ack_bits) report.
+static void s_ack_system_process_ack_bits(cn_ack_system_t* ack_system, uint16_t ack, uint32_t ack_bits)
+{
+	for (int i = 0; i < 32; ++i) {
+		int bit_was_set = ack_bits & 1;
+		ack_bits >>= 1;
+
+		if (bit_was_set) {
+			uint16_t ack_sequence = ack - ((uint16_t)i);
+			cn_sent_packet_t* sent_packet = (cn_sent_packet_t*)cn_sequence_buffer_find(&ack_system->sent_packets, ack_sequence);
+
+			if (sent_packet && !sent_packet->acked) {
+				CN_CHECK_BUFFER_GROW(ack_system, acks_count, acks_capacity, acks, uint16_t);
+				ack_system->acks[ack_system->acks_count++] = ack_sequence;
+				ack_system->counters[CN_ACK_SYSTEM_COUNTERS_PACKETS_ACKED]++;
+				sent_packet->acked = 1;
+
+				float rtt = (float)(ack_system->time - sent_packet->timestamp) * 1000.0f;
+				if (ack_system->rtt == 0.0f && rtt > 0.0f) ack_system->rtt = rtt;
+				else ack_system->rtt += (rtt - ack_system->rtt) * 0.001f;
+				CN_ASSERT(ack_system->rtt >= 0);
+			}
+		}
+	}
+}
+
+// Processes ONLY the ack fields of a packet's header -- for standalone ack packets, which are not
+// themselves ack-worthy traffic (no sequence insert, no dirty_acks, no counters).
+cn_result_t cn_ack_system_receive_acks(cn_ack_system_t* ack_system, void* data, int size)
+{
+	uint16_t sequence;
+	uint16_t ack;
+	uint32_t ack_bits;
+	int header_size = s_read_ack_system_header((uint8_t*)data, size, &sequence, &ack, &ack_bits);
+	if (header_size < 0) return cn_error_failure("Failed to read ack header.");
+	s_ack_system_process_ack_bits(ack_system, ack, ack_bits);
+	return cn_error_success();
 }
 
 cn_result_t cn_ack_system_receive_packet(cn_ack_system_t* ack_system, void* data, int size)
@@ -8375,28 +8449,9 @@ cn_result_t cn_ack_system_receive_packet(cn_ack_system_t* ack_system, void* data
 	CN_ASSERT(packet);
 	packet->timestamp = ack_system->time;
 	packet->size = size;
+	ack_system->dirty_acks++; // The peer now needs to hear this packet was received.
 
-	for (int i = 0; i < 32; ++i) {
-		int bit_was_set = ack_bits & 1;
-		ack_bits >>= 1;
-
-		if (bit_was_set) {
-			uint16_t ack_sequence = ack - ((uint16_t)i);
-			cn_sent_packet_t* sent_packet = (cn_sent_packet_t*)cn_sequence_buffer_find(&ack_system->sent_packets, ack_sequence);
-
-			if (sent_packet && !sent_packet->acked) {
-				CN_CHECK_BUFFER_GROW(ack_system, acks_count, acks_capacity, acks, uint16_t);
-				ack_system->acks[ack_system->acks_count++] = ack_sequence;
-				ack_system->counters[CN_ACK_SYSTEM_COUNTERS_PACKETS_ACKED]++;
-				sent_packet->acked = 1;
-
-				float rtt = (float)(ack_system->time - sent_packet->timestamp) * 1000.0f;
-				if (ack_system->rtt == 0.0f && rtt > 0.0f) ack_system->rtt = rtt;
-				else ack_system->rtt += (rtt - ack_system->rtt) * 0.001f;
-				CN_ASSERT(ack_system->rtt >= 0);
-			}
-		}
-	}
+	s_ack_system_process_ack_bits(ack_system, ack, ack_bits);
 
 	return cn_error_success();
 }
@@ -8832,6 +8887,14 @@ void cn_transport_free_packet(cn_transport_t* transport, void* data)
 cn_result_t cn_transport_process_packet(cn_transport_t* transport, void* data, int size)
 {
 	if (size < CN_ACK_SYSTEM_HEADER_SIZE + CN_TRANSPORT_HEADER_SIZE) return cn_error_failure("`size` is too small to fit the ack-system and transport headers.");
+
+	// A standalone ack packet (see s_transport_send_ack_only) carries no fragment. Process its ack
+	// fields only -- it must not count as ack-worthy traffic itself, or two otherwise-quiet peers
+	// would ack each other's acks forever.
+	if (((uint8_t*)data)[CN_ACK_SYSTEM_HEADER_SIZE] == CN_TRANSPORT_PREFIX_ACKS_ONLY) {
+		return cn_ack_system_receive_acks(transport->ack_system, data, size);
+	}
+
 	cn_result_t result = cn_ack_system_receive_packet(transport->ack_system, data, size);
 	if (cn_is_error(result)) return result;
 
@@ -9040,11 +9103,22 @@ int cn_transport_unacked_fragment_count(cn_transport_t* transport)
 	return transport->fragments_count;
 }
 
+// Flush pending acks in a standalone packet when nothing else this update carried them (see
+// CN_TRANSPORT_PREFIX_ACKS_ONLY). Normal bidirectional traffic piggybacks acks for free and never
+// reaches this.
+static void s_transport_send_ack_only(cn_transport_t* transport)
+{
+	uint8_t buffer[CN_TRANSPORT_HEADER_SIZE];
+	s_transport_write_header(buffer, CN_TRANSPORT_HEADER_SIZE, CN_TRANSPORT_PREFIX_ACKS_ONLY, 0, 0, 0, 0);
+	cn_ack_system_send_acks(transport->ack_system, buffer, CN_TRANSPORT_HEADER_SIZE);
+}
+
 void cn_transport_update(cn_transport_t* transport, double dt)
 {
 	cn_ack_system_update(transport->ack_system, dt);
 	cn_transport_process_acks(transport);
 	cn_transport_send_fragments(transport);
+	if (transport->ack_system->dirty_acks > 0) s_transport_send_ack_only(transport);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -10795,6 +10869,69 @@ int cn_transport_drop_fragments_reliable_hammer()
 	}
 
 	CN_TEST_ASSERT(received);
+	CN_FREE(packet, NULL);
+
+	cn_transport_destroy(transport_a);
+	cn_transport_destroy(transport_b);
+
+	return 0;
+}
+
+CN_TEST_CASE(cn_transport_one_directional_reliable, "A reliable send larger than the in-flight fragment window completes with ZERO reverse traffic (acks ride standalone ack packets).");
+int cn_transport_one_directional_reliable()
+{
+	cn_test_transport_data_t data_a = cn_test_transport_data_defaults();
+	cn_test_transport_data_t data_b = cn_test_transport_data_defaults();
+	data_a.id = 0;
+	data_b.id = 1;
+	double dt = 1.0/60.0;
+
+	cn_transport_config_t config = cn_transport_config_defaults();
+	config.send_packet_fn = cn_test_transport_send_packet_fn;
+	config.udata = &data_a;
+	cn_transport_t* transport_a = cn_transport_create(config);
+	config.udata = &data_b;
+	cn_transport_t* transport_b = cn_transport_create(config);
+	data_a.transport_a = transport_a;
+	data_a.transport_b = transport_b;
+	data_b.transport_a = transport_a;
+	data_b.transport_b = transport_b;
+
+	// Way more fragments than max_fragments_in_flight, and b NEVER sends anything of its own: the
+	// sender can only advance its flight window if acks flow back on standalone ack packets.
+	// Before those existed, this deadlocked -- a resending its full window forever.
+	int packet_size = CN_KB * 100;
+	uint8_t* packet = (uint8_t*)CN_ALLOC(packet_size, NULL);
+	for (int i = 0; i < packet_size; ++i) {
+		packet[i] = (uint8_t)(i * 7);
+	}
+	CN_TEST_CHECK(cn_is_error(cn_transport_send(transport_a, packet, packet_size, true)));
+
+	int received = 0;
+	int iters = 0;
+	while (1) {
+		cn_transport_update(transport_a, dt);
+		cn_transport_update(transport_b, dt);
+
+		void* packet_received;
+		int packet_received_size;
+		if (!cn_is_error(cn_transport_receive_reliably_and_in_order(transport_b, &packet_received, &packet_received_size))) {
+			CN_TEST_ASSERT(packet_received_size == packet_size);
+			CN_TEST_ASSERT(!CN_MEMCMP(packet, packet_received, packet_size));
+			cn_transport_free_packet(transport_b, packet_received);
+			received = 1;
+		}
+
+		if (received && cn_transport_unacked_fragment_count(transport_a) == 0) {
+			break;
+		}
+
+		if (++iters == 1000) {
+			break;
+		}
+	}
+	CN_TEST_ASSERT(received);
+	CN_TEST_ASSERT(iters < 1000);
 	CN_FREE(packet, NULL);
 
 	cn_transport_destroy(transport_a);
@@ -12658,6 +12795,7 @@ int cn_run_tests(int which_test, bool soak)
 		CN_TEST_CASE_ENTRY(cn_transport_basic),
 		CN_TEST_CASE_ENTRY(cn_transport_drop_fragments),
 		CN_TEST_CASE_ENTRY(cn_transport_drop_fragments_reliable_hammer),
+		CN_TEST_CASE_ENTRY(cn_transport_one_directional_reliable),
 		CN_TEST_CASE_ENTRY(cn_transport_send_many_reliables_at_once),
 		CN_TEST_CASE_ENTRY(cn_transport_fragment_header_guards),
 		CN_TEST_CASE_ENTRY(cn_packet_connection_accepted),

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -45,6 +45,239 @@ static CF_INLINE CF_Result cf_wrap(cn_result_t cn_result)
 static CF_INLINE cn_endpoint_t cf_to_cn_endpoint(CF_Address a) { cn_endpoint_t e; CF_MEMCPY(&e, &a, sizeof(e)); return e; }
 static CF_INLINE CF_CryptoKey cf_from_cn_key(cn_crypto_key_t k) { CF_CryptoKey out; CF_MEMCPY(&out, &k, sizeof(out)); return out; }
 
+//--------------------------------------------------------------------------------------------------
+// MESSAGES + CHANNELS (internals)
+//
+// CF owns the wire above cute_net, so every packet CF sends starts with one framing byte: RAW for
+// user packets from cf_client_send / cf_server_send, or BUNDLE for coalesced channel messages. The
+// receive paths demux on that byte, which is why raw pop/free hand out pointers offset by one.
+
+#define CF_NET_PREFIX_RAW    0
+#define CF_NET_PREFIX_BUNDLE 1
+#define CF_NET_BUNDLE_TARGET 1000               // Keep coalesced bundles inside one transport fragment (1100).
+#define CF_NET_CHANNEL_QUEUE_BYTES (4 * 1024 * 1024) // Per-channel cap on locally queued bytes.
+
+// One queued or received message; payload bytes live right after the header.
+struct CF_MsgNode
+{
+	CF_MsgNode* next;
+	int client_index; // Which client sent it (receive side on a server; -1 elsewhere).
+	uint32_t id;
+	int size;
+};
+
+static CF_MsgNode* s_msg_make(int client_index, uint32_t id, const void* data, int size)
+{
+	CF_MsgNode* n = (CF_MsgNode*)cf_alloc(sizeof(CF_MsgNode) + (size > 0 ? size : 1));
+	n->next = NULL;
+	n->client_index = client_index;
+	n->id = id;
+	n->size = size;
+	if (size > 0) CF_MEMCPY(n + 1, data, size);
+	return n;
+}
+
+struct CF_MsgList
+{
+	CF_MsgNode* head;
+	CF_MsgNode* tail;
+};
+
+static void s_msg_push(CF_MsgList* l, CF_MsgNode* n)
+{
+	if (l->tail) l->tail->next = n;
+	else l->head = n;
+	l->tail = n;
+}
+
+static CF_MsgNode* s_msg_pop(CF_MsgList* l)
+{
+	CF_MsgNode* n = l->head;
+	if (n) {
+		l->head = n->next;
+		if (!l->head) l->tail = NULL;
+	}
+	return n;
+}
+
+static void s_msg_clear(CF_MsgList* l)
+{
+	while (CF_MsgNode* n = s_msg_pop(l)) cf_free(n);
+}
+
+// Drop not-yet-popped messages from one client index (a recycled slot must not misattribute the
+// previous occupant's messages to the new connection).
+static void s_msg_remove_client(CF_MsgList* l, int client_index)
+{
+	CF_MsgNode** link = &l->head;
+	l->tail = NULL;
+	while (CF_MsgNode* n = *link) {
+		if (n->client_index == client_index) {
+			*link = n->next;
+			cf_free(n);
+		} else {
+			l->tail = n;
+			link = &n->next;
+		}
+	}
+}
+
+struct CF_ChannelOpts
+{
+	int priority;  // Higher pumps first.
+	bool reliable;
+};
+
+// One peer's outgoing channel queues (a client has one; a server has one per client slot).
+struct CF_PeerChannels
+{
+	CF_MsgList q[CF_NET_MAX_CHANNELS];
+	int queued_bytes[CF_NET_MAX_CHANNELS];
+	double budget; // Token bucket in bytes; may go negative (debt) after an oversized send.
+};
+
+static void s_peer_reset(CF_PeerChannels* p)
+{
+	for (int i = 0; i < CF_NET_MAX_CHANNELS; ++i) {
+		s_msg_clear(&p->q[i]);
+		p->queued_bytes[i] = 0;
+	}
+	p->budget = 0;
+}
+
+// LEB128-style varints frame each message inside a bundle: [id][size][bytes].
+static int s_varint_write(uint8_t* out, uint32_t v)
+{
+	int n = 0;
+	do {
+		uint8_t b = v & 0x7F;
+		v >>= 7;
+		out[n++] = b | (v ? 0x80 : 0);
+	} while (v);
+	return n;
+}
+
+// Returns bytes consumed, or 0 on truncated/overlong input.
+static int s_varint_read(const uint8_t* p, const uint8_t* end, uint32_t* v)
+{
+	uint32_t out = 0;
+	for (int n = 0; n < 5 && p + n < end; ++n) {
+		out |= (uint32_t)(p[n] & 0x7F) << (n * 7);
+		if (!(p[n] & 0x80)) { *v = out; return n + 1; }
+	}
+	return 0;
+}
+
+static uint8_t* s_scratch_fit(uint8_t** buf, int* cap, int size)
+{
+	if (*cap < size) {
+		int new_cap = *cap > 0 ? *cap : 4096;
+		while (new_cap < size) new_cap *= 2;
+		*buf = (uint8_t*)cf_realloc(*buf, new_cap);
+		*cap = new_cap;
+	}
+	return *buf;
+}
+
+static CF_Result s_queue_msg(CF_PeerChannels* peer, uint8_t** scratch, int* scratch_cap, int channel, uint32_t id, const void* data, int size)
+{
+	if (channel < 0 || channel >= CF_NET_MAX_CHANNELS) return cf_result_error("Invalid channel index.");
+	if (size < 0 || size > CF_NET_MAX_MSG_SIZE) return cf_result_error("Message size out of range (see CF_NET_MAX_MSG_SIZE).");
+	if (size > 0 && !data) return cf_result_error("NULL data with non-zero size.");
+	if (peer->queued_bytes[channel] + size > CF_NET_CHANNEL_QUEUE_BYTES) return cf_result_error("Channel send queue is full.");
+	// Grow the bundle scratch now so the pump never has to handle allocation.
+	s_scratch_fit(scratch, scratch_cap, size + 16);
+	s_msg_push(&peer->q[channel], s_msg_make(-1, id, data, size));
+	peer->queued_bytes[channel] += size;
+	return cf_result_success();
+}
+
+typedef cn_result_t (CF_ChannelSendFn)(void* udata, const void* data, int size, bool reliable);
+
+// Drain a peer's channel queues into the transport, highest priority channel first, coalescing
+// messages into bundles, under the byte budget. Called once per update while connected.
+static void s_pump(const CF_ChannelOpts* opts, CF_PeerChannels* peer, int rate, double dt, uint8_t* scratch, CF_ChannelSendFn* send, void* udata)
+{
+	if (rate > 0) {
+		peer->budget += (double)rate * dt;
+		if (peer->budget > (double)rate) peer->budget = (double)rate; // Cap the burst at one second's worth.
+	}
+	// Strict priority, ties broken by lower channel index. N is tiny; select rather than sort.
+	bool visited[CF_NET_MAX_CHANNELS] = { 0 };
+	for (int pass = 0; pass < CF_NET_MAX_CHANNELS; ++pass) {
+		int best = -1;
+		for (int i = 0; i < CF_NET_MAX_CHANNELS; ++i) {
+			if (visited[i]) continue;
+			if (best < 0 || opts[i].priority > opts[best].priority) best = i;
+		}
+		visited[best] = true;
+		CF_MsgList* q = &peer->q[best];
+		while (q->head) {
+			if (rate > 0 && peer->budget <= 0) return; // Out of budget; the rest waits for the next update.
+			// Coalesce messages from the front of the queue into one bundle.
+			int used = 0;
+			scratch[used++] = CF_NET_PREFIX_BUNDLE;
+			int packed = 0;
+			for (CF_MsgNode* n = q->head; n; n = n->next) {
+				uint8_t hdr[10];
+				int hn = s_varint_write(hdr, n->id);
+				hn += s_varint_write(hdr + hn, (uint32_t)n->size);
+				// A lone oversized message still ships (the transport fragments it); otherwise stop
+				// packing at the fragment-friendly target.
+				if (packed > 0 && used + hn + n->size > CF_NET_BUNDLE_TARGET + 1) break;
+				CF_MEMCPY(scratch + used, hdr, hn);
+				used += hn;
+				if (n->size > 0) CF_MEMCPY(scratch + used, n + 1, n->size);
+				used += n->size;
+				packed++;
+				if (used > CF_NET_BUNDLE_TARGET) break;
+			}
+			cn_result_t r = send(udata, scratch, used, opts[best].reliable);
+			if (cn_is_error(r)) {
+				// Reliable messages stay queued and retry next update (backpressure against a full
+				// reliable layer); unreliable ones are droppable by contract, so drop rather than
+				// let stale state pile up.
+				if (!opts[best].reliable) {
+					for (int k = 0; k < packed; ++k) {
+						CF_MsgNode* d = s_msg_pop(q);
+						peer->queued_bytes[best] -= d->size;
+						cf_free(d);
+					}
+				}
+				return; // The transport is unhappy; stop pumping until next update.
+			}
+			peer->budget -= (double)used;
+			for (int k = 0; k < packed; ++k) {
+				CF_MsgNode* d = s_msg_pop(q);
+				peer->queued_bytes[best] -= d->size;
+				cf_free(d);
+			}
+		}
+	}
+}
+
+// Split a received bundle into messages on the receive queue. Bounds-safe: a malformed tail is
+// dropped (can only come from a version-mismatched peer -- the transport authenticates packets).
+static void s_parse_bundle(CF_MsgList* rx, int client_index, const uint8_t* p, int n)
+{
+	const uint8_t* end = p + n;
+	while (p < end) {
+		uint32_t id, size;
+		int a = s_varint_read(p, end, &id);
+		if (!a) return;
+		p += a;
+		int b = s_varint_read(p, end, &size);
+		if (!b) return;
+		p += b;
+		if (size > (uint32_t)(end - p) || size > CF_NET_MAX_MSG_SIZE) return;
+		s_msg_push(rx, s_msg_make(client_index, id, p, (int)size));
+		p += size;
+	}
+}
+
+//--------------------------------------------------------------------------------------------------
+// ADDRESSES + CRYPTO
+
 int cf_address_init(CF_Address* address, const char* address_and_port_string)
 {
 	return cn_endpoint_init((cn_endpoint_t*)address, address_and_port_string);
@@ -106,82 +339,181 @@ CF_Result cf_generate_connect_token(
 	return cf_wrap(result);
 }
 
+//--------------------------------------------------------------------------------------------------
+// CLIENT
+
+// The public CF_Client wraps the walled cute_net client with CF's channel layer.
+struct CF_Client
+{
+	cn_client_t* cn;
+	CF_ChannelOpts opts[CF_NET_MAX_CHANNELS];
+	CF_PeerChannels send;
+	CF_MsgList rx;
+	int rate; // Bytes per second budget for the pump; 0 = unlimited.
+	uint8_t* scratch;
+	int scratch_cap;
+};
+
 CF_Client* cf_make_client(
 	uint16_t port,
 	uint64_t application_id,
 	bool use_ipv6 /* = false */
 )
 {
-	return (CF_Client*)cn_client_create(port, application_id, use_ipv6, NULL);
+	cn_client_t* cn = cn_client_create(port, application_id, use_ipv6, NULL);
+	if (!cn) return NULL;
+	CF_Client* client = (CF_Client*)cf_calloc(1, sizeof(CF_Client));
+	client->cn = cn;
+	return client;
 }
 
 void cf_destroy_client(CF_Client* client)
 {
-	cn_client_destroy((cn_client_t*)client);
+	cn_client_destroy(client->cn);
+	s_peer_reset(&client->send);
+	s_msg_clear(&client->rx);
+	cf_free(client->scratch);
+	cf_free(client);
 }
 
 CF_Result cf_client_connect(CF_Client* client, const uint8_t* connect_token)
 {
-	return cf_wrap(cn_client_connect((cn_client_t*)client, connect_token));
+	// A (re)connect is a fresh conversation: drop anything queued for or from the old one.
+	s_peer_reset(&client->send);
+	s_msg_clear(&client->rx);
+	return cf_wrap(cn_client_connect(client->cn, connect_token));
 }
 
 void cf_client_disconnect(CF_Client* client)
 {
-	cn_client_disconnect((cn_client_t*)client);
+	s_peer_reset(&client->send);
+	cn_client_disconnect(client->cn);
 }
 
 void cf_client_update(CF_Client* client, double dt, uint64_t current_time)
 {
-	cn_client_update((cn_client_t*)client, dt, current_time);
+	if (cn_client_state_get(client->cn) == CN_CLIENT_STATE_CONNECTED) {
+		s_scratch_fit(&client->scratch, &client->scratch_cap, CF_NET_BUNDLE_TARGET + 32);
+		s_pump(client->opts, &client->send, client->rate, dt,
+			client->scratch,
+			[](void* udata, const void* data, int size, bool reliable) { return cn_client_send((cn_client_t*)udata, data, size, reliable); },
+			client->cn);
+	}
+	cn_client_update(client->cn, dt, current_time);
 }
 
 bool cf_client_pop_packet(CF_Client* client, void** packet, int* size, bool* was_sent_reliably /* = NULL */)
 {
-	return cn_client_pop_packet((cn_client_t*)client, packet, size, was_sent_reliably);
+	void* p;
+	int n;
+	bool r;
+	while (cn_client_pop_packet(client->cn, &p, &n, &r)) {
+		uint8_t* b = (uint8_t*)p;
+		if (n >= 1 && b[0] == CF_NET_PREFIX_RAW) {
+			*packet = b + 1;
+			*size = n - 1;
+			if (was_sent_reliably) *was_sent_reliably = r;
+			return true;
+		}
+		if (n >= 1 && b[0] == CF_NET_PREFIX_BUNDLE) s_parse_bundle(&client->rx, -1, b + 1, n - 1);
+		cn_client_free_packet(client->cn, p);
+	}
+	return false;
 }
 
 void cf_client_free_packet(CF_Client* client, void* packet)
 {
-	cn_client_free_packet((cn_client_t*)client, packet);
+	// Undo the framing-byte offset from cf_client_pop_packet.
+	cn_client_free_packet(client->cn, (uint8_t*)packet - 1);
 }
 
 CF_Result cf_client_send(CF_Client* client, const void* packet, int size, bool send_reliably)
 {
-	return cf_wrap(cn_client_send((cn_client_t*)client, packet, size, send_reliably));
+	if (size < 0) return cf_result_error("Negative size.");
+	uint8_t* s = s_scratch_fit(&client->scratch, &client->scratch_cap, size + 1);
+	s[0] = CF_NET_PREFIX_RAW;
+	if (size > 0) CF_MEMCPY(s + 1, packet, size);
+	return cf_wrap(cn_client_send(client->cn, s, size + 1, send_reliably));
+}
+
+void cf_client_channel_options(CF_Client* client, int channel, int priority, bool reliable)
+{
+	if (channel < 0 || channel >= CF_NET_MAX_CHANNELS) return;
+	client->opts[channel].priority = priority;
+	client->opts[channel].reliable = reliable;
+}
+
+void cf_client_set_send_rate(CF_Client* client, int bytes_per_second)
+{
+	client->rate = bytes_per_second;
+}
+
+CF_Result cf_client_send_msg(CF_Client* client, int channel, uint32_t id, const void* data, int size)
+{
+	return s_queue_msg(&client->send, &client->scratch, &client->scratch_cap, channel, id, data, size);
+}
+
+bool cf_client_pop_msg(CF_Client* client, uint32_t* id, void** data, int* size)
+{
+	CF_MsgNode* n = s_msg_pop(&client->rx);
+	if (!n) return false;
+	*id = n->id;
+	*data = (void*)(n + 1);
+	*size = n->size;
+	return true;
+}
+
+void cf_client_free_msg(CF_Client* client, void* data)
+{
+	(void)client;
+	cf_free((CF_MsgNode*)data - 1);
 }
 
 CF_ClientState cf_client_state(const CF_Client* client)
 {
-	return (CF_ClientState)cn_client_state_get((cn_client_t*)client);
+	return (CF_ClientState)cn_client_state_get(client->cn);
 }
 
 float cf_client_rtt(CF_Client* client)
 {
-	return cn_client_get_rtt_estimate((cn_client_t*)client);
+	return cn_client_get_rtt_estimate(client->cn);
 }
 
 float cf_client_packet_loss(CF_Client* client)
 {
-	return cn_client_get_packet_loss_estimate((cn_client_t*)client);
+	return cn_client_get_packet_loss_estimate(client->cn);
 }
 
 float cf_client_incoming_kbps(CF_Client* client)
 {
-	return cn_client_get_incoming_kbps_estimate((cn_client_t*)client);
+	return cn_client_get_incoming_kbps_estimate(client->cn);
 }
 
 float cf_client_outgoing_kbps(CF_Client* client)
 {
-	return cn_client_get_outgoing_kbps_estimate((cn_client_t*)client);
+	return cn_client_get_outgoing_kbps_estimate(client->cn);
 }
 
 void cf_client_enable_network_simulator(CF_Client* client, double latency, double jitter, double drop_chance, double duplicate_chance)
 {
-	cn_client_enable_network_simulator((cn_client_t*)client, latency, jitter, drop_chance, duplicate_chance);
+	cn_client_enable_network_simulator(client->cn, latency, jitter, drop_chance, duplicate_chance);
 }
 
 //--------------------------------------------------------------------------------------------------
 // SERVER
+
+// The public CF_Server wraps the walled cute_net server with CF's channel layer, one set of
+// outgoing queues per client slot.
+struct CF_Server
+{
+	cn_server_t* cn;
+	CF_ChannelOpts opts[CF_NET_MAX_CHANNELS];
+	CF_PeerChannels peers[CF_SERVER_MAX_CLIENTS];
+	CF_MsgList rx;
+	int rate; // Bytes per second budget per client; 0 = unlimited.
+	uint8_t* scratch;
+	int scratch_cap;
+};
 
 CF_Server* cf_make_server(CF_ServerConfig config)
 {
@@ -194,92 +526,190 @@ CF_Server* cf_make_server(CF_ServerConfig config)
 	CF_MEMCPY(&cn_config.public_key, &config.public_key, sizeof(cn_config.public_key));
 	CF_MEMCPY(&cn_config.secret_key, &config.secret_key, sizeof(cn_config.secret_key));
 	cn_config.user_allocator_context = NULL;
-	return (CF_Server*)cn_server_create(cn_config);
+	cn_server_t* cn = cn_server_create(cn_config);
+	if (!cn) return NULL;
+	CF_Server* server = (CF_Server*)cf_calloc(1, sizeof(CF_Server));
+	server->cn = cn;
+	return server;
 }
 
 void cf_destroy_server(CF_Server* server)
 {
-	cn_server_destroy((cn_server_t*)server);
+	cn_server_destroy(server->cn);
+	for (int i = 0; i < CF_SERVER_MAX_CLIENTS; ++i) s_peer_reset(&server->peers[i]);
+	s_msg_clear(&server->rx);
+	cf_free(server->scratch);
+	cf_free(server);
 }
 
 CF_Result cf_server_start(CF_Server* server, const char* address_and_port)
 {
-	return cf_wrap(cn_server_start((cn_server_t*)server, address_and_port));
+	return cf_wrap(cn_server_start(server->cn, address_and_port));
 }
 
 void cf_server_stop(CF_Server* server)
 {
-	cn_server_stop((cn_server_t*)server);
+	for (int i = 0; i < CF_SERVER_MAX_CLIENTS; ++i) s_peer_reset(&server->peers[i]);
+	s_msg_clear(&server->rx);
+	cn_server_stop(server->cn);
 }
 
 void cf_server_set_public_ip(CF_Server* server, const char* address_and_port)
 {
-	cn_server_set_public_ip((cn_server_t*)server, address_and_port);
+	cn_server_set_public_ip(server->cn, address_and_port);
 }
 
 bool cf_server_pop_event(CF_Server* server, CF_ServerEvent* event)
 {
-	return cn_server_pop_event((cn_server_t*)server, (cn_server_event_t*)event);
+	cn_server_event_t e;
+	while (cn_server_pop_event(server->cn, &e)) {
+		if (e.type == CN_SERVER_EVENT_TYPE_PAYLOAD_PACKET) {
+			uint8_t* b = (uint8_t*)e.u.payload_packet.data;
+			int n = e.u.payload_packet.size;
+			int ci = e.u.payload_packet.client_index;
+			if (n >= 1 && b[0] == CF_NET_PREFIX_RAW) {
+				// Strip the framing byte; cf_server_free_packet undoes the offset.
+				e.u.payload_packet.data = b + 1;
+				e.u.payload_packet.size = n - 1;
+				CF_MEMCPY(event, &e, sizeof(e));
+				return true;
+			}
+			if (n >= 1 && b[0] == CF_NET_PREFIX_BUNDLE) s_parse_bundle(&server->rx, ci, b + 1, n - 1);
+			cn_server_free_packet(server->cn, ci, b);
+			continue;
+		}
+		if (e.type == CN_SERVER_EVENT_TYPE_NEW_CONNECTION) {
+			s_peer_reset(&server->peers[e.u.new_connection.client_index]);
+			s_msg_remove_client(&server->rx, e.u.new_connection.client_index);
+		} else if (e.type == CN_SERVER_EVENT_TYPE_DISCONNECTED) {
+			s_peer_reset(&server->peers[e.u.disconnected.client_index]);
+		}
+		CF_MEMCPY(event, &e, sizeof(e));
+		return true;
+	}
+	return false;
 }
 
 void cf_server_free_packet(CF_Server* server, int client_index, void* data)
 {
-	cn_server_free_packet((cn_server_t*)server, client_index, data);
+	// Undo the framing-byte offset from cf_server_pop_event.
+	cn_server_free_packet(server->cn, client_index, (uint8_t*)data - 1);
 }
 
 void cf_server_update(CF_Server* server, double dt, uint64_t current_time)
 {
-	cn_server_update((cn_server_t*)server, dt, current_time);
+	s_scratch_fit(&server->scratch, &server->scratch_cap, CF_NET_BUNDLE_TARGET + 32);
+	for (int i = 0; i < CF_SERVER_MAX_CLIENTS; ++i) {
+		bool any = false;
+		for (int c = 0; c < CF_NET_MAX_CHANNELS; ++c) {
+			if (server->peers[i].q[c].head) { any = true; break; }
+		}
+		if (!any) continue;
+		if (!cn_server_is_client_connected(server->cn, i)) continue;
+		struct Ctx { cn_server_t* cn; int ci; } ctx = { server->cn, i };
+		s_pump(server->opts, &server->peers[i], server->rate, dt,
+			server->scratch,
+			[](void* udata, const void* data, int size, bool reliable) {
+				Ctx* c = (Ctx*)udata;
+				return cn_server_send(c->cn, data, size, c->ci, reliable);
+			},
+			&ctx);
+	}
+	cn_server_update(server->cn, dt, current_time);
 }
 
 void cf_server_disconnect_client(CF_Server* server, int client_index, bool notify_client /* = true */)
 {
-	cn_server_disconnect_client((cn_server_t*)server, client_index, notify_client);
+	s_peer_reset(&server->peers[client_index]);
+	cn_server_disconnect_client(server->cn, client_index, notify_client);
 }
 
 CF_Result cf_server_send(CF_Server* server, const void* packet, int size, int client_index, bool send_reliably)
 {
-	return cf_wrap(cn_server_send((cn_server_t*)server, packet, size, client_index, send_reliably));
+	if (size < 0) return cf_result_error("Negative size.");
+	uint8_t* s = s_scratch_fit(&server->scratch, &server->scratch_cap, size + 1);
+	s[0] = CF_NET_PREFIX_RAW;
+	if (size > 0) CF_MEMCPY(s + 1, packet, size);
+	return cf_wrap(cn_server_send(server->cn, s, size + 1, client_index, send_reliably));
 }
 
 void cf_server_send_to_all(CF_Server* server, const void* packet, int size, bool send_reliably)
 {
-	cn_server_t* s = (cn_server_t*)server;
+	if (size < 0) return;
+	uint8_t* s = s_scratch_fit(&server->scratch, &server->scratch_cap, size + 1);
+	s[0] = CF_NET_PREFIX_RAW;
+	if (size > 0) CF_MEMCPY(s + 1, packet, size);
 	for (int i = 0; i < CF_SERVER_MAX_CLIENTS; ++i) {
-		if (cn_server_is_client_connected(s, i)) {
-			cn_server_send(s, packet, size, i, send_reliably);
+		if (cn_server_is_client_connected(server->cn, i)) {
+			cn_server_send(server->cn, s, size + 1, i, send_reliably);
 		}
 	}
 }
 
+void cf_server_channel_options(CF_Server* server, int channel, int priority, bool reliable)
+{
+	if (channel < 0 || channel >= CF_NET_MAX_CHANNELS) return;
+	server->opts[channel].priority = priority;
+	server->opts[channel].reliable = reliable;
+}
+
+void cf_server_set_send_rate(CF_Server* server, int bytes_per_second)
+{
+	server->rate = bytes_per_second;
+}
+
+CF_Result cf_server_send_msg(CF_Server* server, int client_index, int channel, uint32_t id, const void* data, int size)
+{
+	if (client_index < 0 || client_index >= CF_SERVER_MAX_CLIENTS) return cf_result_error("Invalid client index.");
+	if (!cn_server_is_client_connected(server->cn, client_index)) return cf_result_error("Client is not connected.");
+	return s_queue_msg(&server->peers[client_index], &server->scratch, &server->scratch_cap, channel, id, data, size);
+}
+
+bool cf_server_pop_msg(CF_Server* server, int* client_index, uint32_t* id, void** data, int* size)
+{
+	CF_MsgNode* n = s_msg_pop(&server->rx);
+	if (!n) return false;
+	*client_index = n->client_index;
+	*id = n->id;
+	*data = (void*)(n + 1);
+	*size = n->size;
+	return true;
+}
+
+void cf_server_free_msg(CF_Server* server, void* data)
+{
+	(void)server;
+	cf_free((CF_MsgNode*)data - 1);
+}
+
 bool cf_server_is_client_connected(CF_Server* server, int client_index)
 {
-	return cn_server_is_client_connected((cn_server_t*)server, client_index);
+	return cn_server_is_client_connected(server->cn, client_index);
 }
 
 float cf_server_rtt(CF_Server* server, int client_index)
 {
-	return cn_server_get_rtt_estimate((cn_server_t*)server, client_index);
+	return cn_server_get_rtt_estimate(server->cn, client_index);
 }
 
 float cf_server_packet_loss(CF_Server* server, int client_index)
 {
-	return cn_server_get_packet_loss_estimate((cn_server_t*)server, client_index);
+	return cn_server_get_packet_loss_estimate(server->cn, client_index);
 }
 
 float cf_server_incoming_kbps(CF_Server* server, int client_index)
 {
-	return cn_server_get_incoming_kbps_estimate((cn_server_t*)server, client_index);
+	return cn_server_get_incoming_kbps_estimate(server->cn, client_index);
 }
 
 float cf_server_outgoing_kbps(CF_Server* server, int client_index)
 {
-	return cn_server_get_outgoing_kbps_estimate((cn_server_t*)server, client_index);
+	return cn_server_get_outgoing_kbps_estimate(server->cn, client_index);
 }
 
 void cf_server_enable_network_simulator(CF_Server* server, double latency, double jitter, double drop_chance, double duplicate_chance)
 {
-	cn_server_enable_network_simulator((cn_server_t*)server, latency, jitter, drop_chance, duplicate_chance);
+	cn_server_enable_network_simulator(server->cn, latency, jitter, drop_chance, duplicate_chance);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CF_TEST_SRCS
 	test_math3d.cpp
 	test_math3d.c
 	test_physics.cpp
+	test_networking.cpp
 	test_ckit.c
 	test_model.cpp
 	test_jpg.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -61,6 +61,7 @@ TEST_SUITE(test_math);
 TEST_SUITE(test_math3d);
 TEST_SUITE(test_model);
 TEST_SUITE(test_physics);
+TEST_SUITE(test_networking);
 extern "C" {
 TEST_SUITE(test_math_c);
 TEST_SUITE(test_math3d_c);
@@ -136,6 +137,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_math3d_c);
 	RUN_TRACED(test_model);
 	RUN_TRACED(test_physics);
+	RUN_TRACED(test_networking);
 	// test_ckit calls sintern_nuke(), which invalidates every interned pointer a live
 	// engine holds as map keys (cf_sinuke's documented contract: not while an app
 	// exists). Kill the shared app first; the next GPU suite boots a fresh one whose

--- a/test/test_networking.cpp
+++ b/test/test_networking.cpp
@@ -1,0 +1,326 @@
+/*
+	Cute Framework
+	Copyright (C) 2024 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute_networking.h>
+#include <cute_alloc.h>
+#include <cute_c_runtime.h>
+#include <cute_time.h>
+#include <time.h>
+#include <string.h>
+
+// No UDP on web builds; the suite compiles away to nothing there.
+#ifndef CF_EMSCRIPTEN
+
+// Real loopback sockets through the full stack (crypto handshake included), no app required.
+// Each test uses its own port so a lingering socket from one can't trip the next.
+#define TEST_NET_APP_ID 0xC0FFEEull
+
+struct NetPair
+{
+	CF_Server* server;
+	CF_Client* client;
+	int client_index;
+};
+
+static void s_net_free(NetPair* np)
+{
+	if (np->client) { cf_client_disconnect(np->client); cf_destroy_client(np->client); }
+	if (np->server) { cf_server_stop(np->server); cf_destroy_server(np->server); }
+	np->client = NULL;
+	np->server = NULL;
+}
+
+// Pump one side of the handshake/update loop. Frees any stray payload events.
+static void s_drain_events(NetPair* np)
+{
+	CF_ServerEvent e;
+	while (cf_server_pop_event(np->server, &e)) {
+		if (e.type == CF_SERVER_EVENT_TYPE_NEW_CONNECTION) np->client_index = e.u.new_connection.client_index;
+		else if (e.type == CF_SERVER_EVENT_TYPE_PAYLOAD_PACKET) cf_server_free_packet(np->server, e.u.payload_packet.client_index, e.u.payload_packet.data);
+	}
+}
+
+static bool s_net_start(NetPair* np, const char* addr)
+{
+	memset(np, 0, sizeof(*np));
+	np->client_index = -1;
+	np->server = cf_make_server_insecure(TEST_NET_APP_ID);
+	if (!np->server) return false;
+	if (cf_is_error(cf_server_start(np->server, addr))) return false;
+	np->client = cf_make_client(0, TEST_NET_APP_ID, false);
+	if (!np->client) return false;
+	if (cf_is_error(cf_client_connect_insecure(np->client, addr, TEST_NET_APP_ID))) return false;
+	for (int i = 0; i < 5000; ++i) {
+		uint64_t now = (uint64_t)time(NULL);
+		cf_client_update(np->client, 1.0 / 60.0, now);
+		cf_server_update(np->server, 1.0 / 60.0, now);
+		s_drain_events(np);
+		if (cf_client_state(np->client) == CF_CLIENT_STATE_CONNECTED && np->client_index >= 0) return true;
+		cf_sleep(1);
+	}
+	return false;
+}
+
+static void s_net_update(NetPair* np)
+{
+	uint64_t now = (uint64_t)time(NULL);
+	cf_client_update(np->client, 1.0 / 60.0, now);
+	cf_server_update(np->server, 1.0 / 60.0, now);
+}
+
+/* Raw packets still round-trip (they carry a framing byte now), and messages flow both ways with
+ * ids, payloads, ordering, and zero-size messages intact. */
+TEST_CASE(test_net_raw_and_msgs)
+{
+	NetPair np;
+	REQUIRE(s_net_start(&np, "127.0.0.1:5801"));
+
+	// Raw client -> server.
+	const char raw[] = "raw packet says hi";
+	REQUIRE(!cf_is_error(cf_client_send(np.client, raw, sizeof(raw), true)));
+	bool got_raw = false;
+	for (int i = 0; i < 5000 && !got_raw; ++i) {
+		s_net_update(&np);
+		CF_ServerEvent e;
+		while (cf_server_pop_event(np.server, &e)) {
+			if (e.type == CF_SERVER_EVENT_TYPE_PAYLOAD_PACKET) {
+				REQUIRE(e.u.payload_packet.size == (int)sizeof(raw));
+				REQUIRE(!memcmp(e.u.payload_packet.data, raw, sizeof(raw)));
+				cf_server_free_packet(np.server, e.u.payload_packet.client_index, e.u.payload_packet.data);
+				got_raw = true;
+			}
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got_raw);
+
+	// Raw server -> client.
+	const char raw2[] = "server raw";
+	REQUIRE(!cf_is_error(cf_server_send(np.server, raw2, sizeof(raw2), np.client_index, true)));
+	got_raw = false;
+	for (int i = 0; i < 5000 && !got_raw; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		void* pkt;
+		int size;
+		while (cf_client_pop_packet(np.client, &pkt, &size, NULL)) {
+			REQUIRE(size == (int)sizeof(raw2));
+			REQUIRE(!memcmp(pkt, raw2, sizeof(raw2)));
+			cf_client_free_packet(np.client, pkt);
+			got_raw = true;
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got_raw);
+
+	// Messages client -> server on a reliable channel: ids, payloads, FIFO order, and a zero-size
+	// message. All coalesce into one bundle.
+	cf_client_channel_options(np.client, 0, 0, true);
+	const char* words[] = { "alpha", "beta", "gamma" };
+	for (uint32_t k = 0; k < 3; ++k) {
+		REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 0, 10 + k, words[k], (int)CF_STRLEN(words[k]) + 1)));
+	}
+	REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 0, 99, NULL, 0))); // An id alone is a message.
+	int got = 0;
+	bool got_empty = false;
+	for (int i = 0; i < 5000 && (got < 3 || !got_empty); ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		int ci;
+		uint32_t id;
+		void* data;
+		int size;
+		while (cf_server_pop_msg(np.server, &ci, &id, &data, &size)) {
+			REQUIRE(ci == np.client_index);
+			if (id == 99) {
+				REQUIRE(size == 0);
+				got_empty = true;
+			} else {
+				REQUIRE(id == 10 + (uint32_t)got); // FIFO order per channel.
+				REQUIRE(!CF_STRCMP((const char*)data, words[got]));
+				got++;
+			}
+			cf_server_free_msg(np.server, data);
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got == 3);
+	REQUIRE(got_empty);
+
+	// Messages server -> client.
+	cf_server_channel_options(np.server, 2, 0, true);
+	REQUIRE(!cf_is_error(cf_server_send_msg(np.server, np.client_index, 2, 777, "pong", 5)));
+	got = 0;
+	for (int i = 0; i < 5000 && !got; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		void* pkt;
+		int size;
+		while (cf_client_pop_packet(np.client, &pkt, &size, NULL)) cf_client_free_packet(np.client, pkt);
+		uint32_t id;
+		void* data;
+		while (cf_client_pop_msg(np.client, &id, &data, &size)) {
+			REQUIRE(id == 777);
+			REQUIRE(!CF_STRCMP((const char*)data, "pong"));
+			cf_client_free_msg(np.client, data);
+			got++;
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got == 1);
+
+	s_net_free(&np);
+	return true;
+}
+
+/* With a tight send budget, a high-priority channel's messages beat previously-queued low-priority
+ * ones over the wire, while both channels stay FIFO internally. */
+TEST_CASE(test_net_channel_priority)
+{
+	NetPair np;
+	REQUIRE(s_net_start(&np, "127.0.0.1:5802"));
+
+	cf_client_channel_options(np.client, 0, 0, true);  // Low priority "bulk".
+	cf_client_channel_options(np.client, 1, 10, true); // High priority "urgent".
+	cf_client_set_send_rate(np.client, 500); // Tiny budget so the queues can't drain in one update.
+
+	// Queue ALL the bulk first, then the urgent -- priority must reorder them on the wire.
+	char blob[50];
+	memset(blob, 0xAB, sizeof(blob));
+	for (uint32_t k = 0; k < 10; ++k) REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 0, 200 + k, blob, sizeof(blob))));
+	for (uint32_t k = 0; k < 5; ++k) REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 1, 100 + k, blob, sizeof(blob))));
+
+	uint32_t order[15];
+	int got = 0;
+	for (int i = 0; i < 10000 && got < 15; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		int ci;
+		uint32_t id;
+		void* data;
+		int size;
+		while (cf_server_pop_msg(np.server, &ci, &id, &data, &size)) {
+			REQUIRE(got < 15);
+			order[got++] = id;
+			cf_server_free_msg(np.server, data);
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got == 15);
+	// Every urgent message arrived before every bulk message, each channel in FIFO order. (Both
+	// channels are reliable, so the arrival order IS the pump order.)
+	for (int k = 0; k < 5; ++k) REQUIRE(order[k] == 100 + (uint32_t)k);
+	for (int k = 0; k < 10; ++k) REQUIRE(order[5 + k] == 200 + (uint32_t)k);
+
+	s_net_free(&np);
+	return true;
+}
+
+/* A reliable channel delivers every message in order through heavy simulated packet loss, and a
+ * message far bigger than one transport fragment survives fragmentation. */
+TEST_CASE(test_net_channel_reliable_loss)
+{
+	NetPair np;
+	REQUIRE(s_net_start(&np, "127.0.0.1:5803"));
+	cf_client_enable_network_simulator(np.client, 0, 0, 0.25, 0);
+	cf_server_enable_network_simulator(np.server, 0, 0, 0.25, 0);
+
+	cf_client_channel_options(np.client, 3, 0, true);
+	int n = 60;
+	for (uint32_t k = 0; k < (uint32_t)n; ++k) {
+		uint8_t payload[64];
+		int size = 1 + (int)(k % 60);
+		for (int b = 0; b < size; ++b) payload[b] = (uint8_t)(k + b);
+		REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 3, k, payload, size)));
+	}
+	// One big fragmented message rides behind them on the same channel.
+	int big_size = 100 * 1024;
+	uint8_t* big = (uint8_t*)cf_alloc(big_size);
+	for (int b = 0; b < big_size; ++b) big[b] = (uint8_t)(b * 7);
+	REQUIRE(!cf_is_error(cf_client_send_msg(np.client, 3, 0xB16, big, big_size)));
+
+	uint32_t expect = 0;
+	bool got_big = false;
+	for (int i = 0; i < 30000 && !got_big; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		int ci;
+		uint32_t id;
+		void* data;
+		int size;
+		while (cf_server_pop_msg(np.server, &ci, &id, &data, &size)) {
+			if (id == 0xB16) {
+				REQUIRE(expect == (uint32_t)n); // The big one comes last: FIFO held through loss.
+				REQUIRE(size == big_size);
+				REQUIRE(!memcmp(data, big, big_size));
+				got_big = true;
+			} else {
+				REQUIRE(id == expect); // In order, no gaps, despite 25% loss each way.
+				REQUIRE(size == 1 + (int)(expect % 60));
+				REQUIRE(((uint8_t*)data)[0] == (uint8_t)expect);
+				expect++;
+			}
+			cf_server_free_msg(np.server, data);
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(expect == (uint32_t)n);
+	REQUIRE(got_big);
+	cf_free(big);
+
+	s_net_free(&np);
+	return true;
+}
+
+/* Bad sends fail loudly instead of corrupting the stream: oversized messages, bad channel indices,
+ * unconnected client slots, and a flooded local queue. */
+TEST_CASE(test_net_msg_errors)
+{
+	NetPair np;
+	REQUIRE(s_net_start(&np, "127.0.0.1:5804"));
+
+	char byte = 7;
+	REQUIRE(cf_is_error(cf_client_send_msg(np.client, -1, 0, &byte, 1)));
+	REQUIRE(cf_is_error(cf_client_send_msg(np.client, CF_NET_MAX_CHANNELS, 0, &byte, 1)));
+	REQUIRE(cf_is_error(cf_client_send_msg(np.client, 0, 0, NULL, 1)));
+	REQUIRE(cf_is_error(cf_client_send_msg(np.client, 0, 0, &byte, CF_NET_MAX_MSG_SIZE + 1)));
+	REQUIRE(cf_is_error(cf_server_send_msg(np.server, np.client_index + 1, 0, 0, &byte, 1))); // Nobody there.
+	REQUIRE(cf_is_error(cf_server_send_msg(np.server, -1, 0, 0, &byte, 1)));
+
+	// Flood one channel's local queue without pumping (rate 0 pumps on update, so just don't
+	// update): the cap eventually pushes back with an error instead of eating memory.
+	cf_client_set_send_rate(np.client, 1); // Effectively frozen.
+	uint8_t* chunk = (uint8_t*)cf_alloc(CF_NET_MAX_MSG_SIZE);
+	memset(chunk, 3, CF_NET_MAX_MSG_SIZE);
+	bool full = false;
+	for (int i = 0; i < 64 && !full; ++i) {
+		full = cf_is_error(cf_client_send_msg(np.client, 5, 1, chunk, CF_NET_MAX_MSG_SIZE));
+	}
+	REQUIRE(full);
+	cf_free(chunk);
+
+	s_net_free(&np);
+	return true;
+}
+
+TEST_SUITE(test_networking)
+{
+	RUN_TEST_CASE(test_net_raw_and_msgs);
+	RUN_TEST_CASE(test_net_channel_priority);
+	RUN_TEST_CASE(test_net_channel_reliable_loss);
+	RUN_TEST_CASE(test_net_msg_errors);
+}
+
+#else // CF_EMSCRIPTEN
+
+TEST_SUITE(test_networking)
+{
+}
+
+#endif // CF_EMSCRIPTEN

--- a/tools/docs_parser.c
+++ b/tools/docs_parser.c
@@ -156,6 +156,7 @@ typedef struct Doc
 	char* example_brief;  // sdyna
 	char* example;        // sdyna
 	char* remarks;        // sdyna
+	char* deprecated;     // sdyna
 	char** related;       // dyna of sdyna
 } Doc;
 
@@ -394,6 +395,9 @@ static void emit_title(FILE* fp, Doc* doc)
 static void emit_brief(FILE* fp, Doc* doc)
 {
 	fprintf(fp, "%s\n\n", doc->brief);
+	if (doc->deprecated && slen(doc->deprecated)) {
+		fprintf(fp, "> **Deprecated**: %s\n\n", doc->deprecated);
+	}
 }
 
 static void emit_signature(FILE* fp, Doc* doc)
@@ -587,6 +591,9 @@ static void parse_command()
 	} else if (sequ(s->token, "@remarks")) {
 		sfree(s->doc.remarks);
 		s->doc.remarks = parse_paragraph(0);
+	} else if (sequ(s->token, "@deprecated")) {
+		sfree(s->doc.deprecated);
+		s->doc.deprecated = parse_paragraph(0);
 	} else if (sequ(s->token, "@related")) {
 		char* text = parse_paragraph(0);
 		// Split by space.
@@ -1043,6 +1050,7 @@ int main(int argc, char* argv[])
 		doc->example_brief = auto_generate_links(doc, doc->example_brief);
 		doc->example = auto_generate_links(doc, doc->example);
 		doc->remarks = auto_generate_links(doc, doc->remarks);
+		doc->deprecated = auto_generate_links(doc, doc->deprecated);
 		for (int j = 0; j < asize(doc->related);) {
 			const char* rel = doc->related[j];
 			if (sequ(rel, doc->title)) {


### PR DESCRIPTION
Adds the message/channel layer discussed for friendslop netcode, plus a cute_net transport fix its tests caught.

## Channels
- Messages are `(id, bytes)` queued on one of `CF_NET_MAX_CHANNELS` (8) channels via `cf_client_send_msg` / `cf_server_send_msg`; received with `cf_*_pop_msg` / `cf_*_free_msg`. The id is a user type tag delivered with the bytes.
- `cf_*_channel_options(channel, priority, reliable)`: each update, queues pump into the transport **highest priority first**, under an optional **bytes/sec budget** (`cf_*_set_send_rate`, token bucket that can go into debt so oversized messages still ship). Bulk low-prio traffic waits locally instead of flooding the send queue ahead of urgent messages — the reliable layer sees backpressure instead of a mixed flood.
- Reliability is per channel (reliable = every message, in order, per channel FIFO). Small messages coalesce into single-fragment bundles (~1000B target). Per-channel local queue cap (4MB) returns an error instead of eating memory.
- `CF_Client`/`CF_Server` are now real wrapper structs around the walled `cn` handles, holding channel state. Raw `cf_client_send`/`cf_server_send` are unchanged in API and bypass the budget.
- **Wire change**: every CF packet now leads with one framing byte (raw vs bundle) so receive paths can demux. Both peers must run the same CF version.

## cute_net fix: standalone ack packets
The new one-directional test deadlocked and it's a real transport bug: acks only piggyback on outgoing packets, so a reliable send larger than `max_fragments_in_flight` fragments (~35KB) to a *quiet* peer stalls forever (sender resends its full window, waiting on acks that have no packet to ride; the existing cn test worked around it by pumping fire-and-forget traffic both ways every iteration). The transport now sends a tiny ack-only packet (transport prefix 2) when acks are pending and nothing else carried them. Ack-only packets are processed ack-fields-only — they don't count as ack-worthy traffic, so two idle peers can't ack each other's acks forever. Normal bidirectional games piggyback as before and never emit them.

## Tests
- cute_net self-suite: new `cn_transport_one_directional_reliable` regression; all 55 pass.
- New CF `test_networking` suite (runs in CI, loopback through the full crypto handshake, no app/GPU needed): raw round-trip with framing, msg ids/payloads/FIFO/zero-size, priority-vs-budget wire ordering, 60 msgs + a 100KB fragmented reliable message through 25% simulated loss both ways, and the error paths (oversize, bad channel, not-connected, queue-full backpressure).
- Full CF suite: 355/355.

Next: friendslop moves its input path onto channels (player intents: unreliable movement channel + reliable action channel).