### PR TITLE
cute_net: a client reconnect resets its transport, like the server's

### DIFF
--- a/libraries/cute/cute_net.h
+++ b/libraries/cute/cute_net.h
@@ -9202,6 +9202,23 @@ static cn_result_t s_send(int client_index, void* packet, int size, void* udata)
 	return cn_protocol_client_send(client->p_client, packet, size);
 }
 
+// Destroy and recreate the client's transport, giving it fresh reliability state -- the client
+// half of the server's s_server_reset_transport. Called on every connect: a transport carrying
+// the old session's sequences silently discards the new server's reliable stream (and the new
+// server stashes ours awaiting fragments it never saw) while unreliable traffic still flows --
+// a half-alive session.
+static void s_client_reset_transport(cn_client_t* client)
+{
+	if (client->transport) {
+		cn_transport_destroy(client->transport);
+	}
+	cn_transport_config_t config = cn_transport_config_defaults();
+	config.send_packet_fn = s_send;
+	config.user_allocator_context = client->mem_ctx;
+	config.udata = client;
+	client->transport = cn_transport_create(config);
+}
+
 cn_client_t* cn_client_create(uint16_t port, uint64_t application_id, bool use_ipv6, void* user_allocator_context)
 {
 	cn_result_t result = s_cn_init_check();
@@ -9214,12 +9231,7 @@ cn_client_t* cn_client_create(uint16_t port, uint64_t application_id, bool use_i
 	CN_MEMSET(client, 0, sizeof(*client));
 	client->p_client = p_client;
 	client->mem_ctx = user_allocator_context;
-
-	cn_transport_config_t config = cn_transport_config_defaults();
-	config.send_packet_fn = s_send;
-	config.user_allocator_context = user_allocator_context;
-	config.udata = client;
-	client->transport = cn_transport_create(config);
+	s_client_reset_transport(client);
 
 	return client;
 }
@@ -9240,6 +9252,9 @@ void cn_client_destroy(cn_client_t* client)
 
 cn_result_t cn_client_connect(cn_client_t* client, const uint8_t* connect_token)
 {
+	// A (re)connect is a fresh conversation: the reliability state must start over with it, the
+	// way the server resets a slot's transport on every new connection.
+	s_client_reset_transport(client);
 	return cn_protocol_client_connect(client->p_client, connect_token);
 }
 

--- a/test/test_networking.cpp
+++ b/test/test_networking.cpp
@@ -442,6 +442,73 @@ TEST_CASE(test_net_client_wire)
 	return true;
 }
 
+/* Reliable messages deliver both ways on a SECOND connection of the same client object. The
+ * transport's reliability state (sequence windows, acks, fragment reassembly) must start over
+ * with every connect: carried over, the client silently discards the new server's reliable
+ * stream (and the server stashes the client's) while unreliable traffic still flows -- a
+ * half-alive session on every instance switch or server bounce. */
+TEST_CASE(test_net_reconnect_reliable)
+{
+	NetPair np;
+	REQUIRE(s_net_start(&np, "127.0.0.1:5806"));
+	cf_server_channel_options(np.server, 0, 0, true);
+	cf_client_channel_options(np.client, 0, 0, true);
+
+	auto exchange = [&](uint32_t id_down, uint32_t id_up) -> bool {
+		int payload = 7;
+		if (cf_is_error(cf_server_send_msg(np.server, np.client_index, 0, id_down, &payload, sizeof(payload)))) return false;
+		if (cf_is_error(cf_client_send_msg(np.client, 0, id_up, &payload, sizeof(payload)))) return false;
+		bool down = false, up = false;
+		for (int i = 0; i < 5000 && !(down && up); ++i) {
+			s_net_update(&np);
+			s_drain_events(&np);
+			void* pkt;
+			int size;
+			while (cf_client_pop_packet(np.client, &pkt, &size, NULL)) cf_client_free_packet(np.client, pkt);
+			uint32_t id;
+			void* data;
+			while (cf_client_pop_msg(np.client, &id, &data, &size)) {
+				if (id == id_down) down = true;
+				cf_client_free_msg(np.client, data);
+			}
+			int ci;
+			while (cf_server_pop_msg(np.server, &ci, &id, &data, &size)) {
+				if (id == id_up) up = true;
+				cf_server_free_msg(np.server, data);
+			}
+			cf_sleep(1);
+		}
+		return down && up;
+	};
+
+	// First connection: a welcome down, an action up.
+	REQUIRE(exchange(100, 101));
+
+	// Drop the connection and reconnect the SAME client object (an instance switch, a bounce).
+	cf_client_disconnect(np.client);
+	for (int i = 0; i < 100; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		cf_sleep(1);
+	}
+	np.client_index = -1;
+	REQUIRE(!cf_is_error(cf_client_connect_insecure(np.client, "127.0.0.1:5806", TEST_NET_APP_ID)));
+	bool reconnected = false;
+	for (int i = 0; i < 5000 && !reconnected; ++i) {
+		s_net_update(&np);
+		s_drain_events(&np);
+		reconnected = cf_client_state(np.client) == CF_CLIENT_STATE_CONNECTED && np.client_index >= 0;
+		cf_sleep(1);
+	}
+	REQUIRE(reconnected);
+
+	// The same exchange on the new conversation.
+	REQUIRE(exchange(200, 201));
+
+	s_net_free(&np);
+	return true;
+}
+
 TEST_SUITE(test_networking)
 {
 	RUN_TEST_CASE(test_net_raw_and_msgs);
@@ -449,6 +516,7 @@ TEST_SUITE(test_networking)
 	RUN_TEST_CASE(test_net_channel_reliable_loss);
 	RUN_TEST_CASE(test_net_msg_errors);
 	RUN_TEST_CASE(test_net_client_wire);
+	RUN_TEST_CASE(test_net_reconnect_reliable);
 }
 
 #else // CF_EMSCRIPTEN


### PR DESCRIPTION
Found chasing friendslop's flaky matching: any **second** connect of the same client object — an instance switch, a rejoin after a server bounce — came up half-alive. Connected, snapshots streaming, but the welcome never arrived and no reliable message delivered in either direction. Reproduced natively (kill a lobby instance mid-run, let the client rejoin: `slot=-1` with `rx=469`) and over the web wire.

`cn_client_connect` reused the transport made at `cn_client_create`. Its reliability state (sequence windows, acks, fragment reassembly) carried the old session into the new one: the new server's reliable stream (starting at sequence 0) was silently discarded as duplicates, and the client's reliable sends sat stashed server-side awaiting fragments from a conversation that server never had. Unreliable traffic doesn't consult that state, which is what made it a *half*-alive session rather than an obvious failure.

The server has always rebuilt a slot's transport on every new connection (`s_server_reset_transport`, on connect *and* disconnect); this adds the client half of the same rule (`s_client_reset_transport`), run on every connect, and `cn_client_create` now goes through it too.

New test `test_net_reconnect_reliable`: real loopback sockets, reliable exchange both ways, disconnect, reconnect the same client object, exchange again. Fails without the fix at the second exchange; the full networking suite passes with it.