### PR TITLE
Snapshot compression: tight worst-case bound + exact negative-required returns

### DIFF
--- a/include/cute_networking.h
+++ b/include/cute_networking.h
@@ -1036,12 +1036,31 @@ CF_API void CF_CALL cf_server_free_msg(CF_Server* server, void* data);
  * @param    size            The size of both snapshots in bytes.
  * @param    out             Destination buffer for the compressed bytes.
  * @param    out_capacity    Capacity of `out` in bytes.
- * @return   Returns the compressed size in bytes, or -1 if it did not fit in `out_capacity`.
+ * @return   Returns the compressed size in bytes. When `out_capacity` is too small, returns the
+ *           NEGATIVE of the exact capacity required -- `if (result >= 0)` still means success,
+ *           and a retry with `-result` bytes succeeds. A buffer of
+ *           `cf_snapshot_compress_bound(size)` bytes can never fail.
  * @remarks  `baseline` and `current` must have identical layout and size; only their differences
- *           are encoded. Decompress with `cf_snapshot_decompress` and the same baseline.
- * @related  cf_snapshot_decompress cf_client_send cf_server_send
+ *           are encoded. Decompress with `cf_snapshot_decompress` and the same baseline. Output
+ *           never exceeds `cf_snapshot_compress_bound(size)`: when the entropy coder cannot beat
+ *           raw storage (adversarial or incompressible input), the snapshot is stored raw behind
+ *           a one-byte flag, so pathological input costs one byte of expansion, not a blowup.
+ *           Compressed streams are not stable across CF versions -- both ends of a connection
+ *           must run the same build, which the connect handshake already implies.
+ * @related  cf_snapshot_compress_bound cf_snapshot_decompress cf_client_send cf_server_send
  */
 CF_API int CF_CALL cf_snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity);
+
+/**
+ * @function cf_snapshot_compress_bound
+ * @category net
+ * @brief    Returns the worst-case output size of `cf_snapshot_compress` for a `size`-byte snapshot.
+ * @remarks  Exactly `size + 1`: one flag byte plus, at worst, the raw snapshot (the compressor
+ *           falls back to raw storage whenever entropy coding cannot beat it). Allocate this much
+ *           and `cf_snapshot_compress` cannot fail.
+ * @related  cf_snapshot_compress cf_snapshot_decompress
+ */
+CF_API int CF_CALL cf_snapshot_compress_bound(int size);
 
 /**
  * @function cf_snapshot_decompress
@@ -1052,8 +1071,9 @@ CF_API int CF_CALL cf_snapshot_compress(const void* baseline, const void* curren
  * @param    compressed      The compressed delta bytes.
  * @param    compressed_size The number of compressed bytes.
  * @param    out             Destination buffer for the reconstructed snapshot, `size` bytes.
- * @return   Returns 0 on success.
- * @related  cf_snapshot_compress cf_client_pop_packet cf_server_pop_event
+ * @return   Returns 0 on success, or -1 for malformed input (no flag byte, or a truncated raw
+ *           payload).
+ * @related  cf_snapshot_compress cf_snapshot_compress_bound cf_client_pop_packet cf_server_pop_event
  */
 CF_API int CF_CALL cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out);
 
@@ -1268,6 +1288,7 @@ CF_INLINE void server_free_msg(Server* server, void* data) { cf_server_free_msg(
 // COMPRESSION
 
 CF_INLINE int snapshot_compress(const void* baseline, const void* current, int size, void* out, int out_capacity) { return cf_snapshot_compress(baseline,current,size,out,out_capacity); }
+CF_INLINE int snapshot_compress_bound(int size) { return cf_snapshot_compress_bound(size); }
 CF_INLINE int snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out) { return cf_snapshot_decompress(baseline,size,compressed,compressed_size,out); }
 
 //--------------------------------------------------------------------------------------------------

--- a/libraries/cute/cute_arith.h
+++ b/libraries/cute/cute_arith.h
@@ -25,7 +25,7 @@
 			cf_arith_encoder e; cf_arith_encoder_init(&e, out_buffer, out_cap);
 			cf_arith_encode_byte(&e, model, some_byte);
 			...
-			int bytes = cf_arith_encoder_flush(&e);   // -1 if it overflowed out_cap
+			int bytes = cf_arith_encoder_flush(&e);   // Negative of the required size if out_cap was too small.
 
 		Decode (mirror the exact same model updates and call sequence):
 			uint16_t model[256]; cf_arith_probs_clear(model, 256);
@@ -184,11 +184,13 @@ static inline void cf_arith_encode_uint(cf_arith_encoder* e, uint16_t* probs, ui
 	}
 }
 
-// Finish the stream. Returns the number of bytes written, or -1 if the output buffer overflowed.
+// Finish the stream. Returns the number of bytes written, or, if the output buffer overflowed,
+// the NEGATIVE of the total bytes the stream needed (the encoder keeps counting past the cap,
+// so a failed call still reports the exact required capacity: retry with -return_value).
 static inline int cf_arith_encoder_flush(cf_arith_encoder* e)
 {
 	for (int i = 0; i < 5; ++i) cf_arith_s_shift_low(e);
-	return e->overflow ? -1 : e->count;
+	return e->overflow ? -e->count : e->count;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -285,31 +287,62 @@ static inline uint64_t cf_arith_decode_uint(cf_arith_decoder* d, uint16_t* probs
 // so the long runs of unchanged fields typical of frame-to-frame game state cost almost nothing.
 // The decode side reproduces `cur` exactly given the identical `prev`.
 
-// Returns the compressed size in bytes, or -1 if it overflowed out_cap.
+// Upper bound on cf_arith_delta_compress output for n input bytes: the arithmetic stream is
+// kept only when it beats storing raw, so one flag byte plus the raw bytes is the ceiling.
+// A buffer of at least this size can never overflow.
+#define cf_arith_delta_bound(n) ((n) + 1)
+
+// Compresses into a one-byte flag plus either the arithmetic-coded delta (flag 0) or the raw
+// bytes of `cur` (flag 1) -- raw wins whenever arithmetic coding fails to beat it, so
+// adversarial input costs at most one byte of expansion. Returns the compressed size, or the
+// NEGATIVE of the exact required capacity when out_cap is too small; a
+// cf_arith_delta_bound(n)-sized buffer never fails.
 static inline int cf_arith_delta_compress(const uint8_t* prev, const uint8_t* cur, int n, uint8_t* out, int out_cap)
 {
 	uint16_t changed = CF_ARITH_PROB_INIT;
 	uint16_t value[256];
 	cf_arith_probs_clear(value, 256);
 	cf_arith_encoder e;
-	cf_arith_encoder_init(&e, out, out_cap);
+	int arith_cap = out_cap - 1 < n ? out_cap - 1 : n; // Past n, raw wins anyway.
+	if (arith_cap < 0) arith_cap = 0;
+	cf_arith_encoder_init(&e, out_cap >= 1 ? out + 1 : 0, arith_cap);
 	for (int i = 0; i < n; ++i) {
 		uint8_t d = (uint8_t)(cur[i] ^ (prev ? prev[i] : 0));
 		int is_changed = d != 0;
 		cf_arith_encode_bit(&e, &changed, is_changed);
 		if (is_changed) cf_arith_encode_byte(&e, value, d);
 	}
-	return cf_arith_encoder_flush(&e);
+	int size = cf_arith_encoder_flush(&e);
+	if (size >= 0 && size < n) {
+		out[0] = 0;
+		return size + 1;
+	}
+	if (out_cap >= n + 1) {
+		// Raw escape: arithmetic lost to (or tied with) raw storage.
+		out[0] = 1;
+		for (int i = 0; i < n; ++i) out[1 + i] = cur[i];
+		return n + 1;
+	}
+	int required = (size < 0 ? -size : size) + 1; // Exact: the encoder counts past overflow.
+	if (required > n + 1) required = n + 1;
+	return -required;
 }
 
-// Reconstructs `cur` (n bytes) from `prev` and the compressed delta. Returns 0 on success.
+// Reconstructs `cur` (n bytes) from `prev` and the compressed delta. Returns 0 on success, or
+// -1 for malformed input (no flag byte, or a truncated raw payload).
 static inline int cf_arith_delta_decompress(const uint8_t* prev, int n, const uint8_t* in, int in_size, uint8_t* cur)
 {
+	if (in_size < 1) return -1;
+	if (in[0]) {
+		if (in_size < n + 1) return -1;
+		for (int i = 0; i < n; ++i) cur[i] = in[1 + i];
+		return 0;
+	}
 	uint16_t changed = CF_ARITH_PROB_INIT;
 	uint16_t value[256];
 	cf_arith_probs_clear(value, 256);
 	cf_arith_decoder d;
-	cf_arith_decoder_init(&d, in, in_size);
+	cf_arith_decoder_init(&d, in + 1, in_size - 1);
 	for (int i = 0; i < n; ++i) {
 		uint8_t delta = 0;
 		if (cf_arith_decode_bit(&d, &changed)) delta = cf_arith_decode_byte(&d, value);

--- a/src/cute_networking.cpp
+++ b/src/cute_networking.cpp
@@ -833,6 +833,11 @@ int cf_snapshot_compress(const void* baseline, const void* current, int size, vo
 	return cf_arith_delta_compress((const uint8_t*)baseline, (const uint8_t*)current, size, (uint8_t*)out, out_capacity);
 }
 
+int cf_snapshot_compress_bound(int size)
+{
+	return cf_arith_delta_bound(size);
+}
+
 int cf_snapshot_decompress(const void* baseline, int size, const void* compressed, int compressed_size, void* out)
 {
 	return cf_arith_delta_decompress((const uint8_t*)baseline, size, (const uint8_t*)compressed, compressed_size, (uint8_t*)out);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(CF_TEST_SRCS
 	main.cpp
 	test_alloc.cpp
+	test_arith.cpp
 	test_app.cpp
 	test_array.cpp
 	test_aseprite.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -62,6 +62,7 @@ TEST_SUITE(test_math3d);
 TEST_SUITE(test_model);
 TEST_SUITE(test_physics);
 TEST_SUITE(test_networking);
+TEST_SUITE(test_arith);
 extern "C" {
 TEST_SUITE(test_math_c);
 TEST_SUITE(test_math3d_c);
@@ -138,6 +139,7 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_model);
 	RUN_TRACED(test_physics);
 	RUN_TRACED(test_networking);
+	RUN_TRACED(test_arith);
 	// test_ckit calls sintern_nuke(), which invalidates every interned pointer a live
 	// engine holds as map keys (cf_sinuke's documented contract: not while an app
 	// exists). Kill the shared app first; the next GPU suite boots a fresh one whose

--- a/test/test_arith.cpp
+++ b/test/test_arith.cpp
@@ -1,0 +1,153 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#include "test_harness.h"
+
+#include <cute_networking.h>
+#include <cute_alloc.h>
+#include <string.h>
+
+// Snapshot compression contracts: the worst-case bound is tight (raw-store escape), a
+// bound-sized buffer never fails, and an undersized buffer reports the exact required
+// capacity as a negative return -- `if (result >= 0)` stays the success check.
+
+static void s_fill_random(uint8_t* p, int n, uint32_t seed)
+{
+	// xorshift; incompressible enough to force the raw escape.
+	uint32_t x = seed ? seed : 1;
+	for (int i = 0; i < n; ++i) {
+		x ^= x << 13;
+		x ^= x >> 17;
+		x ^= x << 5;
+		p[i] = (uint8_t)x;
+	}
+}
+
+/* A typical sparse delta compresses far below the bound and round-trips exactly. */
+TEST_CASE(test_arith_sparse_delta_roundtrip)
+{
+	const int n = 4096;
+	uint8_t* base = (uint8_t*)cf_alloc(n);
+	uint8_t* cur = (uint8_t*)cf_alloc(n);
+	uint8_t* out = (uint8_t*)cf_alloc(cf_snapshot_compress_bound(n));
+	uint8_t* rt = (uint8_t*)cf_alloc(n);
+	s_fill_random(base, n, 7);
+	memcpy(cur, base, n);
+	for (int i = 0; i < n; i += 97) cur[i] ^= (uint8_t)(i * 31 + 1); // ~1% changed.
+
+	int size = cf_snapshot_compress(base, cur, n, out, cf_snapshot_compress_bound(n));
+	REQUIRE(size >= 0);
+	REQUIRE(size <= cf_snapshot_compress_bound(n));
+	REQUIRE(size < n / 4); // Sparse changes should compress well below raw.
+	REQUIRE(cf_snapshot_decompress(base, n, out, size, rt) == 0);
+	REQUIRE(!memcmp(rt, cur, n));
+
+	// An identical frame costs nearly nothing: model warm-up plus the coder's flush tail,
+	// far below one bit per byte.
+	int same = cf_snapshot_compress(base, base, n, out, cf_snapshot_compress_bound(n));
+	REQUIRE(same >= 0 && same < n / 64);
+	REQUIRE(cf_snapshot_decompress(base, n, out, same, rt) == 0);
+	REQUIRE(!memcmp(rt, base, n));
+
+	cf_free(base);
+	cf_free(cur);
+	cf_free(out);
+	cf_free(rt);
+	return true;
+}
+
+/* Incompressible input takes the raw escape: output stays within the bound (one byte over raw
+ * at worst) and still round-trips. This is the tight-worst-case guarantee. */
+TEST_CASE(test_arith_incompressible_raw_escape)
+{
+	const int n = 2048;
+	uint8_t* base = (uint8_t*)cf_alloc(n);
+	uint8_t* cur = (uint8_t*)cf_alloc(n);
+	uint8_t* out = (uint8_t*)cf_alloc(cf_snapshot_compress_bound(n));
+	uint8_t* rt = (uint8_t*)cf_alloc(n);
+	s_fill_random(base, n, 11);
+	s_fill_random(cur, n, 999); // Unrelated noise: every byte differs, no structure.
+
+	int size = cf_snapshot_compress(base, cur, n, out, cf_snapshot_compress_bound(n));
+	REQUIRE(size >= 0);
+	REQUIRE(size <= cf_snapshot_compress_bound(n));
+	REQUIRE(cf_snapshot_decompress(base, n, out, size, rt) == 0);
+	REQUIRE(!memcmp(rt, cur, n));
+
+	// NULL baseline (first snapshot) round-trips too.
+	int first = cf_snapshot_compress(NULL, cur, n, out, cf_snapshot_compress_bound(n));
+	REQUIRE(first >= 0 && first <= cf_snapshot_compress_bound(n));
+	REQUIRE(cf_snapshot_decompress(NULL, n, out, first, rt) == 0);
+	REQUIRE(!memcmp(rt, cur, n));
+
+	cf_free(base);
+	cf_free(cur);
+	cf_free(out);
+	cf_free(rt);
+	return true;
+}
+
+/* An undersized buffer reports the exact required capacity, negated; retrying with -result
+ * succeeds and matches a full-buffer compression byte for byte. */
+TEST_CASE(test_arith_negative_required)
+{
+	const int n = 1024;
+	uint8_t* base = (uint8_t*)cf_alloc(n);
+	uint8_t* cur = (uint8_t*)cf_alloc(n);
+	uint8_t* full = (uint8_t*)cf_alloc(cf_snapshot_compress_bound(n));
+	uint8_t* rt = (uint8_t*)cf_alloc(n);
+	s_fill_random(base, n, 3);
+	s_fill_random(cur, n, 12345);
+
+	int full_size = cf_snapshot_compress(base, cur, n, full, cf_snapshot_compress_bound(n));
+	REQUIRE(full_size >= 0);
+
+	for (int cap = 0; cap < full_size; cap += cap < 8 ? 1 : 61) {
+		uint8_t* small = (uint8_t*)cf_alloc(cap > 0 ? cap : 1);
+		int r = cf_snapshot_compress(base, cur, n, small, cap);
+		REQUIRE(r < 0);
+		REQUIRE(-r <= cf_snapshot_compress_bound(n));
+		uint8_t* exact = (uint8_t*)cf_alloc(-r);
+		int r2 = cf_snapshot_compress(base, cur, n, exact, -r);
+		REQUIRE(r2 == -r); // The reported requirement is exact, not padded.
+		REQUIRE(cf_snapshot_decompress(base, n, exact, r2, rt) == 0);
+		REQUIRE(!memcmp(rt, cur, n));
+		cf_free(exact);
+		cf_free(small);
+	}
+
+	cf_free(base);
+	cf_free(cur);
+	cf_free(full);
+	cf_free(rt);
+	return true;
+}
+
+/* Degenerate inputs behave: zero-size snapshots, and malformed compressed data is refused. */
+TEST_CASE(test_arith_edges)
+{
+	uint8_t out[8];
+	uint8_t byte = 0;
+	REQUIRE(cf_snapshot_compress_bound(0) == 1);
+	int size = cf_snapshot_compress(NULL, &byte, 0, out, sizeof(out));
+	REQUIRE(size >= 0 && size <= cf_snapshot_compress_bound(0));
+	REQUIRE(cf_snapshot_decompress(NULL, 0, out, size, &byte) == 0);
+
+	REQUIRE(cf_snapshot_decompress(NULL, 4, out, 0, &byte) == -1); // No flag byte.
+	uint8_t raw_truncated[2] = { 1, 0xAB };
+	uint8_t dst[4];
+	REQUIRE(cf_snapshot_decompress(NULL, 4, raw_truncated, sizeof(raw_truncated), dst) == -1);
+	return true;
+}
+
+TEST_SUITE(test_arith)
+{
+	RUN_TEST_CASE(test_arith_sparse_delta_roundtrip);
+	RUN_TEST_CASE(test_arith_incompressible_raw_escape);
+	RUN_TEST_CASE(test_arith_negative_required);
+	RUN_TEST_CASE(test_arith_edges);
+}


### PR DESCRIPTION
Answers "is there a worst case for `cf_snapshot_compress`?" with: now there is, and it's `size + 1`.

**Raw-store escape.** `cf_arith_delta_compress` writes one leading flag byte: 0 = arithmetic-coded delta, 1 = the raw bytes, chosen whenever entropy coding fails to beat raw. Adversarial/incompressible input now costs one byte of expansion instead of the probability-clamp ceiling (~7x input — the only bound previously *guaranteed*, and why even the header's own tests just guessed `n * 2 + 64`). Also the right network behavior: never ship a packet larger than the raw snapshot.

**`cf_snapshot_compress_bound(size)`** = `size + 1`, exact. Allocate this and compression can never fail.

**Exact negative-required returns** (the ggml convention). Undersized buffers return the negative of the exact capacity needed: `if (result >= 0)` stays the success check, `-result` is the retry size, and no `snprintf`-style positive-but-truncated trap exists. This was free — the encoder already counts bytes past its cap — so `cf_arith_encoder_flush` adopts the same convention in place of its information-discarding `-1`.

**`cf_snapshot_decompress`** now returns -1 on malformed input (missing flag byte, truncated raw payload).

**Breaking:** the delta stream gains the flag byte, so compressed streams are not cross-version — both ends must run the same build, which the connect handshake already implies (documented in the remarks).

New `test_arith` CI suite pins the contracts: sparse/identical/incompressible roundtrips, output always within bound, NULL baselines, degenerate sizes, and exact `-required` verified across a sweep of undersized buffers (retry at `-result` must succeed at exactly that size). Full suite 360/360 locally; docsparser clean.