### PR TITLE
GLES: buffer deletion must not clear the divisor shadow

### DIFF
--- a/src/cute_graphics_gles.cpp
+++ b/src/cute_graphics_gles.cpp
@@ -449,7 +449,13 @@ static inline void s_forget_buffer(GLuint id)
 	if (g_ctx.bound_array_buffer == id) g_ctx.bound_array_buffer = 0;
 	if (g_ctx.bound_element_buffer == id) g_ctx.bound_element_buffer = 0;
 	for (int i = 0; i < 64; ++i) {
-		if (g_ctx.attrib_shadow[i].buf == id) g_ctx.attrib_shadow[i] = { };
+		if (g_ctx.attrib_shadow[i].buf != id) continue;
+		// The divisor is per-index context state, untouched by buffer deletion -- clearing
+		// its shadow here would desync it (a skipped divisor call on stale-but-correct
+		// shadow state is how instanced garbage sneaks into per-vertex draws).
+		uint8_t divisor = g_ctx.attrib_shadow[i].divisor;
+		g_ctx.attrib_shadow[i] = { };
+		g_ctx.attrib_shadow[i].divisor = divisor;
 	}
 }
 


### PR DESCRIPTION
Fixes the 8 `test_draw3d` failures the `linux / gles3` job caught on master after #591 (mea culpa for merging that one without waiting on CI).

The attribute shadow's `s_forget_buffer` zeroed entire entries when a buffer id was deleted. But the divisor is per-index context state that `glDeleteBuffers` does not touch: GL kept divisor 1 while the shadow claimed 0, so the next per-vertex draw at that location skipped its "redundant" divisor call and read vertex data per-instance — garbage geometry/colors in any frame that recycled buffer ids. The forget now clears only the buffer-dependent fields and preserves the divisor.

Verified: `CF_TEST_GLES=1 tests test_draw3d` reproduces master's 8 failures locally and passes 28/28 with this fix; the full suite passes on the default backend. Bisected precisely: fences innocent, pointer cache innocent, divisor forget guilty.