### PR TITLE
Drop IMGUI_STB_NAMESPACE so dcimgui_internal.h compiles as C

### DIFF
--- a/docs/topics/dear_imgui.md
+++ b/docs/topics/dear_imgui.md
@@ -103,6 +103,8 @@ The [Dear ImGui](https://github.com/ocornut/imgui) GitHub has extensive learning
 These examples use the C API (`dcimgui.h` with ImGui prefix). For C++, use `imgui.h` with ImGui:: prefix instead.
 C++ is recommended - it provides default parameters that make the API easier to use. Use the C API only if you're working in plain C.
 
+Both `dcimgui.h` and `imgui.h` work from C++ and can be included before or after `cute.h`. For Dear ImGui's internal API (the DockBuilder, `ImGui_FindWindowByName`, and friends) include `dcimgui_internal.h` after `dcimgui.h`. It compiles as plain C too, with no extra defines.
+
 ## Making Tools
 
 Dear ImGui lets you build development tools directly in your game: level editors, tile editors, debug inspectors, entity editors, and value tweakers. Use it to visualize and modify your game data while it's running. CF includes Dear ImGui by default.

--- a/libraries/imgui/dcimgui.h
+++ b/libraries/imgui/dcimgui.h
@@ -5,8 +5,6 @@
 // dear imgui, v1.92.7
 // (headers)
 
-#define IMGUI_STB_NAMESPACE ImStb
-
 // Help:
 // - Call and read ImGui::ShowDemoWindow() in imgui_demo.cpp. All applications in examples/ are doing that.
 // - Read top of imgui.cpp for more details, links and comments.

--- a/libraries/imgui/dcimgui_internal.h
+++ b/libraries/imgui/dcimgui_internal.h
@@ -4105,8 +4105,8 @@ typedef IMGUI_STB_NAMESPACE::stbrp_node stbrp_node_im;
 #else
 typedef struct stbrp_node_t stbrp_node;
 typedef stbrp_node stbrp_node_im;
+struct ImVector_stbrp_node_im_t { int Size; int Capacity; stbrp_node_im* Data; };  // Instantiation of ImVector<stbrp_node_im>
 #endif // #ifdef IMGUI_STB_NAMESPACE
-struct ImVector_stbrp_node_im_t { int Size; int Capacity; stbrp_node_im* Data; };  // Instantiation of ImVector<stbrp_node_im>  // CF: emitted unconditionally (Dear Bindings v0.19 omits this in the IMGUI_STB_NAMESPACE branch)
 struct stbrp_context_opaque_t
 {
     char data[80];

--- a/libraries/imgui/imconfig.h
+++ b/libraries/imgui/imconfig.h
@@ -14,9 +14,15 @@
 
 #pragma once
 
+// dcimgui.h includes this file from inside an extern "C" block, and cute_math.h carries
+// C++-only declarations, so restore C++ linkage around it.
+#ifdef __cplusplus
+extern "C++" {
+#endif
 #include <cute_math.h>
-
-#define IMGUI_STB_NAMESPACE ImStb
+#ifdef __cplusplus
+}
+#endif
 
 //---- Define assertion handler. Defaults to calling assert().
 // - If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.

--- a/src/cute_draw.cpp
+++ b/src/cute_draw.cpp
@@ -52,10 +52,6 @@ static const char* s_text_without_markups = NULL;
 #define STBTT_free(x, u) cf_free(x)
 #include <stb/stb_truetype.h>
 
-#define IM_ASSERT CF_ASSERT
-#include <imgui.h>
-#include <imgui_internal.h>
-
 #include <algorithm>
 
 // Initial design of this API comes from Noel Berry's Blah framework here:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(CF_TEST_SRCS
 	test_physics.cpp
 	test_networking.cpp
 	test_ckit.c
+	test_dcimgui.cpp
+	test_dcimgui.c
 	test_model.cpp
 	test_jpg.cpp
 	test_dds.cpp

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -67,9 +67,11 @@ extern "C" {
 TEST_SUITE(test_math_c);
 TEST_SUITE(test_math3d_c);
 TEST_SUITE(test_ckit);
+TEST_SUITE(test_dcimgui_c);
 }
 TEST_SUITE(test_jpg);
 TEST_SUITE(test_dds);
+TEST_SUITE(test_dcimgui);
 
 #include <SDL3/SDL.h>
 
@@ -148,6 +150,8 @@ int main(int argc, char* argv[])
 	RUN_TRACED(test_ckit);
 	RUN_TRACED(test_jpg);
 	RUN_TRACED(test_dds);
+	RUN_TRACED(test_dcimgui);
+	RUN_TRACED(test_dcimgui_c);
 	RUN_TRACED(test_video);
 #undef RUN_TRACED
 

--- a/test/test_dcimgui.c
+++ b/test/test_dcimgui.c
@@ -1,0 +1,34 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+#ifdef __cplusplus
+#error "This code must be compiled as C, not C++"
+#endif
+
+// Dear ImGui's C bindings must work from a plain C translation unit, internal header included
+// (DockBuilder, window lookups), with no extra defines or include-order tricks.
+#include <dcimgui.h>
+#include <dcimgui_internal.h>
+
+#include "test_harness.h"
+
+TEST_CASE(test_dcimgui_internal_header_in_c)
+{
+	// ImFontAtlasBuilder holds an ImVector of stb rect-pack nodes. It is only a complete type
+	// when dcimgui_internal.h resolved stbrp_node_im in C.
+	REQUIRE(sizeof(ImFontAtlasBuilder) > 0);
+	ImGuiWindow* (*find_window)(const char*) = ImGui_FindWindowByName;
+	ImGuiDockNode* (*get_node)(ImGuiID) = ImGui_DockBuilderGetNode;
+	REQUIRE(find_window != NULL);
+	REQUIRE(get_node != NULL);
+	return true;
+}
+
+TEST_SUITE(test_dcimgui_c)
+{
+	RUN_TEST_CASE(test_dcimgui_internal_header_in_c);
+}

--- a/test/test_dcimgui.cpp
+++ b/test/test_dcimgui.cpp
@@ -1,0 +1,26 @@
+/*
+	Cute Framework
+	Copyright (C) 2026 Randy Gaul https://randygaul.github.io/
+
+	This software is dual-licensed with zlib or Unlicense, check LICENSE.txt for more info
+*/
+
+// dcimgui.h is deliberately the first include. It wraps imconfig.h in extern "C", and imconfig.h
+// pulls in cute_math.h, so this must compile before any CF header has been seen.
+#include <dcimgui.h>
+#include <dcimgui_internal.h>
+
+#include <cute.h>
+#include "test_harness.h"
+
+TEST_CASE(test_dcimgui_headers_first_in_cpp)
+{
+	REQUIRE(sizeof(ImFontAtlasBuilder) > 0);
+	REQUIRE(sizeof(ImVec2) == sizeof(CF_V2));
+	return true;
+}
+
+TEST_SUITE(test_dcimgui)
+{
+	RUN_TEST_CASE(test_dcimgui_headers_first_in_cpp);
+}


### PR DESCRIPTION
Dear Bindings v0.19 leaves C++ scope syntax (`ImStb::stbrp_node`) in the namespaced branch of `dcimgui_internal.h`, so with `IMGUI_STB_NAMESPACE` set the header failed from C, and from any C++ file that did not include `imgui_internal.h` first. Reaching the DockBuilder from a C game needed an `#undef` between the two includes.

The only reason CF set the namespace was `cute_draw.cpp`, which compiled stb_truetype's implementation next to `imgui_internal.h` in one TU. Nothing there used ImGui, so the includes go and the define goes with them. The generated headers now carry no CF patches.

Separately, `dcimgui.h` includes `imconfig.h` from inside `extern "C"`, which broke any C++ file that included `dcimgui.h` before `cute.h`. `imconfig.h` now restores C++ linkage around its `cute_math.h` include.

Both cases have guard tests. Trade-off: this restores vanilla ImGui behavior, so a downstream C++ TU that compiles its own stb_truetype implementation next to `imgui_internal.h` would clash, as `cute_draw.cpp` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dQLMKSRz7vi8PHh9BQ5Jb
