### PR TITLE
cspv: HLSL matrix subscripts read columns, as GLSL means them

### DIFF
--- a/libraries/cute/cute_spirv.h
+++ b/libraries/cute/cute_spirv.h
@@ -6358,6 +6358,23 @@ static void cspv_tp_expr_node(cspv_tp* g, cspv_expr* e, int prec)
 				break;
 			}
 		}
+		// HLSL: `m[i]` subscripts ROWS, GLSL subscripts COLUMNS -- printed verbatim, every
+		// indexed matrix read comes back transposed (mul() was fine, so a shader that only
+		// ever multiplied never noticed; one that indexed read garbage). transpose() flips
+		// the access back to columns, and `m[i][j]` rides through the same wrap. Reads only:
+		// storing through transpose() is not an lvalue in HLSL, but no output of ours writes
+		// into a matrix column either.
+		if (g->hlsl) {
+			cspv_type* bt = cspv_tp_rtype(g, e->u.index.base);
+			if (bt && bt->kind == CSPV_T_MAT) {
+				sappend(g->ctx->tp_out, "transpose(");
+				cspv_tp_expr(g, e->u.index.base, 0);
+				sappend(g->ctx->tp_out, ")[");
+				cspv_tp_expr(g, e->u.index.index, 0);
+				spush(g->ctx->tp_out, ']');
+				break;
+			}
+		}
 		cspv_tp_expr(g, e->u.index.base, 15);
 		spush(g->ctx->tp_out, '[');
 		cspv_tp_expr(g, e->u.index.index, 0);


### PR DESCRIPTION
GLSL `m[i]` selects COLUMN i; HLSL subscripts select ROWS. The HLSL transpiler printed matrix subscripts verbatim, so on the DXBC/FXC fallback every indexed matrix read arrived transposed. `mul()` products were rewritten correctly, which is why shaders that only multiply by their matrices never showed it — a shader that indexes one reads garbage.

Pinned with a GPU readback probe running identical shaders on D3D12 vs Vulkan: the SPIR-V path (ColMajor + MatrixStride 16 decorations) was correct all along; only HLSL diverged, and only for subscripts.

Fix: for HLSL output alone, an indexed matrix base is wrapped in `transpose()` — `m[i]` and `m[i][j]` both ride through it, all matrix sizes; FXC folds the transpose of a uniform matrix. Reads only: storing through `transpose()` is not an lvalue, but no emitted code writes into a matrix column either (worth a validator error someday).

Verified: the probe's 7 cases (single blocks, scrambled set orders, undeclared uniform names, shader switches mid-queue, and a friendslop-shaped block with mat4 + two vec4 arrays) now pass identically on D3D12 and Vulkan; friendslop renders identically before/after on both backends.