### PR TITLE
Touch: motion updates the stored touch, and coordinates are normalized as documented

### DIFF
--- a/src/cute_input.cpp
+++ b/src/cute_input.cpp
@@ -697,24 +697,32 @@ void cf_pump_input_msgs()
 			CF_Touch& touch = app->touches.add();
 			touch.id = id;
 			touch.pressure = event.tfinger.pressure;
-			touch.x = event.tfinger.x * app->w;
-			touch.y = event.tfinger.y * app->h;
+			// Normalized [0,1], exactly as the header documents (SDL's tfinger is already so).
+			touch.x = event.tfinger.x;
+			touch.y = event.tfinger.y;
 		}	break;
 
 		case SDL_EVENT_FINGER_MOTION:
 		{
+			// Update the STORED touch: fetching a copy and writing to it left every held
+			// finger frozen at the position it landed on, so drags never produced motion.
 			uint64_t id = (uint64_t)event.tfinger.fingerID;
-			CF_Touch touch;
-			if (cf_touch_get(id, &touch)) {
-				touch.pressure = event.tfinger.pressure;
-				touch.x = event.tfinger.x * app->w;
-				touch.y = event.tfinger.y * app->h;
-			} else {
+			bool found = false;
+			for (int i = 0; i < app->touches.size(); ++i) {
+				if (app->touches[i].id == id) {
+					app->touches[i].pressure = event.tfinger.pressure;
+					app->touches[i].x = event.tfinger.x;
+					app->touches[i].y = event.tfinger.y;
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
 				CF_Touch& touch = app->touches.add();
 				touch.id = id;
 				touch.pressure = event.tfinger.pressure;
-				touch.x = event.tfinger.x * app->w;
-				touch.y = event.tfinger.y * app->h;
+				touch.x = event.tfinger.x;
+				touch.y = event.tfinger.y;
 			}
 		}	break;
 


### PR DESCRIPTION
Two bugs found bringing up phone (web) touch controls in friendslop:

1. **`SDL_EVENT_FINGER_MOTION` never moved anything.** It fetched the touch via `cf_touch_get` (a by-value copy) and updated the copy — the stored entry kept its finger-down position until the finger lifted, so every drag read as zero motion.
2. **`CF_Touch.x/y` contradicted the header.** The docs say normalized [0,1]; the implementation multiplied by the window size, handing out a third coordinate space nothing declared (not normalized, not pixels-with-DPR). Callers following the docs (guilty) scaled twice and hit-tested miles off target.

Both fixed to match the documented contract. No other in-tree consumers of the touch API exist, so nothing else shifts.