### PR TITLE
docs: retire the networking use-at-your-own-risk warning

### DIFF
--- a/docs/topics/networking.md
+++ b/docs/topics/networking.md
@@ -1,7 +1,6 @@
 # Networking
 
-> [!NOTE]
-> CF's networking is implemented by [cute_net.h](https://github.com/RandyGaul/cute_headers/blob/master/cute_net.h), a low level networking header. This code has not yet reached stable maturity -- use at your own risk! CF would like to release networking features officially in a future release.
+CF's networking is implemented on top of [cute_net.h](https://github.com/RandyGaul/cute_headers/blob/master/cute_net.h), a low level networking header, wrapped behind the `CF_Client` / `CF_Server` API described here.
 
 CF's networking model uses a [client server networking architecture](https://en.wikipedia.org/wiki/Client%E2%80%93server_model). The underlying protocol works over UDP packets. There is no TCP support or peer-to-peer connections (web builds ride a relay instead -- see [Web Clients](#web-clients) below). However, CF does provide an [https API](../api_reference.md#web) for sending requests to an HTTP server. Here are the features of the client server API.
 


### PR DESCRIPTION
The maturity warning atop networking.md predates networking becoming load-bearing (the friendslop playtest box, and now web clients through the wire seam). cute_net.h itself carries no equivalent warning — this was the only instance. Docs-only.