### PR TITLE
Web client networking: datagram wire seam + cf_client_web_wire

### DIFF
--- a/docs/topics/emscripten.md
+++ b/docs/topics/emscripten.md
@@ -25,6 +25,19 @@ Everything in the ✔ column is exercised by the test suite on both backends. Sh
 > [!NOTE]
 > Emscripten builds automatically disable CF's [HTTPS support](../api_reference.md#web), since web builds suffer from very poor support of this feature.
 
+## Networking on Web
+
+Browsers cannot open UDP sockets, so a web build's [client](networking.md) sends its datagrams through a *wire* instead of a socket: call [`cf_client_web_wire`](../net/function/cf_client_web_wire.md) after `cf_make_client` and before `cf_client_connect`, and every packet rides a browser transport to a tiny relay next to your game server, which forwards them to the server's normal UDP port -- the server cannot tell the difference. See the [Web Clients](networking.md#web-clients) section of the networking topic for the full architecture, including what the relay has to do (very little). Servers do not run in browsers; `cf_server_start` fails cleanly on web.
+
+```c
+CF_Client* client = cf_make_client(0, APP_ID, false);
+#ifdef CF_EMSCRIPTEN
+	// Usually derived from location.origin: the host that served the page runs the relay.
+	cf_client_web_wire(client, "https://mygame.example/wire/5601");
+#endif
+cf_client_connect(client, token);
+```
+
 ## Install Emscripten
 
 Make sure [emscripten is installed](https://emscripten.org/docs/getting_started/downloads.html) on your machine, along with [Perl](https://strawberryperl.com/).

--- a/docs/topics/networking.md
+++ b/docs/topics/networking.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > CF's networking is implemented by [cute_net.h](https://github.com/RandyGaul/cute_headers/blob/master/cute_net.h), a low level networking header. This code has not yet reached stable maturity -- use at your own risk! CF would like to release networking features officially in a future release.
 
-CF's networking model uses a [client server networking architecture](https://en.wikipedia.org/wiki/Client%E2%80%93server_model). The underlying protocol works over UDP packets. There is no TCP support or peer-to-peer connections. However, CF does provide an [https API](../api_reference.md#web) for sending requests to an HTTP server. Here are the features of the client server API.
+CF's networking model uses a [client server networking architecture](https://en.wikipedia.org/wiki/Client%E2%80%93server_model). The underlying protocol works over UDP packets. There is no TCP support or peer-to-peer connections (web builds ride a relay instead -- see [Web Clients](#web-clients) below). However, CF does provide an [https API](../api_reference.md#web) for sending requests to an HTTP server. Here are the features of the client server API.
 
 * Out-of-the-box security model based on state of the art connect tokens.
 * Optional reliable and in-order packets.
@@ -54,3 +54,19 @@ The game server itself is an instance of [`CF_Server`](../net/struct/cf_server.m
 ## Example Client and Server
 
 Here is a [quick and dirty demonstration](https://github.com/RandyGaul/cf_net_test) showing how to setup a client and server for testing purposes. This shows basic usage of the client and server API, where multiple clients can connect to a single server. The connect tokens are generated on the dedicated server instead of using a web service, which is a great way to test things out during development.
+
+## Web Clients
+
+Browsers cannot open UDP sockets, so a client compiled with emscripten routes its packets through a *wire* instead: a pluggable datagram transport ([`CF_ClientWire`](../net/struct/cf_clientwire.md)) that replaces the client's internal socket. Each call to the wire moves one whole packet, with datagram semantics -- packets may arrive dropped, duplicated, or reordered, and the protocol handles all of that exactly as it does over UDP. The server keeps its ordinary UDP socket and cannot tell wired clients from native ones.
+
+The ready-made browser wire is [`cf_client_web_wire`](../net/function/cf_client_web_wire.md): give it a URL like `https://mygame.example/wire/5601` after `cf_make_client` and before `cf_client_connect`. It tries [WebTransport](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport) datagrams first (true unreliable datagrams over HTTP/3 -- no head-of-line blocking), and falls back to a WebSocket at the same URL (`https` -> `wss`) where WebTransport is unavailable or blocked. Both carry one datagram per message.
+
+The URL points at a **relay**: a small service running next to your game server that forwards each browser message to the server's UDP port and each UDP response back, 1:1. The relay needs almost nothing:
+
+* Accept WebTransport sessions and/or WebSocket upgrades at some path carrying the target port (e.g. `/wire/<port>`), allowlisted to your server's port range so it is not an open proxy.
+* Per connection, open one UDP socket to the game server and pump datagrams both ways until either side closes (an idle timeout is wise).
+* Nothing else. The relay is *untrusted by design*: every datagram is already encrypted and authenticated end-to-end by the connect-token handshake, so the relay only ever sees ciphertext, and a malicious relay can do nothing but drop packets -- which the protocol already tolerates.
+
+Since the relay typically lives on the same host that serves the web build, the page can derive the wire URL from `location.origin`. Note the connect token still needs a parseable IP endpoint even though a wired client never dials it -- `127.0.0.1:<port>` works fine as a placeholder.
+
+Serving a WebTransport endpoint requires an HTTP/3 stack and real TLS certificates (browsers only expose WebTransport in secure contexts); libraries like Go's `webtransport-go` plus automatic Let's Encrypt issuance make this a small, self-contained daemon. The WebSocket fallback needs only an ordinary HTTP(S) server. Servers themselves never run in browsers: on web, `cf_server_start` returns an error.

--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -10,8 +10,9 @@
 
 #include "cute_defines.h"
 
-// This entire file makes no sense for web builds, since web doesn't allow UDP.
-#ifndef CF_EMSCRIPTEN
+// Web builds get this whole API too. Browsers have no UDP, so a web client's traffic rides a
+// CF_ClientWire (see cf_client_web_wire) to a relay; servers, whose sockets cannot open in a
+// browser, fail cleanly at cf_server_start.
 
 #include "cute_result.h"
 
@@ -294,6 +295,63 @@ CF_API CF_Result CF_CALL cf_client_connect(CF_Client* client, const uint8_t* con
  * @related  CF_Client cf_make_client cf_destroy_client cf_client_connect cf_client_disconnect cf_client_update
  */
 CF_API void CF_CALL cf_client_disconnect(CF_Client* client);
+
+/**
+ * @struct   CF_ClientWire
+ * @category net
+ * @brief    An optional datagram transport for a client, replacing its internal UDP socket.
+ * @remarks  Each call moves one whole packet: `send` ships `size` bytes to the server as one
+ *           datagram, and `recv` fills `data` with one pending datagram (up to `size` bytes),
+ *           returning its length, 0 when nothing is pending, or negative on transport failure.
+ *           Datagram semantics are assumed -- packets may arrive dropped, duplicated, or
+ *           reordered, and the protocol handles all of that as usual; the wire only moves bytes.
+ *           This is how web builds connect (see `cf_client_web_wire` and the Web topic page):
+ *           browsers have no UDP, so datagrams ride a WebTransport or WebSocket bridge to a
+ *           relay, and the server keeps its normal UDP socket. A wire also makes loopback or
+ *           in-memory transports possible for tests.
+ * @related  CF_Client cf_client_set_wire cf_client_web_wire cf_client_connect
+ */
+typedef struct CF_ClientWire
+{
+	/* @member Passed back to `send` and `recv`. */
+	void* udata;
+
+	/* @member Sends one whole datagram to the server. Returns bytes sent, or negative on failure. */
+	int (CF_CALL* send)(void* udata, const void* data, int size);
+
+	/* @member Receives one whole pending datagram into `data`, up to `size` bytes. Returns its
+	   length, 0 when nothing is pending, or negative on transport failure. */
+	int (CF_CALL* recv)(void* udata, void* data, int size);
+} CF_ClientWire;
+// @end
+
+/**
+ * @function cf_client_set_wire
+ * @category net
+ * @brief    Routes all of a client's traffic through a `CF_ClientWire` instead of a UDP socket.
+ * @remarks  Call after `cf_make_client` and before `cf_client_connect`. The wire struct is copied;
+ *           whatever `udata` points at must outlive the client.
+ * @related  CF_ClientWire cf_client_web_wire cf_client_connect
+ */
+CF_API void CF_CALL cf_client_set_wire(CF_Client* client, CF_ClientWire wire);
+
+/**
+ * @function cf_client_web_wire
+ * @category net
+ * @brief    On web builds, wires a client to a datagram relay by URL -- the browser's road to a UDP server.
+ * @param    url  The relay endpoint, e.g. `"https://mygame.example/wire/5601"`. WebTransport is tried
+ *                at this URL first; on failure the same URL is retried as a WebSocket (`https` ->
+ *                `wss`). Both carry one datagram per message.
+ * @return   Returns an error on native builds (this is web machinery), or when the URL is malformed.
+ * @remarks  Call after `cf_make_client` and before `cf_client_connect`, in place of `cf_client_set_wire`.
+ *           The connection opens in the background; packets sent before it opens are dropped, which the
+ *           protocol's redundant handshake absorbs. The relay is an untrusted dumb pipe (every datagram
+ *           is already encrypted), typically a tiny daemon on the game server's host that forwards
+ *           WebTransport/WebSocket messages to the server's UDP port 1:1. See the Web topic page for
+ *           the full picture, including a reference relay.
+ * @related  CF_ClientWire cf_client_set_wire cf_client_connect
+ */
+CF_API CF_Result CF_CALL cf_client_web_wire(CF_Client* client, const char* url);
 
 /**
  * @function cf_client_update
@@ -1205,7 +1263,5 @@ CF_INLINE void server_tick(Server* server) { cf_server_tick(server); }
 }
 
 #endif // CF_CPP
-
-#endif // CF_EMSCRIPTEN
 
 #endif // CF_NETWORKING_H

--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -35,7 +35,6 @@
 	TODO FEATURES
 
 		* Bandwidth throttling
-		* TCP-only mode (for web builds via emscripten)
 		* Channel support (for reliable packet stalling mitigation)
 		* Loopback clients for server
 		* Memory stats query for server
@@ -60,8 +59,10 @@
 			* ESP
 			* AVR
 
-		Please note emscripten (and browsers) are not supported, as Cute Net uses
-		the UDP transport layer, not TCP.
+		Emscripten (browser) builds are supported for the CLIENT only, via `cn_client_set_wire`:
+		browsers have no UDP, so the client's datagrams ride a user-provided wire (WebTransport
+		or WebSocket) to a relay that speaks plain UDP to the server. Servers are not supported
+		in browsers.
 
 
 	LIMITATIONS
@@ -358,6 +359,28 @@ cn_result_t cn_client_connect(cn_client_t* client, const uint8_t* connect_token)
 void cn_client_disconnect(cn_client_t* client);
 
 /**
+ * An optional datagram transport for the client, replacing the internal UDP socket. Each call
+ * moves one whole packet: `send` ships `size` bytes to the server as one datagram, `recv` fills
+ * `data` with one pending datagram (up to `size` bytes) and returns its length, 0 when nothing
+ * is pending, or negative on transport failure. Datagram semantics are assumed -- packets may
+ * arrive dropped, duplicated, or reordered, and cute net's protocol handles all of that as
+ * usual; the wire only moves bytes. The wire is how web builds (emscripten) connect: browsers
+ * have no UDP, so a wire backed by a WebTransport or WebSocket bridge relays datagrams to the
+ * server, which keeps its normal UDP socket and cannot tell the difference (each datagram is
+ * already encrypted, so the relay is an untrusted dumb pipe). A wire also makes loopback or
+ * in-memory transports possible for tests. Set it after `cn_client_create` and before
+ * `cn_client_connect`. The wire must outlive the client; cute net never frees it.
+ */
+typedef struct cn_wire_t
+{
+	void* udata;
+	int (*send)(void* udata, const void* data, int size);
+	int (*recv)(void* udata, void* data, int size);
+} cn_wire_t;
+
+void cn_client_set_wire(cn_client_t* client, cn_wire_t* wire);
+
+/**
  * You should call this one per game loop after calling `cn_client_connect`.
  */
 void cn_client_update(cn_client_t* client, double dt, uint64_t current_time);
@@ -608,7 +631,7 @@ CN_INLINE cn_result_t cn_error_success(void) { cn_result_t result; result.code =
 #elif defined(__ANDROID__)
 #	define CN_ANDROID 1
 #elif defined(__EMSCRIPTEN__)
-#	error Emscripten is not supported, as Cute Net uses the UDP transport layer.
+#	define CN_EMSCRIPTEN 1
 #endif
 
 #if !defined(CN_ALLOC)
@@ -2007,7 +2030,7 @@ static TLS struct {
 		return 0;
 	}
 
-#elif defined(__wasi__)
+#elif defined(__wasi__) || defined(__EMSCRIPTEN__)
 
 	#include <unistd.h>
 
@@ -5292,6 +5315,7 @@ struct cn_protocol_client_t
 	int server_endpoint_index;
 	cn_endpoint_t web_service_endpoint;
 	cn_socket_t socket;
+	cn_wire_t* wire; // When set, replaces the socket entirely (see cn_client_set_wire).
 	uint64_t sequence;
 	cn_circular_buffer_t packet_queue;
 	cn_protocol_replay_buffer_t replay_buffer;
@@ -6645,7 +6669,7 @@ cn_result_t cn_protocol_client_connect(cn_protocol_client_t* client, const uint8
 	}
 	cn_address_type_t sock_addr_type = CN_ADDRESS_TYPE_IPV4;
 #endif
-	if (cn_socket_init1(&client->socket, sock_addr_type, client->port, CN_PROTOCOL_CLIENT_SEND_BUFFER_SIZE, CN_PROTOCOL_CLIENT_RECEIVE_BUFFER_SIZE)) {
+	if (!client->wire && cn_socket_init1(&client->socket, sock_addr_type, client->port, CN_PROTOCOL_CLIENT_SEND_BUFFER_SIZE, CN_PROTOCOL_CLIENT_RECEIVE_BUFFER_SIZE)) {
 		return cn_error_failure("Unable to open socket.");
 	}
 
@@ -6680,12 +6704,18 @@ CN_INLINE const char* s_protocol_packet_str(uint8_t type)
 	return NULL;
 }
 
+static CN_INLINE void s_protocol_client_send_raw(cn_protocol_client_t* client, int sz)
+{
+	if (client->wire) client->wire->send(client->wire->udata, client->buffer, sz);
+	else cn_socket_send(&client->socket, client->sim, s_protocol_server_endpoint(client), client->buffer, sz);
+}
+
 static void s_protocol_client_send(cn_protocol_client_t* client, void* packet)
 {
 	int sz = cn_protocol_packet_write(packet, client->buffer, client->sequence++, &client->connect_token.client_to_server_key);
 
 	if (sz >= 73) {
-		cn_socket_send(&client->socket, client->sim, s_protocol_server_endpoint(client), client->buffer, sz);
+		s_protocol_client_send_raw(client, sz);
 		client->last_packet_sent_time = 0;
 		//log(CN_LOG_LEVEL_INFORMATIONAL, "Protocol Client: Sent %s packet to server.", s_protocol_packet_str(*(uint8_t*)packet));
 	}
@@ -6745,13 +6775,19 @@ static void s_protocol_receive_packets(cn_protocol_client_t* client)
 
 	while (1)
 	{
-		// Read packet from UDP stack, and open it.
-		cn_endpoint_t from;
-		int sz = cn_socket_receive(&client->socket, &from, buffer, CN_PROTOCOL_PACKET_SIZE_MAX);
-		if (!sz) break;
-
-		if (!cn_endpoint_equals(s_protocol_server_endpoint(client), from)) {
-			continue;
+		// Read packet from the UDP stack (or the wire, which is point-to-point with the
+		// server, so its packets need no source-address check), and open it.
+		int sz;
+		if (client->wire) {
+			sz = client->wire->recv(client->wire->udata, buffer, CN_PROTOCOL_PACKET_SIZE_MAX);
+			if (sz <= 0) break;
+		} else {
+			cn_endpoint_t from;
+			sz = cn_socket_receive(&client->socket, &from, buffer, CN_PROTOCOL_PACKET_SIZE_MAX);
+			if (!sz) break;
+			if (!cn_endpoint_equals(s_protocol_server_endpoint(client), from)) {
+				continue;
+			}
 		}
 
 		if (sz < 73) {
@@ -6960,7 +6996,7 @@ cn_result_t cn_protocol_client_send(cn_protocol_client_t* client, const void* da
 	if (size > CN_PROTOCOL_PACKET_PAYLOAD_MAX) return cn_error_failure("`size` exceeded `CN_PROTOCOL_PACKET_PAYLOAD_MAX`.");
 	int sz = s_protocol_write_payload_packet(data, size, client->buffer, client->sequence++, &client->connect_token.client_to_server_key);
 	if (sz >= 73) {
-		cn_socket_send(&client->socket, client->sim, s_protocol_server_endpoint(client), client->buffer, sz);
+		s_protocol_client_send_raw(client, sz);
 		client->last_packet_sent_time = 0;
 	}
 	return cn_error_success();
@@ -9159,6 +9195,11 @@ cn_client_t* cn_client_create(uint16_t port, uint64_t application_id, bool use_i
 	return client;
 }
 
+void cn_client_set_wire(cn_client_t* client, cn_wire_t* wire)
+{
+	client->p_client->wire = wire;
+}
+
 void cn_client_destroy(cn_client_t* client)
 {
 	if (!client) return;
@@ -9251,6 +9292,7 @@ const char* cn_client_state_string(cn_client_state_t state)
 
 void cn_client_enable_network_simulator(cn_client_t* client, double latency, double jitter, double drop_chance, double duplicate_chance)
 {
+	if (client->p_client->wire) return; // The simulator wraps the UDP socket; a wire has none.
 	cn_protocol_client_enable_network_simulator(client->p_client, latency, jitter, drop_chance, duplicate_chance);
 }
 

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -11,9 +11,9 @@
 #include <cute_time.h>
 #include <time.h>
 
-// This entire file makes no sense for web builds, since web doesn't allow UDP.
-#ifndef CF_EMSCRIPTEN
-
+// Web builds compile all of this too: a client rides a CF_ClientWire (see cf_client_web_wire at
+// the bottom of this file) since browsers have no UDP, while servers -- whose sockets cannot open
+// in a browser -- fail cleanly at cf_server_start.
 #define CUTE_NET_IMPLEMENTATION
 #define CN_ALLOC(size, ctx) cf_alloc(size)
 #define CN_FREE(mem, ctx) cf_free(mem)
@@ -352,7 +352,31 @@ struct CF_Client
 	int rate; // Bytes per second budget for the pump; 0 = unlimited.
 	uint8_t* scratch;
 	int scratch_cap;
+	CF_ClientWire wire;      // Optional datagram transport (see cf_client_set_wire); cn_wire installed when wire.send is set.
+	cn_wire_t cn_wire;
+	int web_wire_handle;     // Nonzero when cf_client_web_wire owns a JS-side connection.
 };
+
+static int s_wire_send_thunk(void* udata, const void* data, int size)
+{
+	CF_Client* client = (CF_Client*)udata;
+	return client->wire.send(client->wire.udata, data, size);
+}
+
+static int s_wire_recv_thunk(void* udata, void* data, int size)
+{
+	CF_Client* client = (CF_Client*)udata;
+	return client->wire.recv(client->wire.udata, data, size);
+}
+
+void cf_client_set_wire(CF_Client* client, CF_ClientWire wire)
+{
+	client->wire = wire;
+	client->cn_wire.udata = client;
+	client->cn_wire.send = s_wire_send_thunk;
+	client->cn_wire.recv = s_wire_recv_thunk;
+	cn_client_set_wire(client->cn, &client->cn_wire);
+}
 
 CF_Client* cf_make_client(
 	uint16_t port,
@@ -367,8 +391,15 @@ CF_Client* cf_make_client(
 	return client;
 }
 
+#ifdef CF_EMSCRIPTEN
+extern "C" void s_js_wire_close(int h); // Defined via EM_JS at the bottom of this file.
+#endif
+
 void cf_destroy_client(CF_Client* client)
 {
+#ifdef CF_EMSCRIPTEN
+	if (client->web_wire_handle) s_js_wire_close(client->web_wire_handle);
+#endif
 	cn_client_destroy(client->cn);
 	s_peer_reset(&client->send);
 	s_msg_clear(&client->rx);
@@ -790,6 +821,124 @@ void cf_client_tick(CF_Client* client)
 void cf_server_tick(CF_Server* server)
 {
 	cf_server_update(server, CF_DELTA_TIME, (uint64_t)time(NULL));
+}
+
+//--------------------------------------------------------------------------------------------------
+// The web wire: WebTransport datagrams with a WebSocket fallback, one datagram per message either
+// way. All connection state lives in JS; C polls a per-wire receive queue. Opening is async and
+// sends before the pipe is up are dropped -- the protocol's redundant handshake absorbs that.
+
+#ifdef CF_EMSCRIPTEN
+
+#include <emscripten/emscripten.h>
+
+// clang-format off
+EM_JS(void, s_js_wire_open, (int h, const char* url_cstr), {
+	var url = UTF8ToString(url_cstr);
+	if (!Module.cfWires) Module.cfWires = {};
+	var w = { q: [], open: false, dead: false, wt: null, ws: null, writer: null };
+	Module.cfWires[h] = w;
+	var push = function(bytes) {
+		if (w.q.length >= 256) w.q.shift(); // Datagram semantics: drop oldest under pressure.
+		w.q.push(bytes);
+	};
+	var fallback = function() {
+		if (w.dead || w.ws) return;
+		try {
+			var ws = new WebSocket(url.replace(/^http/, "ws"));
+			ws.binaryType = "arraybuffer";
+			ws.onmessage = function(e) { push(new Uint8Array(e.data)); };
+			ws.onopen = function() { w.open = true; };
+			ws.onclose = function() { if (w.open || !w.wt) w.dead = true; };
+			ws.onerror = function() { if (!w.open) w.dead = true; };
+			w.ws = ws;
+		} catch (e) { w.dead = true; }
+	};
+	if (typeof WebTransport !== "undefined") {
+		try {
+			var wt = new WebTransport(url);
+			w.wt = wt;
+			wt.ready.then(function() {
+				w.open = true;
+				w.writer = wt.datagrams.writable.getWriter();
+				var reader = wt.datagrams.readable.getReader();
+				var pump = function() {
+					reader.read().then(function(r) {
+						if (r.done || w.dead) return;
+						push(r.value);
+						pump();
+					}).catch(function() { w.dead = true; });
+				};
+				pump();
+				wt.closed.then(function() { w.dead = true; }).catch(function() { w.dead = true; });
+			}).catch(function() { w.wt = null; fallback(); });
+		} catch (e) { w.wt = null; fallback(); }
+	} else {
+		fallback();
+	}
+});
+
+EM_JS(int, s_js_wire_send, (int h, const void* data, int size), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w || w.dead) return -1;
+	if (!w.open) return 0; // Still connecting: drop, the handshake retries.
+	var bytes = HEAPU8.slice(data, data + size);
+	try {
+		if (w.writer) w.writer.write(bytes);
+		else if (w.ws && w.ws.readyState === 1) w.ws.send(bytes);
+		else return 0;
+	} catch (e) { return -1; }
+	return size;
+});
+
+EM_JS(int, s_js_wire_recv, (int h, void* data, int size), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w) return -1;
+	if (!w.q.length) return w.dead ? -1 : 0;
+	var bytes = w.q.shift();
+	var n = Math.min(bytes.length, size);
+	HEAPU8.set(bytes.subarray(0, n), data);
+	return n;
+});
+
+EM_JS(void, s_js_wire_close, (int h), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w) return;
+	w.dead = true;
+	try { if (w.wt) w.wt.close(); } catch (e) {}
+	try { if (w.ws) w.ws.close(); } catch (e) {}
+	delete Module.cfWires[h];
+});
+// clang-format on
+
+static int s_web_wire_send(void* udata, const void* data, int size) { return s_js_wire_send((int)(uintptr_t)udata, data, size); }
+static int s_web_wire_recv(void* udata, void* data, int size) { return s_js_wire_recv((int)(uintptr_t)udata, data, size); }
+
+CF_Result cf_client_web_wire(CF_Client* client, const char* url)
+{
+	if (!url || (CF_STRNCMP(url, "https://", 8) && CF_STRNCMP(url, "http://", 7))) {
+		return cf_result_error("cf_client_web_wire wants an http(s):// relay URL.");
+	}
+	static int next_handle = 1;
+	int h = next_handle++;
+	if (client->web_wire_handle) s_js_wire_close(client->web_wire_handle);
+	client->web_wire_handle = h;
+	s_js_wire_open(h, url);
+	CF_ClientWire wire;
+	wire.udata = (void*)(uintptr_t)h;
+	wire.send = s_web_wire_send;
+	wire.recv = s_web_wire_recv;
+	cf_client_set_wire(client, wire);
+	return cf_result_success();
+}
+
+#else // CF_EMSCRIPTEN
+
+CF_Result cf_client_web_wire(CF_Client* client, const char* url)
+{
+	CF_UNUSED(client);
+	CF_UNUSED(url);
+	return cf_result_error("cf_client_web_wire is web (emscripten) machinery; on native builds connect over UDP as usual, or install your own CF_ClientWire.");
 }
 
 #endif // CF_EMSCRIPTEN

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -14,6 +14,92 @@
 // Web builds compile all of this too: a client rides a CF_ClientWire (see cf_client_web_wire at
 // the bottom of this file) since browsers have no UDP, while servers -- whose sockets cannot open
 // in a browser -- fail cleanly at cf_server_start.
+// The JS half of the web wire (used by cf_client_web_wire at the bottom of this file):
+// WebTransport datagrams with a WebSocket fallback, one datagram per message either way,
+// all connection state living in JS while C polls a per-wire receive queue.
+#ifdef CF_EMSCRIPTEN
+#include <emscripten/emscripten.h>
+
+// clang-format off
+EM_JS(void, s_js_wire_open, (int h, const char* url_cstr), {
+	var url = UTF8ToString(url_cstr);
+	if (!Module.cfWires) Module.cfWires = {};
+	var w = { q: [], open: false, dead: false, wt: null, ws: null, writer: null };
+	Module.cfWires[h] = w;
+	var push = function(bytes) {
+		if (w.q.length >= 256) w.q.shift(); // Datagram semantics: drop oldest under pressure.
+		w.q.push(bytes);
+	};
+	var fallback = function() {
+		if (w.dead || w.ws) return;
+		try {
+			var ws = new WebSocket(url.replace(/^http/, "ws"));
+			ws.binaryType = "arraybuffer";
+			ws.onmessage = function(e) { push(new Uint8Array(e.data)); };
+			ws.onopen = function() { w.open = true; };
+			ws.onclose = function() { if (w.open || !w.wt) w.dead = true; };
+			ws.onerror = function() { if (!w.open) w.dead = true; };
+			w.ws = ws;
+		} catch (e) { w.dead = true; }
+	};
+	if (typeof WebTransport !== "undefined") {
+		try {
+			var wt = new WebTransport(url);
+			w.wt = wt;
+			wt.ready.then(function() {
+				w.open = true;
+				w.writer = wt.datagrams.writable.getWriter();
+				var reader = wt.datagrams.readable.getReader();
+				var pump = function() {
+					reader.read().then(function(r) {
+						if (r.done || w.dead) return;
+						push(r.value);
+						pump();
+					}).catch(function() { w.dead = true; });
+				};
+				pump();
+				wt.closed.then(function() { w.dead = true; }).catch(function() { w.dead = true; });
+			}).catch(function() { w.wt = null; fallback(); });
+		} catch (e) { w.wt = null; fallback(); }
+	} else {
+		fallback();
+	}
+});
+
+EM_JS(int, s_js_wire_send, (int h, const void* data, int size), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w || w.dead) return -1;
+	if (!w.open) return 0; // Still connecting: drop, the handshake retries.
+	var bytes = HEAPU8.slice(data, data + size);
+	try {
+		if (w.writer) w.writer.write(bytes);
+		else if (w.ws && w.ws.readyState === 1) w.ws.send(bytes);
+		else return 0;
+	} catch (e) { return -1; }
+	return size;
+});
+
+EM_JS(int, s_js_wire_recv, (int h, void* data, int size), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w) return -1;
+	if (!w.q.length) return w.dead ? -1 : 0;
+	var bytes = w.q.shift();
+	var n = Math.min(bytes.length, size);
+	HEAPU8.set(bytes.subarray(0, n), data);
+	return n;
+});
+
+EM_JS(void, s_js_wire_close, (int h), {
+	var w = Module.cfWires && Module.cfWires[h];
+	if (!w) return;
+	w.dead = true;
+	try { if (w.wt) w.wt.close(); } catch (e) {}
+	try { if (w.ws) w.ws.close(); } catch (e) {}
+	delete Module.cfWires[h];
+});
+// clang-format on
+#endif // CF_EMSCRIPTEN
+
 #define CUTE_NET_IMPLEMENTATION
 #define CN_ALLOC(size, ctx) cf_alloc(size)
 #define CN_FREE(mem, ctx) cf_free(mem)
@@ -390,10 +476,6 @@ CF_Client* cf_make_client(
 	client->cn = cn;
 	return client;
 }
-
-#ifdef CF_EMSCRIPTEN
-extern "C" void s_js_wire_close(int h); // Defined via EM_JS at the bottom of this file.
-#endif
 
 void cf_destroy_client(CF_Client* client)
 {
@@ -830,86 +912,7 @@ void cf_server_tick(CF_Server* server)
 
 #ifdef CF_EMSCRIPTEN
 
-#include <emscripten/emscripten.h>
 
-// clang-format off
-EM_JS(void, s_js_wire_open, (int h, const char* url_cstr), {
-	var url = UTF8ToString(url_cstr);
-	if (!Module.cfWires) Module.cfWires = {};
-	var w = { q: [], open: false, dead: false, wt: null, ws: null, writer: null };
-	Module.cfWires[h] = w;
-	var push = function(bytes) {
-		if (w.q.length >= 256) w.q.shift(); // Datagram semantics: drop oldest under pressure.
-		w.q.push(bytes);
-	};
-	var fallback = function() {
-		if (w.dead || w.ws) return;
-		try {
-			var ws = new WebSocket(url.replace(/^http/, "ws"));
-			ws.binaryType = "arraybuffer";
-			ws.onmessage = function(e) { push(new Uint8Array(e.data)); };
-			ws.onopen = function() { w.open = true; };
-			ws.onclose = function() { if (w.open || !w.wt) w.dead = true; };
-			ws.onerror = function() { if (!w.open) w.dead = true; };
-			w.ws = ws;
-		} catch (e) { w.dead = true; }
-	};
-	if (typeof WebTransport !== "undefined") {
-		try {
-			var wt = new WebTransport(url);
-			w.wt = wt;
-			wt.ready.then(function() {
-				w.open = true;
-				w.writer = wt.datagrams.writable.getWriter();
-				var reader = wt.datagrams.readable.getReader();
-				var pump = function() {
-					reader.read().then(function(r) {
-						if (r.done || w.dead) return;
-						push(r.value);
-						pump();
-					}).catch(function() { w.dead = true; });
-				};
-				pump();
-				wt.closed.then(function() { w.dead = true; }).catch(function() { w.dead = true; });
-			}).catch(function() { w.wt = null; fallback(); });
-		} catch (e) { w.wt = null; fallback(); }
-	} else {
-		fallback();
-	}
-});
-
-EM_JS(int, s_js_wire_send, (int h, const void* data, int size), {
-	var w = Module.cfWires && Module.cfWires[h];
-	if (!w || w.dead) return -1;
-	if (!w.open) return 0; // Still connecting: drop, the handshake retries.
-	var bytes = HEAPU8.slice(data, data + size);
-	try {
-		if (w.writer) w.writer.write(bytes);
-		else if (w.ws && w.ws.readyState === 1) w.ws.send(bytes);
-		else return 0;
-	} catch (e) { return -1; }
-	return size;
-});
-
-EM_JS(int, s_js_wire_recv, (int h, void* data, int size), {
-	var w = Module.cfWires && Module.cfWires[h];
-	if (!w) return -1;
-	if (!w.q.length) return w.dead ? -1 : 0;
-	var bytes = w.q.shift();
-	var n = Math.min(bytes.length, size);
-	HEAPU8.set(bytes.subarray(0, n), data);
-	return n;
-});
-
-EM_JS(void, s_js_wire_close, (int h), {
-	var w = Module.cfWires && Module.cfWires[h];
-	if (!w) return;
-	w.dead = true;
-	try { if (w.wt) w.wt.close(); } catch (e) {}
-	try { if (w.ws) w.ws.close(); } catch (e) {}
-	delete Module.cfWires[h];
-});
-// clang-format on
 
 static int s_web_wire_send(void* udata, const void* data, int size) { return s_js_wire_send((int)(uintptr_t)udata, data, size); }
 static int s_web_wire_recv(void* udata, void* data, int size) { return s_js_wire_recv((int)(uintptr_t)udata, data, size); }

--- a/test/test_networking.cpp
+++ b/test/test_networking.cpp
@@ -46,7 +46,7 @@ static void s_drain_events(NetPair* np)
 	}
 }
 
-static bool s_net_start(NetPair* np, const char* addr)
+static bool s_net_start_wired(NetPair* np, const char* addr, CF_ClientWire* wire)
 {
 	memset(np, 0, sizeof(*np));
 	np->client_index = -1;
@@ -55,6 +55,7 @@ static bool s_net_start(NetPair* np, const char* addr)
 	if (cf_is_error(cf_server_start(np->server, addr))) return false;
 	np->client = cf_make_client(0, TEST_NET_APP_ID, false);
 	if (!np->client) return false;
+	if (wire) cf_client_set_wire(np->client, *wire);
 	if (cf_is_error(cf_client_connect_insecure(np->client, addr, TEST_NET_APP_ID))) return false;
 	for (int i = 0; i < 5000; ++i) {
 		uint64_t now = (uint64_t)time(NULL);
@@ -65,6 +66,11 @@ static bool s_net_start(NetPair* np, const char* addr)
 		cf_sleep(1);
 	}
 	return false;
+}
+
+static bool s_net_start(NetPair* np, const char* addr)
+{
+	return s_net_start_wired(np, addr, NULL);
 }
 
 static void s_net_update(NetPair* np)
@@ -309,12 +315,140 @@ TEST_CASE(test_net_msg_errors)
 	return true;
 }
 
+// A UDP socket dressed as a CF_ClientWire: in-process, this is exactly what a web build's
+// relay does from the server's point of view -- datagrams arrive on its normal UDP socket
+// while the client rides the wire.
+#ifdef _WIN32
+#	include <winsock2.h>
+#	pragma comment(lib, "ws2_32.lib")
+	typedef SOCKET WireSocketHandle;
+#else
+#	include <sys/socket.h>
+#	include <netinet/in.h>
+#	include <arpa/inet.h>
+#	include <fcntl.h>
+#	include <unistd.h>
+	typedef int WireSocketHandle;
+#endif
+
+struct WireSocket
+{
+	WireSocketHandle s;
+	sockaddr_in to;
+};
+
+static bool s_wire_socket_open(WireSocket* w, uint16_t port)
+{
+#ifdef _WIN32
+	WSADATA wsa; // Refcounted; harmless alongside cn's own WSAStartup.
+	if (WSAStartup(MAKEWORD(2, 2), &wsa)) return false;
+#endif
+	w->s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	memset(&w->to, 0, sizeof(w->to));
+	w->to.sin_family = AF_INET;
+	w->to.sin_port = htons(port);
+	w->to.sin_addr.s_addr = htonl(0x7F000001); // 127.0.0.1
+#ifdef _WIN32
+	if (w->s == INVALID_SOCKET) return false;
+	u_long yes = 1;
+	ioctlsocket(w->s, FIONBIO, &yes);
+#else
+	if (w->s < 0) return false;
+	fcntl(w->s, F_SETFL, fcntl(w->s, F_GETFL, 0) | O_NONBLOCK);
+#endif
+	return true;
+}
+
+static void s_wire_socket_close(WireSocket* w)
+{
+#ifdef _WIN32
+	closesocket(w->s);
+#else
+	close(w->s);
+#endif
+}
+
+static int s_wire_send(void* udata, const void* data, int size)
+{
+	WireSocket* w = (WireSocket*)udata;
+	return (int)sendto(w->s, (const char*)data, size, 0, (sockaddr*)&w->to, sizeof(w->to));
+}
+
+static int s_wire_recv(void* udata, void* data, int size)
+{
+	WireSocket* w = (WireSocket*)udata;
+	int n = (int)recvfrom(w->s, (char*)data, size, 0, NULL, NULL);
+	return n < 0 ? 0 : n; // Nonblocking: a would-block error means nothing pending.
+}
+
+/* The whole protocol -- crypto handshake, raw packets, reliable channel messages -- flows
+ * through a CF_ClientWire while the server keeps its ordinary UDP socket, never able to tell
+ * the difference. This is the seam web builds ride (cf_client_web_wire). */
+TEST_CASE(test_net_client_wire)
+{
+	WireSocket w;
+	REQUIRE(s_wire_socket_open(&w, 5805));
+	CF_ClientWire wire;
+	wire.udata = &w;
+	wire.send = s_wire_send;
+	wire.recv = s_wire_recv;
+
+	NetPair np;
+	REQUIRE(s_net_start_wired(&np, "127.0.0.1:5805", &wire));
+
+	// Raw client -> server through the wire.
+	const char raw[] = "datagrams in disguise";
+	REQUIRE(!cf_is_error(cf_client_send(np.client, raw, sizeof(raw), true)));
+	bool got_raw = false;
+	for (int i = 0; i < 5000 && !got_raw; ++i) {
+		s_net_update(&np);
+		CF_ServerEvent e;
+		while (cf_server_pop_event(np.server, &e)) {
+			if (e.type == CF_SERVER_EVENT_TYPE_PAYLOAD_PACKET) {
+				REQUIRE(e.u.payload_packet.size == (int)sizeof(raw));
+				REQUIRE(!memcmp(e.u.payload_packet.data, raw, sizeof(raw)));
+				cf_server_free_packet(np.server, e.u.payload_packet.client_index, e.u.payload_packet.data);
+				got_raw = true;
+			}
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got_raw);
+
+	// A reliable message server -> client through the wire.
+	cf_server_channel_options(np.server, 0, 0, true);
+	REQUIRE(!cf_is_error(cf_server_send_msg(np.server, np.client_index, 0, 42, "wired", 6)));
+	bool got_msg = false;
+	for (int i = 0; i < 5000 && !got_msg; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		void* pkt;
+		int size;
+		while (cf_client_pop_packet(np.client, &pkt, &size, NULL)) cf_client_free_packet(np.client, pkt);
+		uint32_t id;
+		void* data;
+		while (cf_client_pop_msg(np.client, &id, &data, &size)) {
+			REQUIRE(id == 42);
+			REQUIRE(!CF_STRCMP((const char*)data, "wired"));
+			cf_client_free_msg(np.client, data);
+			got_msg = true;
+		}
+		cf_sleep(1);
+	}
+	REQUIRE(got_msg);
+
+	s_net_free(&np);
+	s_wire_socket_close(&w);
+	return true;
+}
+
 TEST_SUITE(test_networking)
 {
 	RUN_TEST_CASE(test_net_raw_and_msgs);
 	RUN_TEST_CASE(test_net_channel_priority);
 	RUN_TEST_CASE(test_net_channel_reliable_loss);
 	RUN_TEST_CASE(test_net_msg_errors);
+	RUN_TEST_CASE(test_net_client_wire);
 }
 
 #else // CF_EMSCRIPTEN


### PR DESCRIPTION
Browsers have no UDP, which has kept CF networking off the web entirely (the whole module was compiled out under emscripten). This PR gives cute_net clients a pluggable datagram transport and builds the browser path on top of it:

- **cute_net**: `cn_wire_t` + `cn_client_set_wire` — an optional send/recv pair replacing the client's internal UDP socket, one whole packet per call, datagram semantics assumed (the protocol handles loss/dup/reorder as usual). The emscripten `#error` is gone; hydrogen randomness rides `getentropy` on wasm. Servers still never run in browsers — `cf_server_start` fails cleanly there instead of the API not existing.
- **CF**: `CF_ClientWire` / `cf_client_set_wire`, plus `cf_client_web_wire(url)` — a ready-made browser wire that tries WebTransport datagrams first and falls back to a WebSocket at the same URL, one datagram per message, all state in JS with C polling a queue. Packets sent while the pipe is still opening are dropped, which the redundant handshake absorbs.
- **Test**: `test_net_client_wire` runs the whole protocol — crypto handshake, raw packets, reliable channel messages — through a wire (a raw UDP socket standing in for the relay) against a server on its normal socket.
- **Docs**: emscripten.md + networking.md gain the web-client architecture, including the relay contract (an untrusted dumb pipe: every datagram is already encrypted end-to-end, so a relay can only drop packets, which the protocol tolerates).

Proven end-to-end in friendslop: a browser client through a WebSocket relay into a live game instance — connected, snapshots flowing, world rendering. Retires the "TCP-only mode (for web builds via emscripten)" TODO in cute_net's header.