### PR TITLE
sdlgpu: sampler for depth textures with explicit SAMPLER usage

### DIFF
--- a/src/cute_graphics_sdlgpu.cpp
+++ b/src/cute_graphics_sdlgpu.cpp
@@ -612,8 +612,10 @@ static inline CF_Texture s_make_texture(CF_TextureParams params, CF_SampleCount 
 	SDL_GPUSampler* sampler = NULL;
 	// Depth/stencil textures don't need their own sampler, as the associated color
 	// texture in the owning canvas already has a sampler attached -- except comparison
-	// (shadow) samplers, which exist precisely to sample a depth texture.
-	if (!s_is_depth(params.pixel_format) || params.compare_enable) {
+	// (shadow) samplers, which exist precisely to sample a depth texture, and depth
+	// textures that explicitly ask for SAMPLER usage: those are bound as a plain
+	// sampler2D for non-comparison reads (soft particles, SSAO, depth-aware fog).
+	if (!s_is_depth(params.pixel_format) || params.compare_enable || (params.usage & CF_TEXTURE_USAGE_SAMPLER_BIT)) {
 		SDL_GPUSamplerCreateInfo sampler_info = SDL_GPUSamplerCreateInfoDefaults();
 		sampler_info.mip_lod_bias = params.mip_lod_bias;
 		// Without the enable flag max_anisotropy is ignored wholesale (it also overrides


### PR DESCRIPTION
A depth texture created without `compare_enable` never got a sampler object — the backend assumed depth is only sampled through comparison (shadow) samplers. Binding such a texture as a plain `sampler2D` handed SDL_GPU a NULL sampler and access-violated at draw time.

Non-comparison depth reads are a normal access-layer need (soft particles fading against scene depth, SSAO, depth-aware fog), and `cf_canvas_get_depth_stencil_target` + `cf_draw3d_set_texture` already advertise the path. Create the sampler whenever the texture explicitly requests `CF_TEXTURE_USAGE_SAMPLER_BIT`, matching what the user asked for at creation.

Default canvas depth targets carry only `DEPTH_STENCIL_TARGET` usage, so they still skip the sampler exactly as before; the comparison-sampler path is untouched. GLES backend untouched (its samplers are per-unit state, no equivalent NULL-object hazard).

Hit in practice by friendslop's soft fireball particles: scene depth in a `SAMPLER_BIT` D32 target, sampled by the FX pass through a color-only `attach_target` canvas — instant AV on both D3D12 and Vulkan before this fix, works on both after.