### PR TITLE
Wire docs: use-case list + header TODO refresh

### DIFF
--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -305,10 +305,28 @@ CF_API void CF_CALL cf_client_disconnect(CF_Client* client);
  *           returning its length, 0 when nothing is pending, or negative on transport failure.
  *           Datagram semantics are assumed -- packets may arrive dropped, duplicated, or
  *           reordered, and the protocol handles all of that as usual; the wire only moves bytes.
- *           This is how web builds connect (see `cf_client_web_wire` and the Web topic page):
- *           browsers have no UDP, so datagrams ride a WebTransport or WebSocket bridge to a
- *           relay, and the server keeps its normal UDP socket. A wire also makes loopback or
- *           in-memory transports possible for tests.
+ *
+ *           The wire is deliberately contentless -- addressing lives outside it, and security
+ *           and delivery guarantees live above it (every datagram is independently encrypted
+ *           and authenticated) -- so wires compose, and unlock more than the obvious:
+ *
+ *           - Web builds (`cf_client_web_wire`, and the Web Clients section of the networking
+ *             topic page): browsers have no UDP, so datagrams ride a WebTransport or WebSocket
+ *             bridge to a relay beside the server, which keeps its normal UDP socket.
+ *           - Untrusted relays / NAT traversal: a relay only ever sees ciphertext, so bouncing
+ *             through any rented box is safe -- a hostile relay can only drop packets.
+ *           - Multi-path racing: send each datagram down two routes and merge receives;
+ *             per-packet latency becomes the minimum of the paths, and replay protection
+ *             already dedupes the copies.
+ *           - In-memory loopback: a queue-pair wire runs a client with no sockets at all, for
+ *             deterministic tests.
+ *           - Network-condition simulation: wrap any wire in a latency/jitter/loss wire --
+ *             composes on every platform, web included.
+ *           - Fuzzing and metrics: a natural interception point to flip bits (exercising the
+ *             crypto reject path) or meter bandwidth. Note a wire tee sees ciphertext under
+ *             ephemeral session keys; payload-level capture is the better forensics tool.
+ *           - Exotic transports: anything that moves an opaque datagram (platform relay
+ *             services, console transport layers, P2P sessions) can carry a connection.
  * @related  CF_Client cf_client_set_wire cf_client_web_wire cf_client_connect
  */
 typedef struct CF_ClientWire

--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -30,13 +30,18 @@
 		* State of the art connect tokens for security.
 		* Support for large packets (fragmentation and reassembly).
 		* Bandwidth stats (incoming/outgoing kbps, packet loss).
+		* Pluggable client transport (`cn_client_set_wire`): route a client's datagrams
+		  through anything that can carry opaque bytes -- browser transports on web builds,
+		  untrusted relays, in-memory queues for tests. See the cn_wire_t docs for the
+		  use cases this unlocks.
 
 
 	TODO FEATURES
 
 		* Bandwidth throttling
 		* Channel support (for reliable packet stalling mitigation)
-		* Loopback clients for server
+		* Server-side wire, completing in-process loopback clients (the client half ships
+		  via cn_client_set_wire; the server still receives only on its UDP socket)
 		* Memory stats query for server
 
 
@@ -364,12 +369,36 @@ void cn_client_disconnect(cn_client_t* client);
  * `data` with one pending datagram (up to `size` bytes) and returns its length, 0 when nothing
  * is pending, or negative on transport failure. Datagram semantics are assumed -- packets may
  * arrive dropped, duplicated, or reordered, and cute net's protocol handles all of that as
- * usual; the wire only moves bytes. The wire is how web builds (emscripten) connect: browsers
- * have no UDP, so a wire backed by a WebTransport or WebSocket bridge relays datagrams to the
- * server, which keeps its normal UDP socket and cannot tell the difference (each datagram is
- * already encrypted, so the relay is an untrusted dumb pipe). A wire also makes loopback or
- * in-memory transports possible for tests. Set it after `cn_client_create` and before
+ * usual; the wire only moves bytes. Set it after `cn_client_create` and before
  * `cn_client_connect`. The wire must outlive the client; cute net never frees it.
+ *
+ * The wire is deliberately contentless: addressing lives outside it, security and delivery
+ * guarantees live above it (every datagram is independently encrypted and authenticated, and
+ * loss/duplication/reordering are already the protocol's job). That makes wires compose, and
+ * unlocks more than the obvious:
+ *
+ *    * Web builds -- browsers have no UDP, so datagrams ride a WebTransport or WebSocket
+ *      bridge to a relay beside the server, which keeps its normal UDP socket and cannot
+ *      tell the difference.
+ *    * Untrusted relays / NAT traversal -- a relay only ever sees ciphertext, so bouncing
+ *      through ANY box you can rent is safe; the worst a hostile relay can do is drop
+ *      packets, which is just weather.
+ *    * Multi-path racing -- send every datagram down two routes (say direct UDP and a
+ *      relay) and merge receives: per-packet latency becomes the minimum of the paths,
+ *      and replay protection already dedupes the copies.
+ *    * In-memory loopback -- a queue-pair wire runs a client with no sockets at all,
+ *      for deterministic tests.
+ *    * Network-condition simulation -- wrap any wire in a latency/jitter/loss wire; unlike
+ *      the built-in simulator (which wraps the UDP socket), this composes on every platform,
+ *      web included.
+ *    * Fuzzing and metrics -- the wire is a natural interception point: flip bits to
+ *      exercise the crypto reject path, or meter bandwidth. (Note a wire tee captures
+ *      ciphertext under ephemeral session keys, so offline replay of a capture needs the
+ *      keys saved alongside; payload-level capture above the protocol is usually the
+ *      better forensics tool.)
+ *    * Exotic transports -- anything that moves an opaque datagram (platform relay
+ *      services, console transport layers, P2P sessions) can carry a connection without
+ *      touching cute net again.
  */
 typedef struct cn_wire_t
 {


### PR DESCRIPTION
Doc-comments only. `cn_wire_t` and `CF_ClientWire` remarks gain a brief list of what the contentless wire unlocks — web builds, untrusted relays (ciphertext-only, worst case is dropped packets), multi-path racing (replay protection dedupes the copies), in-memory loopback tests, composable network simulation, fuzzing/metrics interception, exotic transports — with the honest caveat that a wire tee captures ciphertext under ephemeral session keys, so payload-level capture is the better forensics tool. cute_net's top-of-header FEATURES list gains the wire, and the loopback TODO shrinks to its remaining half (a server-side wire; the client half shipped in #590). Verified with a local docsparser run: parses clean, list renders on the generated pages.